### PR TITLE
test: [M3-9859] - Fix Cypress LKE Create Test Failures

### DIFF
--- a/packages/manager/.changeset/pr-12391-tests-1750096907761.md
+++ b/packages/manager/.changeset/pr-12391-tests-1750096907761.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Fix Cypress LKE Create Test Failures ([#12391](https://github.com/linode/manager/pull/12391))

--- a/packages/manager/cypress.config.ts
+++ b/packages/manager/cypress.config.ts
@@ -91,6 +91,13 @@ export default defineConfig({
 
     setupNodeEvents(cypressOn, config) {
       const on = cypressOnFix(cypressOn);
+      on('task', {
+        log(message) {
+          // eslint-disable-next-line no-console
+          console.log(message);
+          return null;
+        },
+      });
       return setupPlugins(on, config, [
         loadEnvironmentConfig,
         nodeVersionCheck,

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
@@ -2,6 +2,7 @@
  * @file LKE creation end-to-end tests.
  */
 import {
+  accountAvailabilityFactory,
   accountBetaFactory,
   dedicatedTypeFactory,
   linodeTypeFactory,
@@ -21,7 +22,10 @@ import {
   latestEnterpriseTierKubernetesVersion,
   latestKubernetesVersion,
 } from 'support/constants/lke';
-import { mockGetAccount } from 'support/intercepts/account';
+import {
+  mockGetAccount,
+  mockGetAccountAvailability,
+} from 'support/intercepts/account';
 import { mockGetAccountBeta } from 'support/intercepts/betas';
 import { mockAppendFeatureFlags } from 'support/intercepts/feature-flags';
 import { mockGetLinodeTypes } from 'support/intercepts/linodes';
@@ -215,6 +219,14 @@ describe('LKE Cluster Creation', () => {
     mockedLKEClusterTypes
   );
 
+  beforeEach(() => {
+    const accountAvailability = accountAvailabilityFactory.build({
+      region: clusterRegion.id,
+      unavailable: [],
+    });
+    mockGetAccountAvailability([accountAvailability]);
+  });
+
   it('can create an LKE cluster', () => {
     mockCreateCluster(mockedLKECluster).as('createCluster');
     mockGetCluster(mockedLKECluster).as('getCluster');
@@ -389,6 +401,14 @@ describe('LKE Cluster Creation', () => {
 });
 
 describe('LKE Cluster Creation with APL enabled', () => {
+  beforeEach(() => {
+    const accountAvailability = accountAvailabilityFactory.build({
+      region: clusterRegion.id,
+      unavailable: [],
+    });
+    mockGetAccountAvailability([accountAvailability]);
+  });
+
   it('can create an LKE cluster with APL flag enabled', () => {
     const clusterLabel = randomLabel();
     const mockedLKECluster = kubernetesClusterFactory.build({
@@ -475,7 +495,8 @@ describe('LKE Cluster Creation with APL enabled', () => {
       .click();
     cy.focused().type(`${clusterLabel}{enter}`);
 
-    ui.regionSelect.find().click().type(`${clusterRegion.label}{enter}`);
+    const region = clusterRegion.label;
+    ui.regionSelect.find().click().type(`${region}{enter}`);
 
     cy.findByTestId('apl-label').should('have.text', 'Akamai App Platform');
     cy.findByTestId('apl-beta-chip').should('have.text', 'BETA');
@@ -544,6 +565,14 @@ describe('LKE Cluster Creation with APL enabled', () => {
 });
 
 describe('LKE Cluster Creation with DC-specific pricing', () => {
+  beforeEach(() => {
+    const accountAvailability = accountAvailabilityFactory.build({
+      region: clusterRegion.id,
+      unavailable: [],
+    });
+    mockGetAccountAvailability([accountAvailability]);
+  });
+
   /*
    * - Confirms that DC-specific prices are present in the LKE create form.
    * - Confirms that pricing docs link is shown in "Region" section.
@@ -662,6 +691,14 @@ describe('LKE Cluster Creation with DC-specific pricing', () => {
 });
 
 describe('LKE Cluster Creation with ACL', () => {
+  beforeEach(() => {
+    const accountAvailability = accountAvailabilityFactory.build({
+      region: clusterRegion.id,
+      unavailable: [],
+    });
+    mockGetAccountAvailability([accountAvailability]);
+  });
+
   /**
    * - Confirms ACL flow does not exist if account doesn't have the corresponding capability
    */
@@ -1306,6 +1343,14 @@ describe('LKE Cluster Creation with ACL', () => {
 });
 
 describe('LKE Cluster Creation with LKE-E', () => {
+  beforeEach(() => {
+    const accountAvailability = accountAvailabilityFactory.build({
+      region: clusterRegion.id,
+      unavailable: [],
+    });
+    mockGetAccountAvailability([accountAvailability]);
+  });
+
   /**
    * - Confirms LKE-E flow does not exist if account doesn't have the corresponding capability
    * @todo LKE-E: Remove this test once LKE-E is fully rolled out

--- a/packages/manager/cypress/support/component/setup.tsx
+++ b/packages/manager/cypress/support/component/setup.tsx
@@ -110,3 +110,13 @@ declare global {
 
 Cypress.Commands.add('mount', mount);
 Cypress.Commands.add('mountWithTheme', mountWithTheme);
+Cypress.Commands.overwrite('log', (log, ...args) => {
+  if (Cypress.browser.isHeadless) {
+    return cy.task('log', args, { log: false }).then(() => {
+      return log(...args);
+    });
+  } else {
+    console.log(...args);
+    return log(...args);
+  }
+});


### PR DESCRIPTION
## Description 📝

Found the root cause of LKE create test failures, which is due to missing capacity of account availability. 

## Changes  🔄

List any change(s) relevant to the reviewer.

- Add `mockGetAccountAvailability()` before each test.

## How to test 🧪
```
 pnpm cy:run -s "cypress/e2e/core/kubernetes/lke-create.spec.ts,cypress/e2e/core/kubernetes/smoke-lke-create.spec.ts"
```