### PR TITLE
upcoming: [M3-10192] - Add Beta "Alerts Assigned +n" Count to Linode Create Flow Summary

### DIFF
--- a/packages/manager/.changeset/pr-12396-upcoming-features-1750171179709.md
+++ b/packages/manager/.changeset/pr-12396-upcoming-features-1750171179709.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add beta `Alerts Assigned +n` count to Linode Create flow Summary ([#12396](https://github.com/linode/manager/pull/12396))


### PR DESCRIPTION
## Description 📝

As part of the ACLP-Linode integration for legacy/beta alerts, we want to display an "Alerts Assigned +n" count in the summary section on the Create Linode page. This will help users understand how many beta alerts have been assigned during the linode creation process.

## Changes  🔄
- Add Beta "Alerts Assigned +n" Count logic to Linode Create Flow Summary

## Target release date 🗓️
N/A

## Preview 📷

- ACLP-supported regions:
![Screenshot 2025-06-17 at 7 55 17 PM](https://github.com/user-attachments/assets/32b06f8a-674f-44e5-9ce2-77efa39b5ff0)
![Screenshot 2025-06-17 at 7 55 39 PM](https://github.com/user-attachments/assets/5ebb0ee0-5a8e-47f3-8ba1-ff79b832ec7c)
- Non ACLP-supported regions:
![Screenshot 2025-06-17 at 8 11 42 PM](https://github.com/user-attachments/assets/66b0b7a5-0ac9-460c-9dbb-d5899be84bbf)

## How to test 🧪

### Prerequisites
- Enabled MSW and `aclpBetaServices.alerts` feature flag
- Navigate to the Linode Create page

### Verification steps

- For ACLP-supported (mocked) regions (Washington, DC or Newark, NJ):
   - Go to Additional Options -> Alerts -> Beta Mode
     - Verify "Assigned Alerts +n" is visible with a tooltip displaying enabled beta alert IDs in the summary section if the assigned `beta alerts count > 0`
     - Verify "Assigned Alerts 0" is displayed in the summary section if the assigned `beta alerts count = 0`
   -  Verify that neither "Assigned Alerts +n" nor "Assigned Alerts 0" is displayed on legacy mode

- For non-ACLP supported regions:
  - Verify that neither "Assigned Alerts +n" nor "Assigned Alerts 0" is displayed
  - Verify that the Additional Options -> Alerts section is not displayed

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support
</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules