### PR TITLE
fix: [M3-10208] - Legacy Alerts toggle incorrectly enabled on Create Linode page after ADS toggle PR merge

### DIFF
--- a/packages/manager/src/features/Kubernetes/CreateCluster/ControlPlaneACLPane.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/ControlPlaneACLPane.tsx
@@ -72,9 +72,9 @@ export const ControlPlaneACLPane = (props: ControlPlaneACLProps) => {
             control={
               <StyledACLToggle
                 checked={enableControlPlaneACL}
+                disabled={isEnterpriseCluster}
                 name="ipacl-checkbox"
                 onChange={() => setControlPlaneACL(!enableControlPlaneACL)}
-                toggleDisabled={isEnterpriseCluster}
               />
             }
             label="Enable Control Plane ACL"

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeControlPaneACLDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeControlPaneACLDrawer.tsx
@@ -239,6 +239,7 @@ export const KubeControlPlaneACLDrawer = (
                       checked={
                         isEnterpriseCluster ? true : (field.value ?? false)
                       }
+                      disabled={isEnterpriseCluster}
                       name="ipacl-checkbox"
                       onBlur={field.onBlur}
                       onChange={() => {
@@ -269,7 +270,6 @@ export const KubeControlPlaneACLDrawer = (
                           );
                         }
                       }}
-                      toggleDisabled={isEnterpriseCluster}
                     />
                   }
                   label="Enable Control Plane ACL"

--- a/packages/ui/src/components/Toggle/Toggle.stories.tsx
+++ b/packages/ui/src/components/Toggle/Toggle.stories.tsx
@@ -53,8 +53,8 @@ export const Disabled: StoryObj<ToggleProps> = {
         <Toggle
           {...args}
           checked={checked}
+          disabled
           onChange={onChange}
-          toggleDisabled
           tooltipText={EXAMPLE_TEXT}
         />
       )}

--- a/packages/ui/src/components/Toggle/Toggle.tsx
+++ b/packages/ui/src/components/Toggle/Toggle.tsx
@@ -10,7 +10,6 @@ import { TooltipIcon } from '../TooltipIcon';
 import type { SwitchProps } from '@mui/material/Switch';
 
 export interface ToggleProps extends SwitchProps {
-  toggleDisabled?: boolean;
   /**
    * Content to display inside an optional tooltip.
    */
@@ -29,7 +28,7 @@ export interface ToggleProps extends SwitchProps {
  * > **Note:** Do not use toggles in long forms where other types of form fields are present, and users will need to click a Submit button for other changes to take effect. This scenario confuses users because they can’t be sure whether their toggle choice will take immediate effect.
  */
 export const Toggle = (props: ToggleProps) => {
-  const { toggleDisabled, tooltipText, size = 'medium', sx, ...rest } = props;
+  const { tooltipText, size = 'medium', sx, ...rest } = props;
 
   return (
     <Box
@@ -60,7 +59,6 @@ export const Toggle = (props: ToggleProps) => {
         checkedIcon={<ToggleOnIcon />}
         color="primary"
         data-qa-toggle={props.checked}
-        disabled={toggleDisabled}
         icon={<ToggleOffIcon />}
         sx={{
           ...(size === 'small' && {


### PR DESCRIPTION
## Description 📝
Following the merge of the Toggle ADS [PR](https://github.com/linode/manager/pull/12303), a regression is introduced in the Linode Create flow. The Legacy Mode Alerts toggles are now incorrectly enabled when they should be disabled/ready-only.

> [!Note]
> - The toggle ADS PR was merged after the release cut, so a `changeset` for this PR is not required
> - We'll create a separate ticket (if one doesn't already exist) to add tests ensuring that Legacy Alerts are disabled in the Create Linode flow and enabled in the Linode Details/Edit flow cc: @jdamore-linode @dmcintyr-akamai


## Changes  🔄
- Removed duplicate `disabledToggle` prop introduced in Toggle ADS https://github.com/linode/manager/pull/12303

## Target release date 🗓️
1 July (Next release)

## Preview 📷

| On Dev branch  | On this branch   |
| ------- | ------- |
| ![Screenshot 2025-06-18 at 6 10 17 PM](https://github.com/user-attachments/assets/e73d05be-c8e9-44ab-b24b-a7d2ca006bfd) | ![Screenshot 2025-06-18 at 7 14 06 PM](https://github.com/user-attachments/assets/01284084-3b01-41cb-b1f0-4b6a1a01b272) |

## How to test 🧪

### Prerequisites
- Enable MSW & `aclpBetaServices` -> alerts feature flag

### Reproduction steps
- Enable MSW & `aclpBetaServices` -> alerts feature flag
- Navigate to Create Linode page 
- Select aclp supported region -> Washington DC, or Newark NJ
- Go to Additional Option Section -> Alerts
- For legacy mode -> toggle should have been disabled but they got enabled

### Verification steps
- In the Create Linode page:
   -  Select aclp supported region -> Washington DC, or Newark , NJ
   - Go to Additional Option Section -> Legacy Alerts
   - Alerts with toggle options and input fields should remain in a `disabled/read-only` state when Legacy Mode is active
- In Linode Details page -> Alerts -> Legacy Mode:
    - Alerts with toggle options and input fields should remain active (editable) in Legacy Mode 
- Ensure all related references are updated correctly
- Ensure storybook for toggle disabled state works as expected 

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support
</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules