### PR TITLE
test: [M3-9860] - Fix Cypress Linode clone test

### DIFF
--- a/packages/manager/.changeset/pr-12403-tests-1750430192369.md
+++ b/packages/manager/.changeset/pr-12403-tests-1750430192369.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Fix Cypress Linode clone test ([#12403](https://github.com/linode/manager/pull/12403))

--- a/packages/manager/cypress/e2e/core/linodes/clone-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/clone-linode.spec.ts
@@ -21,6 +21,7 @@ import {
   LINODE_CREATE_TIMEOUT,
 } from 'support/constants/linodes';
 import { mockGetLinodeConfigs } from 'support/intercepts/configs';
+import { interceptEvents } from 'support/intercepts/events';
 import { mockAppendFeatureFlags } from 'support/intercepts/feature-flags';
 import {
   interceptCloneLinode,
@@ -46,7 +47,7 @@ import {
 } from 'support/util/random';
 import { chooseRegion, extendRegion } from 'support/util/regions';
 
-import type { Linode } from '@linode/api-v4';
+import type { Event, Linode } from '@linode/api-v4';
 
 /**
  * Returns the Cloud Manager URL to clone a given Linode.
@@ -78,7 +79,7 @@ describe('clone linode', () => {
    */
   it('can clone a Linode from Linode details page', () => {
     cy.tag('method:e2e', 'purpose:dcTesting');
-    const linodeRegion = chooseRegion({ capabilities: ['Vlans'] });
+    const linodeRegion = chooseRegion({ capabilities: ['Linodes', 'Vlans'] });
     const linodePayload = createLinodeRequestFactory.build({
       booted: false,
       label: randomLabel(),
@@ -96,6 +97,7 @@ describe('clone linode', () => {
       createTestLinode(linodePayload, { securityMethod: 'vlan_no_internet' })
     ).then((linode: Linode) => {
       interceptCloneLinode(linode.id).as('cloneLinode');
+      interceptEvents().as('cloneEvents');
       cy.visitWithLogin(`/linodes/${linode.id}`);
 
       // Wait for Linode to boot, then initiate clone flow.
@@ -138,9 +140,30 @@ describe('clone linode', () => {
       });
 
       ui.toast.assertMessage(`Your Linode ${newLinodeLabel} is being created.`);
-      ui.toast.assertMessage(
-        `Linode ${linode.label} has been cloned to ${newLinodeLabel}.`,
-        { timeout: LINODE_CLONE_TIMEOUT }
+
+      // Change the way to check the clone progress due to M3-9860
+      cy.wait('@cloneEvents').then((xhr) => {
+        const eventData: Event[] = xhr.response?.body?.data;
+        const cloneEvent = eventData.filter(
+          (event: Event) => event['action'] === 'linode_clone'
+        );
+        cy.get('[id="menu-button--notification-events-menu"]')
+          .should('be.visible')
+          .click();
+        cy.get(`[data-qa-event="${cloneEvent[0]['id']}"]`).should('be.visible');
+        cy.get('[data-testid="linear-progress"]').should('be.visible');
+        // The progress bar should disappear when the clone is done.
+        cy.get('[data-testid="linear-progress"]', {
+          timeout: LINODE_CLONE_TIMEOUT,
+        }).should('not.exist');
+      });
+
+      cy.visit('/linodes');
+      cy.findByText(newLinodeLabel, { timeout: LINODE_CLONE_TIMEOUT }).should(
+        'be.visible'
+      );
+      cy.findByText(linode.label, { timeout: LINODE_CLONE_TIMEOUT }).should(
+        'be.visible'
       );
     });
   });

--- a/packages/manager/cypress/support/intercepts/events.ts
+++ b/packages/manager/cypress/support/intercepts/events.ts
@@ -83,3 +83,11 @@ export const mockGetNotifications = (
     paginateResponse(notifications)
   );
 };
+
+/* Intercepts GET request to get progress events.
+ *
+ * @returns Cypress chainable.
+ */
+export const interceptEvents = (): Cypress.Chainable<null> => {
+  return cy.intercept('GET', apiMatcher(`account/events*`));
+};


### PR DESCRIPTION
## Description 📝

Fix Cypress Linode clone test, and make the test more robust.

## Changes  🔄

List any change(s) relevant to the reviewer.
- Intercept event to get the clone event ID.
- Change a way to verify clone notification instead.

## How to test 🧪
```
pnpm cy:run -s "cypress/e2e/core/linodes/clone-linode.spec.ts"
```