### PR TITLE
test: [M3-10198] - Fix LKE update test failure against DevCloud

### DIFF
--- a/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
@@ -1047,9 +1047,10 @@ describe('LKE cluster updates', () => {
               cy.findByLabelText('Add 1').should('be.visible').click();
             });
 
+          ui.button.findByTitle('Add pool').scrollIntoView();
+
           ui.button
             .findByTitle('Add pool')
-            .scrollIntoView()
             .should('be.visible')
             .should('be.enabled')
             .click();

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
@@ -1049,6 +1049,7 @@ describe('LKE cluster updates', () => {
 
           ui.button
             .findByTitle('Add pool')
+            .scrollIntoView()
             .should('be.visible')
             .should('be.enabled')
             .click();


### PR DESCRIPTION
## Description 📝

Fix Cypress LKE update test failure against DevCloud.

## Changes  🔄

List any change(s) relevant to the reviewer.
- Use `.scrollIntoView()` to scroll down to get the `Add pool` button

## How to test 🧪
```
pnpm cy:run -s "cypress/e2e/core/kubernetes/lke-update.spec.ts"
```