### PR TITLE
fix: [M3-10084] - Checkbox Color Token

### DIFF
--- a/packages/ui/src/components/Checkbox/Checkbox.tsx
+++ b/packages/ui/src/components/Checkbox/Checkbox.tsx
@@ -112,7 +112,7 @@ const StyledCheckbox = styled(_Checkbox, {
     props.readOnly && {
       svg: {
         'g rect:nth-of-type(2)': {
-          fill: theme.tokens.component.Checkbox.Indeterminated.ReadOnly.Icon,
+          fill: `${theme.tokens.component.Checkbox.Indeterminated.ReadOnly.Icon} !important`,
         },
         border: `1px solid ${theme.tokens.component.Checkbox.Indeterminated.ReadOnly.Border}`,
       },

--- a/packages/ui/src/foundations/themes/dark.ts
+++ b/packages/ui/src/foundations/themes/dark.ts
@@ -485,6 +485,28 @@ export const darkTheme: ThemeOptions = {
     MuiCheckbox: {
       styleOverrides: {
         root: {
+          '& svg path': {
+            fill: `${Component.Checkbox.Checked.Default.Icon}`,
+          },
+          '&:active': {
+            color: `${Component.Checkbox.Empty.Active.Border} !important`,
+          },
+          '&:hover': {
+            color: `${Component.Checkbox.Empty.Hover.Border} !important`,
+          },
+          // Checked
+          '&.Mui-checked': {
+            color: Component.Checkbox.Checked.Default.Background,
+          },
+          // Indeterminate
+          '&.MuiCheckbox-indeterminate': {
+            color: Component.Checkbox.Indeterminated.Default.Background,
+            svg: {
+              'g rect:nth-of-type(2)': {
+                fill: Component.Checkbox.Indeterminated.Default.Icon,
+              },
+            },
+          },
           // Unchecked & Disabled
           '&.Mui-disabled': {
             '& svg': {
@@ -500,6 +522,11 @@ export const darkTheme: ThemeOptions = {
           // Indeterminate & Disabled
           '&.MuiCheckbox-indeterminate.Mui-disabled': {
             color: Component.Checkbox.Indeterminated.Disabled.Background,
+            svg: {
+              'g rect:nth-of-type(2)': {
+                fill: Component.Checkbox.Indeterminated.Default.Icon,
+              },
+            },
           },
           color: Component.Checkbox.Empty.Default.Border,
         },

--- a/packages/ui/src/foundations/themes/light.ts
+++ b/packages/ui/src/foundations/themes/light.ts
@@ -243,10 +243,9 @@ const MuiTableHeadSvgStyles = {
 };
 
 const MuiTableZebraHoverStyles = {
-  '&.MuiTableRow-hover:hover, &.Mui-selected, &.Mui-selected:hover':
-    {
-      background: Table.Row.Background.Hover,
-    },
+  '&.MuiTableRow-hover:hover, &.Mui-selected, &.Mui-selected:hover': {
+    background: Table.Row.Background.Hover,
+  },
 };
 
 const MuiTableZebraStyles = {
@@ -649,6 +648,9 @@ export const lightTheme: ThemeOptions = {
     MuiCheckbox: {
       styleOverrides: {
         root: {
+          '& svg path': {
+            fill: `${Component.Checkbox.Checked.Default.Icon}`,
+          },
           '&:active': {
             color: `${Component.Checkbox.Empty.Active.Border} !important`,
           },
@@ -662,6 +664,11 @@ export const lightTheme: ThemeOptions = {
           // Indeterminate
           '&.MuiCheckbox-indeterminate': {
             color: Component.Checkbox.Indeterminated.Default.Background,
+            svg: {
+              'g rect:nth-of-type(2)': {
+                fill: Component.Checkbox.Indeterminated.Default.Icon,
+              },
+            },
           },
           // Unchecked & Disabled
           '&.Mui-disabled': {
@@ -678,6 +685,11 @@ export const lightTheme: ThemeOptions = {
           // Indeterminate & Disabled
           '&.MuiCheckbox-indeterminate.Mui-disabled': {
             color: Component.Checkbox.Indeterminated.Disabled.Background,
+            svg: {
+              'g rect:nth-of-type(2)': {
+                fill: Component.Checkbox.Indeterminated.Default.Icon,
+              },
+            },
           },
           color: Component.Checkbox.Empty.Default.Border,
         },
@@ -1538,10 +1550,9 @@ export const lightTheme: ThemeOptions = {
             backgroundColor: Table.HeaderNested.Background,
           },
           // The `hover` rule isn't implemented correctly in MUI, so we apply it here.
-          '&.MuiTableRow-hover:hover, &.Mui-selected, &.Mui-selected:hover':
-            {
-              backgroundColor: Table.Row.Background.Hover,
-            },
+          '&.MuiTableRow-hover:hover, &.Mui-selected, &.Mui-selected:hover': {
+            backgroundColor: Table.Row.Background.Hover,
+          },
           '&.MuiTableRow-hover:hover.disabled-row': {
             cursor: 'not-allowed',
             backgroundColor: 'inherit',


### PR DESCRIPTION
## Description

This PR Fixes checkbox styling in dark mode:
- Incorrect blue shade used.
- Check icon appears white instead of black (per ADS guidelines).

## Changes

- Corrected color tokens for all checkbox variants in dark mode.

## Target Release
N/A

## Preview

| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/93a1c6f0-fff2-4ace-8198-4d55de335a1c) | ![After](https://github.com/user-attachments/assets/3e320682-a43d-49a8-a25a-1f12391a892b) |

## How to Test

1. Enable dark mode.
2. Locate checkboxes across the UI.
3. Confirm correct blue shade and black check icon.

## Acceptance Criteria

- The correct color tokens are applied for all variants.


<details>
<summary>Author Checklists</summary>

### As an Author, I considered:  
- [x] Self-review  
- [x] Contribution guidelines  
- [x] Small, focused PR  
- [x] Changeset added if needed  
- [x] Tests added or updated  
- [x] No sensitive info  
- [x] Feature flag if needed  
- [x] Reproduction steps  
- [x] Docs updated if needed  
- [x] Mobile and a11y support  

### Before moving from Draft to Open:  
- [x] All unit tests passing  
- [x] TypeScript compiles  
- [x] Linting passes  

</details>
