### PR TITLE
feat: [UIE-8534, UIE-8888, UIE-8881] - IAM RBAC: add the links

### DIFF
--- a/packages/manager/.changeset/pr-12410-upcoming-features-1750687946787.md
+++ b/packages/manager/.changeset/pr-12410-upcoming-features-1750687946787.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+IAM RBAC: add the docs links, fix typo and styling issue ([#12410](https://github.com/linode/manager/pull/12410))

--- a/packages/manager/src/features/IAM/Roles/RolesTable/RolesTable.tsx
+++ b/packages/manager/src/features/IAM/Roles/RolesTable/RolesTable.tsx
@@ -26,7 +26,10 @@ import {
 } from 'src/features/IAM/Shared/utilities';
 import { usePaginationV2 } from 'src/hooks/usePaginationV2';
 
-import { ROLES_TABLE_PREFERENCE_KEY } from '../../Shared/constants';
+import {
+  ROLES_LEARN_MORE_LINK,
+  ROLES_TABLE_PREFERENCE_KEY,
+} from '../../Shared/constants';
 
 import type { RoleView } from '../../Shared/types';
 import type { SelectOption } from '@linode/ui';
@@ -271,10 +274,9 @@ export const RolesTable = ({ roles = [] }: Props) => {
                     {roleRow.permissions.length ? (
                       roleRow.description
                     ) : (
-                      // TODO: update the link for the description when it's ready - UIE-8534
                       <Typography>
                         {getFacadeRoleDescription(roleRow)}{' '}
-                        <Link to="#">Learn more.</Link>
+                        <Link to={ROLES_LEARN_MORE_LINK}>Learn more.</Link>
                       </Typography>
                     )}
                   </TableCell>

--- a/packages/manager/src/features/IAM/Roles/RolesTable/RolesTable.tsx
+++ b/packages/manager/src/features/IAM/Roles/RolesTable/RolesTable.tsx
@@ -276,7 +276,7 @@ export const RolesTable = ({ roles = [] }: Props) => {
                     ) : (
                       <Typography>
                         {getFacadeRoleDescription(roleRow)}{' '}
-                        <Link to={ROLES_LEARN_MORE_LINK}>Learn more.</Link>
+                        <Link to={ROLES_LEARN_MORE_LINK}>Learn more</Link>.
                       </Typography>
                     )}
                   </TableCell>

--- a/packages/manager/src/features/IAM/Shared/AssignedPermissionsPanel/AssignedPermissionsPanel.tsx
+++ b/packages/manager/src/features/IAM/Shared/AssignedPermissionsPanel/AssignedPermissionsPanel.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { Link } from 'src/components/Link';
 
+import { ROLES_LEARN_MORE_LINK } from '../constants';
 import { Entities } from '../Entities/Entities';
 import { Permissions } from '../Permissions/Permissions';
 import { type ExtendedRole, getFacadeRoleDescription } from '../utilities';
@@ -36,7 +37,6 @@ export const AssignedPermissionsPanel = ({
   sx,
   value,
 }: Props) => {
-  // TODO: update the link for the description when it's ready - UIE-8534
   return (
     <StyledPaper sx={{ ...sx }}>
       {hideDetails && showName && (
@@ -52,7 +52,8 @@ export const AssignedPermissionsPanel = ({
               role.description
             ) : (
               <>
-                {getFacadeRoleDescription(role)} <Link to="#">Learn more.</Link>
+                {getFacadeRoleDescription(role)}{' '}
+                <Link to={ROLES_LEARN_MORE_LINK}>Learn more.</Link>
               </>
             )}
           </StyledDescription>

--- a/packages/manager/src/features/IAM/Shared/AssignedPermissionsPanel/AssignedPermissionsPanel.tsx
+++ b/packages/manager/src/features/IAM/Shared/AssignedPermissionsPanel/AssignedPermissionsPanel.tsx
@@ -53,7 +53,7 @@ export const AssignedPermissionsPanel = ({
             ) : (
               <>
                 {getFacadeRoleDescription(role)}{' '}
-                <Link to={ROLES_LEARN_MORE_LINK}>Learn more.</Link>
+                <Link to={ROLES_LEARN_MORE_LINK}>Learn more</Link>.
               </>
             )}
           </StyledDescription>

--- a/packages/manager/src/features/IAM/Shared/AssignedRolesTable/AssignedRolesTable.tsx
+++ b/packages/manager/src/features/IAM/Shared/AssignedRolesTable/AssignedRolesTable.tsx
@@ -19,7 +19,10 @@ import { useAccountEntities } from 'src/queries/entities/entities';
 
 import { AssignedEntities } from '../../Users/UserRoles/AssignedEntities';
 import { AssignNewRoleDrawer } from '../../Users/UserRoles/AssignNewRoleDrawer';
-import { ASSIGNED_ROLES_TABLE_PREFERENCE_KEY } from '../constants';
+import {
+  ASSIGNED_ROLES_TABLE_PREFERENCE_KEY,
+  ROLES_LEARN_MORE_LINK,
+} from '../constants';
 import { Permissions } from '../Permissions/Permissions';
 import { RemoveAssignmentConfirmationDialog } from '../RemoveAssignmentConfirmationDialog/RemoveAssignmentConfirmationDialog';
 import {
@@ -242,7 +245,7 @@ export const AssignedRolesTable = () => {
             </TableCell>
           </>
         );
-        // TODO: update the link for 'Learn more' in the description when it's ready - UIE-8534
+
         const InnerTable = (
           <Grid
             sx={{
@@ -266,7 +269,7 @@ export const AssignedRolesTable = () => {
               ) : (
                 <>
                   {getFacadeRoleDescription(role)}{' '}
-                  <Link to="#">Learn more.</Link>
+                  <Link to={ROLES_LEARN_MORE_LINK}>Learn more.</Link>
                 </>
               )}
             </Typography>

--- a/packages/manager/src/features/IAM/Shared/AssignedRolesTable/AssignedRolesTable.tsx
+++ b/packages/manager/src/features/IAM/Shared/AssignedRolesTable/AssignedRolesTable.tsx
@@ -269,7 +269,7 @@ export const AssignedRolesTable = () => {
               ) : (
                 <>
                   {getFacadeRoleDescription(role)}{' '}
-                  <Link to={ROLES_LEARN_MORE_LINK}>Learn more.</Link>
+                  <Link to={ROLES_LEARN_MORE_LINK}>Learn more</Link>.
                 </>
               )}
             </Typography>

--- a/packages/manager/src/features/IAM/Shared/AssignedRolesTable/ChangeRoleDrawer.test.tsx
+++ b/packages/manager/src/features/IAM/Shared/AssignedRolesTable/ChangeRoleDrawer.test.tsx
@@ -103,7 +103,9 @@ describe('ChangeRoleDrawer', () => {
     );
 
     // Check that the correct text is displayed for account_access
-    expect(screen.getByText('Select a role you want to assign.')).toBeVisible();
+    expect(
+      screen.getByText(/Select a role you want to assign./i)
+    ).toBeVisible();
   });
 
   it('renders the correct text for entity_access roles', async () => {
@@ -117,7 +119,9 @@ describe('ChangeRoleDrawer', () => {
 
     // Check that the correct text is displayed for account_access
     expect(
-      screen.getByText('Select a role you want the entities to be attached to.')
+        screen.getByText(/Select a role you want the entities to be attached to./i)
+
+      // screen.getByText('Select a role you want the entities to be attached to.')
     ).toBeVisible();
   });
 

--- a/packages/manager/src/features/IAM/Shared/AssignedRolesTable/ChangeRoleDrawer.tsx
+++ b/packages/manager/src/features/IAM/Shared/AssignedRolesTable/ChangeRoleDrawer.tsx
@@ -139,8 +139,9 @@ export const ChangeRoleDrawer = ({ mode, onClose, open, role }: Props) => {
             ? 'to assign.'
             : 'the entities to be attached to.'}{' '}
           <Link to={ROLES_LEARN_MORE_LINK}>
-            Learn more about roles and permissions.
+            Learn more about roles and permissions
           </Link>
+          .
         </Typography>
 
         <Typography sx={{ marginBottom: theme.tokens.spacing.S8 }}>

--- a/packages/manager/src/features/IAM/Shared/AssignedRolesTable/ChangeRoleDrawer.tsx
+++ b/packages/manager/src/features/IAM/Shared/AssignedRolesTable/ChangeRoleDrawer.tsx
@@ -18,6 +18,7 @@ import { Controller, useForm } from 'react-hook-form';
 import { Link } from 'src/components/Link';
 
 import { AssignedPermissionsPanel } from '../AssignedPermissionsPanel/AssignedPermissionsPanel';
+import { ROLES_LEARN_MORE_LINK } from '../constants';
 import {
   changeUserRole,
   getAllRoles,
@@ -126,7 +127,6 @@ export const ChangeRoleDrawer = ({ mode, onClose, open, role }: Props) => {
     onClose();
   };
 
-  // TODO - add a link 'Learn more" - UIE-8534
   return (
     <Drawer onClose={handleClose} open={open} title="Change Role">
       {errors.root?.message && (
@@ -137,8 +137,10 @@ export const ChangeRoleDrawer = ({ mode, onClose, open, role }: Props) => {
           Select a role you want{' '}
           {role?.access === 'account_access'
             ? 'to assign.'
-            : 'the entities to be attached to.'}
-          <Link to=""> Learn more about roles and permissions.</Link>
+            : 'the entities to be attached to.'}{' '}
+          <Link to={ROLES_LEARN_MORE_LINK}>
+            Learn more about roles and permissions.
+          </Link>
         </Typography>
 
         <Typography sx={{ marginBottom: theme.tokens.spacing.S8 }}>

--- a/packages/manager/src/features/IAM/Shared/Permissions/Permissions.tsx
+++ b/packages/manager/src/features/IAM/Shared/Permissions/Permissions.tsx
@@ -37,7 +37,6 @@ export const Permissions = React.memo(({ permissions }: Props) => {
     };
   }, [handleResize]);
 
-  // TODO: update the link for TooltipIcon when it's ready - UIE-8534
   return (
     <Grid container data-testid="parent" direction="column">
       <StyledTitle>Permissions</StyledTitle>

--- a/packages/manager/src/features/IAM/Shared/constants.ts
+++ b/packages/manager/src/features/IAM/Shared/constants.ts
@@ -9,15 +9,17 @@ export const NO_ASSIGNED_ENTITIES_TEXT = `The user doesn't have any entity acces
 
 export const INTERNAL_ERROR_NO_CHANGES_SAVED = `Internal Error. No changes were saved.`;
 
-export const LAST_ACCOUNT_ADMIN_ERROR = `Failed to unassigned the role. You need to have at least one user with the account_admin role on your acount.`;
+export const LAST_ACCOUNT_ADMIN_ERROR = `Failed to unassign the role. You need to have at least one user with the account_admin role on your acount.`;
 
 export const ERROR_STATE_TEXT =
   'An unexpected error occurred. Refresh the page or try again later.';
 
 // Links
-// TODO: update the link when it's ready - UIE-8534
 export const IAM_DOCS_LINK =
-  'https://www.linode.com/docs/platform/identity-access-management/';
+  'https://techdocs.akamai.com/cloud-computing/docs/identity-and-access-cm';
+
+export const ROLES_LEARN_MORE_LINK =
+  'https://techdocs.akamai.com/cloud-computing/docs/identity-access-cm-available-roles';
 
 export const PAID_ENTITY_TYPES = [
   'database',

--- a/packages/manager/src/features/IAM/Shared/constants.ts
+++ b/packages/manager/src/features/IAM/Shared/constants.ts
@@ -9,7 +9,8 @@ export const NO_ASSIGNED_ENTITIES_TEXT = `The user doesn't have any entity acces
 
 export const INTERNAL_ERROR_NO_CHANGES_SAVED = `Internal Error. No changes were saved.`;
 
-export const LAST_ACCOUNT_ADMIN_ERROR = `Failed to unassign the role. You need to have at least one user with the account_admin role on your acount.`;
+export const LAST_ACCOUNT_ADMIN_ERROR =
+  'Failed to unassign the role. You need to have at least one user with the account_admin role on your account.';
 
 export const ERROR_STATE_TEXT =
   'An unexpected error occurred. Refresh the page or try again later.';

--- a/packages/manager/src/features/IAM/Users/UserEntities/ChangeRoleForEntityDrawer.test.tsx
+++ b/packages/manager/src/features/IAM/Users/UserEntities/ChangeRoleForEntityDrawer.test.tsx
@@ -73,7 +73,7 @@ describe('ChangeRoleForEntityDrawer', () => {
     // Verify title renders
     expect(screen.getByText('Change Role')).toBeVisible();
     expect(
-      screen.getByText('Select a role you want the entity to be attached to.')
+      screen.getByText(/Select a role you want the entity to be attached to/i)
     ).toBeVisible();
   });
 

--- a/packages/manager/src/features/IAM/Users/UserEntities/ChangeRoleForEntityDrawer.tsx
+++ b/packages/manager/src/features/IAM/Users/UserEntities/ChangeRoleForEntityDrawer.tsx
@@ -141,8 +141,9 @@ export const ChangeRoleForEntityDrawer = ({
         <Typography sx={{ marginBottom: 2.5 }}>
           Select a role you want the entity to be attached to.{' '}
           <Link to={ROLES_LEARN_MORE_LINK}>
-            Learn more about roles and permissions.
+            Learn more about roles and permissions
           </Link>
+          .
         </Typography>
 
         <Typography sx={{ marginBottom: theme.tokens.spacing.S8 }}>

--- a/packages/manager/src/features/IAM/Users/UserEntities/ChangeRoleForEntityDrawer.tsx
+++ b/packages/manager/src/features/IAM/Users/UserEntities/ChangeRoleForEntityDrawer.tsx
@@ -18,7 +18,10 @@ import { Controller, useForm } from 'react-hook-form';
 import { Link } from 'src/components/Link';
 
 import { AssignedPermissionsPanel } from '../../Shared/AssignedPermissionsPanel/AssignedPermissionsPanel';
-import { INTERNAL_ERROR_NO_CHANGES_SAVED } from '../../Shared/constants';
+import {
+  INTERNAL_ERROR_NO_CHANGES_SAVED,
+  ROLES_LEARN_MORE_LINK,
+} from '../../Shared/constants';
 import {
   changeRoleForEntity,
   getAllRoles,
@@ -129,7 +132,6 @@ export const ChangeRoleForEntityDrawer = ({
     onClose();
   };
 
-  // TODO - add a link 'Learn more" - UIE-8534
   return (
     <Drawer onClose={handleClose} open={open} title="Change Role">
       {errors.root?.message && (
@@ -137,8 +139,10 @@ export const ChangeRoleForEntityDrawer = ({
       )}
       <form onSubmit={handleSubmit(onSubmit)}>
         <Typography sx={{ marginBottom: 2.5 }}>
-          Select a role you want the entity to be attached to.
-          <Link to=""> Learn more about roles and permissions.</Link>
+          Select a role you want the entity to be attached to.{' '}
+          <Link to={ROLES_LEARN_MORE_LINK}>
+            Learn more about roles and permissions.
+          </Link>
         </Typography>
 
         <Typography sx={{ marginBottom: theme.tokens.spacing.S8 }}>

--- a/packages/manager/src/features/IAM/Users/UserRoles/AssignNewRoleDrawer.tsx
+++ b/packages/manager/src/features/IAM/Users/UserRoles/AssignNewRoleDrawer.tsx
@@ -17,7 +17,10 @@ import { LinkButton } from 'src/components/LinkButton';
 import { StyledLinkButtonBox } from 'src/components/SelectFirewallPanel/SelectFirewallPanel';
 import { AssignSingleRole } from 'src/features/IAM/Users/UserRoles/AssignSingleRole';
 
-import { INTERNAL_ERROR_NO_CHANGES_SAVED } from '../../Shared/constants';
+import {
+  INTERNAL_ERROR_NO_CHANGES_SAVED,
+  ROLES_LEARN_MORE_LINK,
+} from '../../Shared/constants';
 import {
   getAllRoles,
   mergeAssignedRolesIntoExistingRoles,
@@ -105,7 +108,7 @@ export const AssignNewRoleDrawer = ({ onClose, open }: Props) => {
       });
     }
   }, [open, reset]);
-  // TODO - add a link 'Learn more" - UIE-8534
+
   return (
     <Drawer onClose={handleClose} open={open} title="Assign New Roles">
       <FormProvider {...form}>
@@ -117,8 +120,10 @@ export const AssignNewRoleDrawer = ({ onClose, open }: Props) => {
           <Typography sx={{ marginBottom: 2.5 }}>
             Select a role you want to assign to a user. Some roles require
             selecting entities they should apply to. Configure the first role
-            and continue adding roles or save the assignment.
-            <Link to=""> Learn more about roles and permissions.</Link>
+            and continue adding roles or save the assignment.{' '}
+            <Link to={ROLES_LEARN_MORE_LINK}>
+              Learn more about roles and permissions.
+            </Link>
           </Typography>
           <Grid
             container

--- a/packages/manager/src/features/IAM/Users/UserRoles/AssignNewRoleDrawer.tsx
+++ b/packages/manager/src/features/IAM/Users/UserRoles/AssignNewRoleDrawer.tsx
@@ -122,8 +122,9 @@ export const AssignNewRoleDrawer = ({ onClose, open }: Props) => {
             selecting entities they should apply to. Configure the first role
             and continue adding roles or save the assignment.{' '}
             <Link to={ROLES_LEARN_MORE_LINK}>
-              Learn more about roles and permissions.
+              Learn more about roles and permissions
             </Link>
+            .
           </Typography>
           <Grid
             container

--- a/packages/manager/src/features/IAM/Users/UserRoles/AssignSingleRole.tsx
+++ b/packages/manager/src/features/IAM/Users/UserRoles/AssignSingleRole.tsx
@@ -118,7 +118,11 @@ export const AssignSingleRole = ({
           verticalAlign: 'top',
         }}
       >
-        <Button disabled={roles.length === 1} onClick={() => onRemove(index)}>
+        <Button
+          disabled={roles.length === 1}
+          onClick={() => onRemove(index)}
+          sx={{ paddingRight: 0 }}
+        >
           <DeleteIcon />
         </Button>
       </Box>


### PR DESCRIPTION
## Description 📝

Add the docs links, fix the bugs

## Changes  🔄

List any change(s) relevant to the reviewer.

- Add the links for the docs and Learn more buttons
- Fix the typo
- Fix the style issue

## Target release date 🗓️

07/01

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/d967cccc-e5b3-4d7b-943b-44edb3b58915) | ![image](https://github.com/user-attachments/assets/6235e509-aaec-4c8c-b21f-501ec2fb2887) |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Ensure the Identity and Access Beta flag is enabled in dev tools
- Use devenv and login as vagrant user


### Verification steps

(How to verify changes)

- [ ] Confirm that the “Docs” and “Learn more” buttons contain working links and open the correct target URLs
- [ ] Confirm that the previous typo has been corrected
- [ ] Confirm that the padding has been removed in the assign new roles drawer

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
