### PR TITLE
fix: [M3-10236, M3-10235] - Linode Disk Action Menu and LKE Node Action Menu table styles

### DIFF
--- a/packages/manager/.changeset/pr-12413-fixed-1750706040269.md
+++ b/packages/manager/.changeset/pr-12413-fixed-1750706040269.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Incorrectly styled Linode Disk row action menu and buttons ([#12413](https://github.com/linode/manager/pull/12413))

--- a/packages/manager/.changeset/pr-12413-fixed-1750706078072.md
+++ b/packages/manager/.changeset/pr-12413-fixed-1750706078072.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Incorrectly styled LKE cluster node row action button ([#12413](https://github.com/linode/manager/pull/12413))

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeActionMenu.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeActionMenu.tsx
@@ -58,5 +58,3 @@ export const NodeActionMenu = (props: Props) => {
     </Box>
   );
 };
-
-export default React.memo(NodeActionMenu);

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeRow.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeRow.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled';
 import { usePreferences } from '@linode/queries';
 import { Box, Typography } from '@linode/ui';
-import Grid from '@mui/material/Grid';
 import * as React from 'react';
 
 import { CopyTooltip } from 'src/components/CopyTooltip/CopyTooltip';
@@ -12,9 +11,9 @@ import { TableRow } from 'src/components/TableRow';
 import { transitionText } from 'src/features/Linodes/transitions';
 import { useInProgressEvents } from 'src/queries/events/events';
 
-import NodeActionMenu from './NodeActionMenu';
+import { NodeActionMenu } from './NodeActionMenu';
 
-import type { APIError } from '@linode/api-v4/lib/types';
+import type { APIError } from '@linode/api-v4';
 
 export interface NodeRow {
   instanceId?: number;
@@ -79,24 +78,12 @@ export const NodeRow = React.memo((props: NodeRowProps) => {
 
   return (
     <TableRow data-qa-node-row={nodeId}>
-      <TableCell>
-        <Grid
-          container
-          sx={{
-            alignItems: 'center',
-          }}
-          wrap="nowrap"
-        >
-          <Grid>
-            <Typography>
-              {linodeLink ? (
-                <Link to={linodeLink}>{displayLabel}</Link>
-              ) : (
-                displayLabel
-              )}
-            </Typography>
-          </Grid>
-        </Grid>
+      <TableCell noWrap>
+        {linodeLink ? (
+          <Link to={linodeLink}>{displayLabel}</Link>
+        ) : (
+          displayLabel
+        )}
       </TableCell>
       <TableCell statusCell={!linodeError}>
         {linodeError ? (
@@ -135,7 +122,7 @@ export const NodeRow = React.memo((props: NodeRowProps) => {
           </Box>
         ) : null}
       </TableCell>
-      <TableCell>
+      <TableCell actionCell>
         <NodeActionMenu
           instanceLabel={label}
           isLkeClusterRestricted={isLkeClusterRestricted}

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeStorage/LinodeDiskActionMenu.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeStorage/LinodeDiskActionMenu.tsx
@@ -1,4 +1,3 @@
-import { Box } from '@linode/ui';
 import { splitAt } from '@linode/utilities';
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
@@ -90,7 +89,7 @@ export const LinodeDiskActionMenu = (props: Props) => {
   const [inlineActions, menuActions] = splitAt(splitActionsArrayIndex, actions);
 
   return (
-    <Box alignItems="center" display="flex" justifyContent="flex-end">
+    <>
       {!matchesSmDown &&
         inlineActions.map((action) => (
           <InlineMenuAction
@@ -115,6 +114,6 @@ export const LinodeDiskActionMenu = (props: Props) => {
         actionsList={menuActions}
         ariaLabel={`Action menu for Disk ${disk.label}`}
       />
-    </Box>
+    </>
   );
 };

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeStorage/LinodeDiskRow.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeStorage/LinodeDiskRow.tsx
@@ -83,7 +83,7 @@ export const LinodeDiskRow = React.memo((props: Props) => {
           <DateTimeDisplay value={disk.created} />
         </TableCell>
       </Hidden>
-      <TableCell>
+      <TableCell actionCell>
         <LinodeDiskActionMenu
           disk={disk}
           linodeId={linodeId}


### PR DESCRIPTION
## Description 📝

Fixes some incorrectly styled action menu table rows 


## Preview 📷

### Linode Disk Table

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-06-23 at 3 02 12 PM](https://github.com/user-attachments/assets/ce3c8f5d-7bc1-4d45-9e5c-544bbfd28781) | ![Screenshot 2025-06-23 at 3 02 32 PM](https://github.com/user-attachments/assets/f4ccf854-57cb-4fb7-91bc-96e792f48d74) |
| Buttons are not the same height & Action menu is not right aligned | Fixed! |

### Kubernetes Node Pool Table

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-06-23 at 3 04 06 PM](https://github.com/user-attachments/assets/c60c3717-7e3a-4599-a2ca-05127d88b232) | ![Screenshot 2025-06-23 at 3 04 17 PM](https://github.com/user-attachments/assets/7ed864b5-ea3b-418f-920c-5a9fde14d1f7) |
| Recycle button is not right aligned |  Fixed! |

## How to test 🧪

### Linode Disks
- View a Linode's detail's page
- Go to the Storage tab
- Verify the Disk rows look good (check various viewport sizes too)

### LKE Cluster
- View a LKE cluster detail's page
- Verify the Node Row's action button looks good

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>