### PR TITLE
fix: [M3-10176, M3-10177, M3-10244] - Fix columns misalignment in Subnet NodeBalancers Table

### DIFF
--- a/packages/manager/.changeset/pr-12428-fixed-1750852226481.md
+++ b/packages/manager/.changeset/pr-12428-fixed-1750852226481.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Fix console error in Create NodeBalancer page and columns misalignment in Subnet NodeBalancers Table ([#12428](https://github.com/linode/manager/pull/12428))

--- a/packages/manager/src/features/NodeBalancers/VPCPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/VPCPanel.tsx
@@ -143,9 +143,12 @@ export const VPCPanel = (props: Props) => {
                 placeholder="Subnet"
                 textFieldProps={{
                   helperText: (
-                    <Typography mb={2}>
-                      The VPC subnet for this NodeBalancer.
-                    </Typography>
+                    <Box component="span" mb={2} sx={{ display: 'block' }}>
+                      <Typography component="span" variant="body1">
+                        Select a subnet in which to allocate the VPC CIDR for
+                        the NodeBalancer.
+                      </Typography>
+                    </Box>
                   ),
                   helperTextPosition: 'top',
                 }}

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeActionMenu.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeActionMenu.test.tsx
@@ -18,6 +18,7 @@ const props = {
   linode: linodeFactory.build({ label: 'linode-1' }),
   subnet: subnetFactory.build({ label: 'subnet-1' }),
   isOffline: false,
+  isRebootNeeded: false,
   showPowerButton: true,
 };
 
@@ -30,21 +31,20 @@ describe('SubnetActionMenu', () => {
       `Action menu for Linodes in Subnet subnet-1`
     );
     await userEvent.click(actionMenu);
-    getByText('Reboot Linode');
     getByText('Power Off');
     getByText('Unassign Linode');
   });
 
   it('should allow the reboot button to be clicked', async () => {
     const { getByLabelText, getByText, queryByLabelText } = renderWithTheme(
-      <SubnetLinodeActionMenu {...props} />
+      <SubnetLinodeActionMenu {...props} isRebootNeeded={true} />
     );
     const actionMenu = getByLabelText(
       `Action menu for Linodes in Subnet subnet-1`
     );
     await userEvent.click(actionMenu);
 
-    const rebootButton = getByText('Reboot Linode');
+    const rebootButton = getByText('Reboot');
     await userEvent.click(rebootButton);
     expect(props.handlePowerActionsLinode).toHaveBeenCalled();
     const tooltipText = queryByLabelText(

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeActionMenu.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeActionMenu.test.tsx
@@ -1,5 +1,4 @@
 import { linodeFactory } from '@linode/utilities';
-import { fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
@@ -23,14 +22,14 @@ const props = {
 };
 
 describe('SubnetActionMenu', () => {
-  it('should render the subnet action menu', () => {
+  it('should render the subnet action menu', async () => {
     const { getByLabelText, getByText } = renderWithTheme(
       <SubnetLinodeActionMenu {...props} />
     );
     const actionMenu = getByLabelText(
       `Action menu for Linodes in Subnet subnet-1`
     );
-    fireEvent.click(actionMenu);
+    await userEvent.click(actionMenu);
     getByText('Reboot Linode');
     getByText('Power Off');
     getByText('Unassign Linode');

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeActionMenu.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeActionMenu.test.tsx
@@ -5,11 +5,7 @@ import * as React from 'react';
 import { subnetFactory } from 'src/factories';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
-import SubnetLinodeActionMenu from './SubnetLinodeActionMenu';
-
-afterEach(() => {
-  vi.clearAllMocks();
-});
+import { SubnetLinodeActionMenu } from './SubnetLinodeActionMenu';
 
 const props = {
   handlePowerActionsLinode: vi.fn(),

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeActionMenu.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeActionMenu.test.tsx
@@ -1,0 +1,114 @@
+import { linodeFactory } from '@linode/utilities';
+import { fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+
+import { subnetFactory } from 'src/factories';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import SubnetLinodeActionMenu from './SubnetLinodeActionMenu';
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+const props = {
+  handlePowerActionsLinode: vi.fn(),
+  handleUnassignLinode: vi.fn(),
+  isVPCLKEEnterpriseCluster: false,
+  linode: linodeFactory.build({ label: 'linode-1' }),
+  subnet: subnetFactory.build({ label: 'subnet-1' }),
+  isOffline: false,
+  showPowerButton: true,
+};
+
+describe('SubnetActionMenu', () => {
+  it('should render the subnet action menu', () => {
+    const { getByLabelText, getByText } = renderWithTheme(
+      <SubnetLinodeActionMenu {...props} />
+    );
+    const actionMenu = getByLabelText(
+      `Action menu for Linodes in Subnet subnet-1`
+    );
+    fireEvent.click(actionMenu);
+    getByText('Reboot Linode');
+    getByText('Power Off');
+    getByText('Unassign Linode');
+  });
+
+  it('should allow the reboot button to be clicked', async () => {
+    const { getByLabelText, getByText, queryByLabelText } = renderWithTheme(
+      <SubnetLinodeActionMenu {...props} />
+    );
+    const actionMenu = getByLabelText(
+      `Action menu for Linodes in Subnet subnet-1`
+    );
+    await userEvent.click(actionMenu);
+
+    const rebootButton = getByText('Reboot Linode');
+    await userEvent.click(rebootButton);
+    expect(props.handlePowerActionsLinode).toHaveBeenCalled();
+    const tooltipText = queryByLabelText(
+      'Linodes assigned to a subnet must be unassigned before the subnet can be deleted.'
+    );
+    expect(tooltipText).not.toBeInTheDocument();
+  });
+
+  it('should allow the Power Off button to be clicked', async () => {
+    const { getByLabelText, getByText } = renderWithTheme(
+      <SubnetLinodeActionMenu {...props} />
+    );
+    const actionMenu = getByLabelText(
+      `Action menu for Linodes in Subnet subnet-1`
+    );
+    await userEvent.click(actionMenu);
+
+    const powerOffButton = getByText('Power Off');
+    await userEvent.click(powerOffButton);
+    expect(props.handlePowerActionsLinode).toHaveBeenCalled();
+  });
+
+  it('should allow the Power On button to be clicked', async () => {
+    const { getByLabelText, getByText } = renderWithTheme(
+      <SubnetLinodeActionMenu {...props} isOffline={true} />
+    );
+    const actionMenu = getByLabelText(
+      `Action menu for Linodes in Subnet subnet-1`
+    );
+    await userEvent.click(actionMenu);
+
+    const powerOnButton = getByText('Power On');
+    await userEvent.click(powerOnButton);
+    expect(props.handlePowerActionsLinode).toHaveBeenCalled();
+  });
+
+  it('should allow the Unassign Linode button to be clicked', async () => {
+    const { getByLabelText, getByText } = renderWithTheme(
+      <SubnetLinodeActionMenu {...props} />
+    );
+    const actionMenu = getByLabelText(
+      `Action menu for Linodes in Subnet subnet-1`
+    );
+    await userEvent.click(actionMenu);
+
+    const unassignButton = getByText('Unassign Linode');
+    await userEvent.click(unassignButton);
+    expect(props.handleUnassignLinode).toHaveBeenCalled();
+  });
+
+  it('should disable action buttons if isVPCLKEEnterpriseCluster is true', async () => {
+    const updatedProps = { ...props, isVPCLKEEnterpriseCluster: true };
+    const { getByLabelText, getAllByRole } = renderWithTheme(
+      <SubnetLinodeActionMenu {...updatedProps} />
+    );
+    const actionMenu = getByLabelText(
+      `Action menu for Linodes in Subnet subnet-1`
+    );
+    await userEvent.click(actionMenu);
+
+    const actionButtons = getAllByRole('menuitem');
+    actionButtons.forEach((button) =>
+      expect(button).toHaveAttribute('aria-disabled', 'true')
+    );
+  });
+});

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeActionMenu.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeActionMenu.tsx
@@ -1,0 +1,76 @@
+import * as React from 'react';
+
+import { ActionMenu } from 'src/components/ActionMenu/ActionMenu';
+
+import type { Linode, Subnet } from '@linode/api-v4';
+import type { Action as ActionMenuAction } from 'src/components/ActionMenu/ActionMenu';
+import type { Action as PowerAction } from 'src/features/Linodes/PowerActionsDialogOrDrawer';
+
+interface SubnetLinodeActionHandlers {
+  handlePowerActionsLinode: (
+    linode: Linode,
+    action: PowerAction,
+    subnet: Subnet
+  ) => void;
+  handleUnassignLinode: (linode: Linode, subnet?: Subnet) => void;
+}
+
+interface Props extends SubnetLinodeActionHandlers {
+  isOffline: boolean;
+  isVPCLKEEnterpriseCluster: boolean;
+  linode: Linode;
+  showPowerButton: boolean;
+  subnet: Subnet;
+}
+
+export const SubnetLinodeActionMenu = (props: Props) => {
+  const {
+    handlePowerActionsLinode,
+    handleUnassignLinode,
+    isVPCLKEEnterpriseCluster,
+    isOffline,
+    subnet,
+    linode,
+    showPowerButton,
+  } = props;
+
+  const actions: ActionMenuAction[] = [
+    {
+      disabled: isVPCLKEEnterpriseCluster,
+      onClick: () => {
+        handlePowerActionsLinode(linode, 'Reboot', subnet);
+      },
+      title: 'Reboot Linode',
+    },
+    {
+      disabled: isVPCLKEEnterpriseCluster,
+      onClick: () => {
+        handleUnassignLinode(linode, subnet);
+      },
+      title: 'Unassign Linode',
+    },
+  ];
+
+  if (showPowerButton) {
+    actions.splice(1, 0, {
+      disabled: isVPCLKEEnterpriseCluster,
+      onClick: () => {
+        handlePowerActionsLinode(
+          linode,
+          isOffline ? 'Power On' : 'Power Off',
+          subnet
+        );
+      },
+      title: isOffline ? 'Power On' : 'Power Off',
+    });
+  }
+
+  return (
+    <ActionMenu
+      actionsList={actions}
+      ariaLabel={`Action menu for Linodes in Subnet ${subnet.label}`}
+    />
+  );
+};
+
+export default SubnetLinodeActionMenu;

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeActionMenu.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeActionMenu.tsx
@@ -17,6 +17,7 @@ interface SubnetLinodeActionHandlers {
 
 interface Props extends SubnetLinodeActionHandlers {
   isOffline: boolean;
+  isRebootNeeded: boolean;
   isVPCLKEEnterpriseCluster: boolean;
   linode: Linode;
   showPowerButton: boolean;
@@ -29,30 +30,25 @@ export const SubnetLinodeActionMenu = (props: Props) => {
     handleUnassignLinode,
     isVPCLKEEnterpriseCluster,
     isOffline,
+    isRebootNeeded,
     subnet,
     linode,
     showPowerButton,
   } = props;
 
-  const actions: ActionMenuAction[] = [
-    {
+  const actions: ActionMenuAction[] = [];
+  if (isRebootNeeded) {
+    actions.push({
       disabled: isVPCLKEEnterpriseCluster,
       onClick: () => {
         handlePowerActionsLinode(linode, 'Reboot', subnet);
       },
-      title: 'Reboot Linode',
-    },
-    {
-      disabled: isVPCLKEEnterpriseCluster,
-      onClick: () => {
-        handleUnassignLinode(linode, subnet);
-      },
-      title: 'Unassign Linode',
-    },
-  ];
+      title: 'Reboot',
+    });
+  }
 
   if (showPowerButton) {
-    actions.splice(1, 0, {
+    actions.push({
       disabled: isVPCLKEEnterpriseCluster,
       onClick: () => {
         handlePowerActionsLinode(
@@ -64,6 +60,14 @@ export const SubnetLinodeActionMenu = (props: Props) => {
       title: isOffline ? 'Power On' : 'Power Off',
     });
   }
+
+  actions.push({
+    disabled: isVPCLKEEnterpriseCluster,
+    onClick: () => {
+      handleUnassignLinode(linode, subnet);
+    },
+    title: 'Unassign Linode',
+  });
 
   return (
     <ActionMenu

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeActionMenu.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeActionMenu.tsx
@@ -76,5 +76,3 @@ export const SubnetLinodeActionMenu = (props: Props) => {
     />
   );
 };
-
-export default SubnetLinodeActionMenu;

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.tsx
@@ -6,7 +6,6 @@ import ErrorOutline from '@mui/icons-material/ErrorOutline';
 import * as React from 'react';
 import type { JSX } from 'react';
 
-import { InlineMenuAction } from 'src/components/InlineMenuAction/InlineMenuAction';
 import { Link } from 'src/components/Link';
 import { StatusIcon } from 'src/components/StatusIcon/StatusIcon';
 import { TableCell } from 'src/components/TableCell';
@@ -25,6 +24,7 @@ import {
   getLinodeInterfaceRanges,
   hasUnrecommendedConfigurationLinodeInterface,
 } from '../utils';
+import SubnetLinodeActionMenu from './SubnetLinodeActionMenu';
 import { StyledWarningIcon } from './SubnetLinodeRow.styles';
 import {
   ConfigInterfaceFirewallCell,
@@ -238,35 +238,15 @@ export const SubnetLinodeRow = (props: Props) => {
       </Hidden>
       <TableCell actionCell>
         {!isVPCLKEEnterpriseCluster && (
-          <>
-            {isRebootNeeded && (
-              <InlineMenuAction
-                actionText="Reboot"
-                disabled={isVPCLKEEnterpriseCluster}
-                onClick={() => {
-                  handlePowerActionsLinode(linode, 'Reboot', subnet);
-                }}
-              />
-            )}
-            {showPowerButton && (
-              <InlineMenuAction
-                actionText={isOffline ? 'Power On' : 'Power Off'}
-                disabled={isVPCLKEEnterpriseCluster}
-                onClick={() => {
-                  handlePowerActionsLinode(
-                    linode,
-                    isOffline ? 'Power On' : 'Power Off',
-                    subnet
-                  );
-                }}
-              />
-            )}
-            <InlineMenuAction
-              actionText="Unassign Linode"
-              disabled={isVPCLKEEnterpriseCluster}
-              onClick={() => handleUnassignLinode(linode, subnet)}
-            />
-          </>
+          <SubnetLinodeActionMenu
+            handlePowerActionsLinode={handlePowerActionsLinode}
+            handleUnassignLinode={handleUnassignLinode}
+            isOffline={isOffline}
+            isVPCLKEEnterpriseCluster={isVPCLKEEnterpriseCluster}
+            linode={linode}
+            showPowerButton={showPowerButton}
+            subnet={subnet}
+          />
         )}
       </TableCell>
     </TableRow>
@@ -351,8 +331,8 @@ export const SubnetLinodeTableRowHead = (
       <TableCell>VPC IPv4 Ranges</TableCell>
     </Hidden>
     <Hidden smDown>
-      <TableCell>Firewalls</TableCell>
+      <TableCell sx={{ width: '18%' }}>Firewalls</TableCell>
     </Hidden>
-    <TableCell />
+    <TableCell sx={{ width: '10%' }} />
   </TableRow>
 );

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.tsx
@@ -242,6 +242,7 @@ export const SubnetLinodeRow = (props: Props) => {
             handlePowerActionsLinode={handlePowerActionsLinode}
             handleUnassignLinode={handleUnassignLinode}
             isOffline={isOffline}
+            isRebootNeeded={isRebootNeeded}
             isVPCLKEEnterpriseCluster={isVPCLKEEnterpriseCluster}
             linode={linode}
             showPowerButton={showPowerButton}

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.tsx
@@ -24,7 +24,7 @@ import {
   getLinodeInterfaceRanges,
   hasUnrecommendedConfigurationLinodeInterface,
 } from '../utils';
-import SubnetLinodeActionMenu from './SubnetLinodeActionMenu';
+import { SubnetLinodeActionMenu } from './SubnetLinodeActionMenu';
 import { StyledWarningIcon } from './SubnetLinodeRow.styles';
 import {
   ConfigInterfaceFirewallCell,

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetNodebalancerRow.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetNodebalancerRow.tsx
@@ -9,7 +9,6 @@ import { Typography } from '@mui/material';
 import * as React from 'react';
 
 import { Link } from 'src/components/Link';
-import { StatusIcon } from 'src/components/StatusIcon/StatusIcon';
 import { TableCell } from 'src/components/TableCell';
 import { TableRow } from 'src/components/TableRow';
 
@@ -64,8 +63,7 @@ export const SubnetNodeBalancerRow = ({
 
     return (
       <>
-        <StatusIcon aria-label="Nodebalancer status active" status="active" />
-        {up} up, {down} down
+        {up} up - {down} down
       </>
     );
   };
@@ -167,8 +165,8 @@ export const SubnetNodeBalancerRow = ({
 export const SubnetNodebalancerTableRowHead = (
   <TableRow>
     <TableCell sx={{ width: '24%' }}>NodeBalancer</TableCell>
-    <TableCell sx={{ width: '23%' }}>Backend Status</TableCell>
-    <TableCell sx={{ width: '14.25%' }}>VPC IPv4 Range</TableCell>
+    <TableCell sx={{ width: '18%' }}>Backend Status</TableCell>
+    <TableCell sx={{ width: '30%' }}>VPC IPv4 Range</TableCell>
     <TableCell>Firewalls</TableCell>
   </TableRow>
 );


### PR DESCRIPTION
## Description 📝

When viewing the Subnets table that lists both Linode and NodeBalancer resources, the "VPC IPv4 Ranges" and "Firewalls" columns become misaligned if there are multiple subnets present. 

## Changes  🔄

- Fixed misalignment in Subnet's NodeBalancer table 
- Fixed console error for the helper text in the Create Nodebalancer's VPC Panel
- Removed backend status icon in Subnet's NodeBalancer table

## Target release date 🗓️
09/07

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/981646b0-66d3-4d54-a532-407c5a9bcb3e) | ![image](https://github.com/user-attachments/assets/5456909a-3d76-498f-b5ad-5bf0afd322c3) |

| Console Error in the Create Nodebalancer page |
| ------- |
| ![image](https://github.com/user-attachments/assets/7f2ebc42-75f4-478e-92ec-68b55d1b9f85) |

## How to test 🧪

### Reproduction steps

#### Misaligned table columns
- [ ] Switch to `develop`
- [ ] Navigate to the VPC Detail page and observe the misaligned table columns in the Subnet's nested tables

#### Console error 
- [ ] Enable NodeBalancer-VPC Integration flag 
- [ ] Navigate to the Create NodeBalancer Page and select a VPC
- [ ] Observe the console error 

### Verification steps

- [ ] Verify that the Subnets' tables are aligned
- [ ] Verify you don't observe any console error while creating a NodeBalancer 

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>


