### PR TITLE
fix: [M3-10246] - Disabled kubeconfig and upgrade option for read only access user

### DIFF
--- a/packages/manager/.changeset/pr-12430-fixed-1750866239525.md
+++ b/packages/manager/.changeset/pr-12430-fixed-1750866239525.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Disable kubeconfig and upgrade options for users with read-only access ([#12430](https://github.com/linode/manager/pull/12430))

--- a/packages/manager/src/features/Kubernetes/ClusterList/KubernetesClusterRow.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/KubernetesClusterRow.tsx
@@ -51,6 +51,12 @@ export const KubernetesClusterRow = (props: Props) => {
     id: cluster.id,
   });
 
+  const isLKEClusterReadWrite = useIsResourceRestricted({
+    grantLevel: 'read_write',
+    grantType: 'lkecluster',
+    id: cluster.id,
+  });
+
   const nextVersion = getNextVersion(cluster.k8s_version, versions ?? []);
 
   const hasUpgrade = nextVersion !== null;
@@ -82,7 +88,7 @@ export const KubernetesClusterRow = (props: Props) => {
       <Hidden mdDown>
         <TableCell data-qa-cluster-version>
           {cluster.k8s_version}
-          {hasUpgrade && (
+          {hasUpgrade && isLKEClusterReadWrite && (
             <Chip
               clickable
               label="UPGRADE"

--- a/packages/manager/src/features/Kubernetes/ClusterList/KubernetesClusterRow.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/KubernetesClusterRow.tsx
@@ -51,12 +51,6 @@ export const KubernetesClusterRow = (props: Props) => {
     id: cluster.id,
   });
 
-  const isLKEClusterReadWrite = useIsResourceRestricted({
-    grantLevel: 'read_write',
-    grantType: 'lkecluster',
-    id: cluster.id,
-  });
-
   const nextVersion = getNextVersion(cluster.k8s_version, versions ?? []);
 
   const hasUpgrade = nextVersion !== null;
@@ -88,7 +82,7 @@ export const KubernetesClusterRow = (props: Props) => {
       <Hidden mdDown>
         <TableCell data-qa-cluster-version>
           {cluster.k8s_version}
-          {hasUpgrade && isLKEClusterReadWrite && (
+          {hasUpgrade && !isLKEClusterReadOnly && (
             <Chip
               clickable
               label="UPGRADE"

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigDisplay.tsx
@@ -37,9 +37,9 @@ interface Props {
 const useStyles = makeStyles()((theme: Theme) => ({
   disabled: {
     '& g': {
-      stroke: theme.tokens.color.Neutrals[20],
+      stroke: theme.tokens.alias.Content.Icon.Primary.Disabled,
     },
-    color: theme.tokens.color.Neutrals[20],
+    color: theme.tokens.alias.Content.Text.Primary.Disabled,
     pointer: 'default',
     pointerEvents: 'none',
   },

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigDisplay.tsx
@@ -16,6 +16,7 @@ import CopyIcon from 'src/assets/icons/copy.svg';
 import DownloadIcon from 'src/assets/icons/lke-download.svg';
 import ResetIcon from 'src/assets/icons/reset.svg';
 import { MaskableText } from 'src/components/MaskableText/MaskableText';
+import { useIsResourceRestricted } from 'src/hooks/useIsResourceRestricted';
 import {
   useAllKubernetesClusterAPIEndpointsQuery,
   useKubernetesKubeConfigQuery,
@@ -36,9 +37,9 @@ interface Props {
 const useStyles = makeStyles()((theme: Theme) => ({
   disabled: {
     '& g': {
-      stroke: theme.palette.text.secondary,
+      stroke: theme.tokens.color.Neutrals[20],
     },
-    color: theme.palette.text.secondary,
+    color: theme.tokens.color.Neutrals[20],
     pointer: 'default',
     pointerEvents: 'none',
   },
@@ -153,6 +154,12 @@ export const KubeConfigDisplay = (props: Props) => {
     isLoading: endpointsLoading,
   } = useAllKubernetesClusterAPIEndpointsQuery(clusterId);
 
+  const isClusterReadOnly = useIsResourceRestricted({
+    grantLevel: 'read_only',
+    grantType: 'lkecluster',
+    id: clusterId,
+  });
+
   const downloadKubeConfig = async () => {
     try {
       const queryResult = await getKubeConfig();
@@ -221,27 +228,50 @@ export const KubeConfigDisplay = (props: Props) => {
           <StyledLinkButton
             aria-label={`Download kubeconfig for ${clusterLabel}`}
             className={classes.kubeconfigElement}
+            disabled={isClusterReadOnly}
             onClick={downloadKubeConfig}
           >
             <DownloadIcon
-              className={classes.kubeconfigIcons}
+              className={cx({
+                [classes.disabled]: isResettingKubeConfig || isClusterReadOnly,
+                [classes.kubeconfigIcons]: true,
+              })}
               style={{ marginLeft: 0 }}
             />
-            <Typography className={classes.kubeconfigFileText}>
+            <Typography
+              className={cx({
+                [classes.disabled]: isResettingKubeConfig || isClusterReadOnly,
+                [classes.kubeconfigFileText]: !isClusterReadOnly,
+              })}
+            >
               {`${clusterLabel}-kubeconfig.yaml`}
             </Typography>
           </StyledLinkButton>
           <StyledLinkButton
             aria-label="View kubeconfig details"
             className={classes.kubeconfigElement}
+            disabled={isClusterReadOnly}
             onClick={handleOpenDrawer}
           >
-            <DetailsIcon className={classes.kubeconfigIcons} />
-            <Typography className={classes.kubeconfigFileText}>View</Typography>
+            <DetailsIcon
+              className={cx({
+                [classes.disabled]: isResettingKubeConfig || isClusterReadOnly,
+                [classes.kubeconfigIcons]: true,
+              })}
+            />
+            <Typography
+              className={cx({
+                [classes.disabled]: isResettingKubeConfig || isClusterReadOnly,
+                [classes.kubeconfigFileText]: !isClusterReadOnly,
+              })}
+            >
+              View
+            </Typography>
           </StyledLinkButton>
           <StyledLinkButton
             aria-label="Copy kubeconfig token"
             className={classes.kubeconfigElement}
+            disabled={isClusterReadOnly}
             onClick={onCopyToken}
           >
             {isCopyTokenLoading ? (
@@ -251,25 +281,39 @@ export const KubeConfigDisplay = (props: Props) => {
                 size="xs"
               />
             ) : (
-              <CopyIcon className={classes.kubeconfigIcons} />
+              <CopyIcon
+                className={cx({
+                  [classes.disabled]:
+                    isResettingKubeConfig || isClusterReadOnly,
+                  [classes.kubeconfigIcons]: true,
+                })}
+              />
             )}
-            <Box className={classes.kubeconfigFileText}>Copy Token</Box>
+            <Box
+              className={cx({
+                [classes.disabled]: isResettingKubeConfig || isClusterReadOnly,
+                [classes.kubeconfigFileText]: !isClusterReadOnly,
+              })}
+            >
+              Copy Token
+            </Box>
           </StyledLinkButton>
           <StyledLinkButton
             aria-label="Reset kubeconfig"
             className={classes.kubeconfigElement}
+            disabled={isClusterReadOnly}
             onClick={() => setResetKubeConfigDialogOpen(true)}
           >
             <ResetIcon
               className={cx({
-                [classes.disabled]: isResettingKubeConfig,
+                [classes.disabled]: isResettingKubeConfig || isClusterReadOnly,
                 [classes.kubeconfigIcons]: true,
               })}
             />
             <Typography
               className={cx({
-                [classes.disabled]: isResettingKubeConfig,
-                [classes.kubeconfigFileText]: true,
+                [classes.disabled]: isResettingKubeConfig || isClusterReadOnly,
+                [classes.kubeconfigFileText]: !isClusterReadOnly,
               })}
             >
               Reset

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeEntityDetailFooter.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeEntityDetailFooter.tsx
@@ -134,6 +134,14 @@ export const KubeEntityDetailFooter = React.memo((props: FooterProps) => {
               <StyledLinkButton
                 disabled={isClusterReadOnly}
                 onClick={() => setControlPlaneACLDrawerOpen(true)}
+                sx={(theme) => ({
+                  '&:disabled': {
+                    '& g': {
+                      stroke: theme.tokens.alias.Content.Icon.Primary.Disabled,
+                    },
+                    color: theme.tokens.alias.Content.Text.Primary.Disabled,
+                  },
+                })}
               >
                 {buttonCopyACL}
               </StyledLinkButton>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
@@ -181,7 +181,9 @@ export const KubeSummaryPanel = React.memo((props: Props) => {
                 {isLkeEnterpriseLAFeatureEnabled &&
                 cluster.tier === 'enterprise' ? undefined : (
                   <StyledActionButton
-                    disabled={Boolean(dashboardError) || !dashboard}
+                    disabled={
+                      Boolean(dashboardError) || !dashboard || isClusterReadOnly
+                    }
                     endIcon={<OpenInNewIcon sx={{ height: '14px' }} />}
                     onClick={() => window.open(dashboard?.url, '_blank')}
                   >

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
@@ -188,7 +188,10 @@ export const KubeSummaryPanel = React.memo((props: Props) => {
                     Kubernetes Dashboard
                   </StyledActionButton>
                 )}
-                <StyledActionButton onClick={() => setIsDeleteDialogOpen(true)}>
+                <StyledActionButton
+                  disabled={isClusterReadOnly}
+                  onClick={() => setIsDeleteDialogOpen(true)}
+                >
                   Delete Cluster
                 </StyledActionButton>
               </Hidden>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -61,17 +61,17 @@ export const KubernetesClusterDetail = () => {
     cluster
   );
 
-  const isLkeClusterRestricted = useIsResourceRestricted({
-    grantLevel: 'read_only',
-    grantType: 'lkecluster',
-    id: cluster?.id,
-  });
-
   const [updateError, setUpdateError] = React.useState<string | undefined>();
   const [isUpgradeToHAOpen, setIsUpgradeToHAOpen] = React.useState(false);
 
   const isClusterReadOnly = useIsResourceRestricted({
     grantLevel: 'read_only',
+    grantType: 'lkecluster',
+    id: cluster?.id,
+  });
+
+  const isClusterReadWrite = useIsResourceRestricted({
+    grantLevel: 'read_write',
     grantType: 'lkecluster',
     id: cluster?.id,
   });
@@ -113,12 +113,14 @@ export const KubernetesClusterDetail = () => {
       <DocumentTitleSegment
         segment={`${cluster?.label} | Kubernetes Cluster`}
       />
-      <UpgradeKubernetesVersionBanner
-        clusterID={cluster?.id}
-        clusterTier={cluster?.tier ?? 'standard'} // TODO LKE: remove fallback once LKE-E is in GA and tier is required
-        currentVersion={cluster?.k8s_version}
-      />
-      {isLkeClusterRestricted && restrictedLkeNotice}
+      {isClusterReadWrite && (
+        <UpgradeKubernetesVersionBanner
+          clusterID={cluster?.id}
+          clusterTier={cluster?.tier ?? 'standard'} // TODO LKE: remove fallback once LKE-E is in GA and tier is required
+          currentVersion={cluster?.k8s_version}
+        />
+      )}
+      {isClusterReadOnly && restrictedLkeNotice}
       <LandingHeader
         breadcrumbProps={{
           breadcrumbDataAttrs: { 'data-qa-breadcrumb': true },
@@ -162,7 +164,7 @@ export const KubernetesClusterDetail = () => {
             clusterLabel={cluster.label}
             clusterRegionId={cluster.region}
             clusterTier={cluster.tier ?? 'standard'}
-            isLkeClusterRestricted={isLkeClusterRestricted}
+            isLkeClusterRestricted={isClusterReadOnly}
             regionsData={regionsData || []}
           />
         </Stack>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -70,12 +70,6 @@ export const KubernetesClusterDetail = () => {
     id: cluster?.id,
   });
 
-  const isClusterReadWrite = useIsResourceRestricted({
-    grantLevel: 'read_write',
-    grantType: 'lkecluster',
-    id: cluster?.id,
-  });
-
   if (error) {
     return (
       <ErrorState
@@ -113,7 +107,7 @@ export const KubernetesClusterDetail = () => {
       <DocumentTitleSegment
         segment={`${cluster?.label} | Kubernetes Cluster`}
       />
-      {isClusterReadWrite && (
+      {!isClusterReadOnly && (
         <UpgradeKubernetesVersionBanner
           clusterID={cluster?.id}
           clusterTier={cluster?.tier ?? 'standard'} // TODO LKE: remove fallback once LKE-E is in GA and tier is required


### PR DESCRIPTION
## Description

This PR implements part of the read-only user restrictions for LKE/E clusters:

- **Kubeconfig** is now disabled (greyed out) for read-only users.
- **Kubernetes version upgrade** is now restricted for read-only users.

## Changes

- Disabled Kubeconfig for read-only users.
- Removed the Kubernetes upgrade option for read-only users.

## Target Release

N/A

## Preview

| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/9936a4a0-956c-4e3f-af85-262817c3ff41) | ![After](https://github.com/user-attachments/assets/f4e325dc-89f5-4210-a0de-fc6a9984a3b9) |
| ![Before](https://github.com/user-attachments/assets/c3b96710-fdb0-449d-ac9a-b2d9ababab45) | ![After](https://github.com/user-attachments/assets/44c708eb-f24e-4415-aac5-03cff2ee44d5) |

## How to Test

1. Assign a user read-only access via the **User Account Permissions** page.
2. Log in as that user.
3. Go to: `/kubernetes/clusters`
4. Verify:
   - Kubeconfig is greyed out.
   - Kubernetes version upgrade is not available.

<details>
<summary>Author Checklists</summary>

### As an Author, I considered:  
- [x] Self-review  
- [x] Contribution guidelines  
- [x] Small, focused PR  
- [x] Changeset added if needed  
- [x] Tests added or updated  
- [x] No sensitive info  
- [x] Feature flag if needed  
- [x] Reproduction steps  
- [x] Docs updated if needed  
- [x] Mobile and a11y support  

### Before moving from Draft to Open:  
- [x] All unit tests passing  
- [x] TypeScript compiles  
- [x] Linting passes  

</details>
