### PR TITLE
upcoming: [M3-10247] - Make `monitors` property optional on API SDK `Region` type

### DIFF
--- a/packages/api-v4/src/regions/types.ts
+++ b/packages/api-v4/src/regions/types.ts
@@ -46,7 +46,13 @@ export interface Region {
   country: Country;
   id: string;
   label: string;
-  monitors: MonitoringCapabilities;
+  /**
+   * CloudPulse monitoring capabilities that are available in the region.
+   *
+   * **Upcoming Feature Notice:** this property may not be available to all customers
+   * and may change in subsequent releases.
+   */
+  monitors?: MonitoringCapabilities;
   placement_group_limits: {
     maximum_linodes_per_pg: number;
     maximum_pgs_per_customer: null | number; // This value can be unlimited for some customers, for which the API returns the `null` value.

--- a/packages/utilities/src/factories/regions.ts
+++ b/packages/utilities/src/factories/regions.ts
@@ -24,7 +24,7 @@ export const regionFactory = Factory.Sync.makeFactory<Region>({
   resolvers: resolverFactory.build(),
   site_type: 'core',
   status: 'ok',
-  monitors: { alerts: [], metrics: [] },
+  monitors: undefined,
 });
 
 export const regionWithDynamicPricingFactory = Factory.Sync.makeFactory<Region>(

--- a/packages/utilities/src/factories/regions.ts
+++ b/packages/utilities/src/factories/regions.ts
@@ -24,7 +24,6 @@ export const regionFactory = Factory.Sync.makeFactory<Region>({
   resolvers: resolverFactory.build(),
   site_type: 'core',
   status: 'ok',
-  monitors: undefined,
 });
 
 export const regionWithDynamicPricingFactory = Factory.Sync.makeFactory<Region>(

--- a/packages/utilities/src/helpers/isAclpSupportedRegion.ts
+++ b/packages/utilities/src/helpers/isAclpSupportedRegion.ts
@@ -35,5 +35,5 @@ export const isAclpSupportedRegion = ({
 
   const region = regions.find((region) => region.id === regionId);
 
-  return region?.monitors?.[type].includes(capability) ?? false;
+  return region?.monitors?.[type]?.includes(capability) ?? false;
 };


### PR DESCRIPTION
## Description 📝

This makes the `monitors` property on the API SDK `Region` type optional while the corresponding API feature remains work-in-progress.

Since the `monitors` property hasn't been released yet, I'm not planning to add a changeset to this PR unless anyone prefers there be one.

## Changes  🔄

- Make `monitors` property optional on `Region` type in the API-v4 SDK
- Make `monitors` `undefined` by default in `regionFactory`
- Add documentation noting that the `monitors` property relates to an upcoming/unstable feature
- Update `isAclpSupportedRegion` util to account for cases when `monitors` is undefined

## Target release date 🗓️

July 1, 2025

## Preview 📷

![Screenshot 2025-06-25 at 11 01 12 AM](https://github.com/user-attachments/assets/704d712b-4825-4d42-a169-b066be5857d3)

## How to test 🧪

- Confirm unit tests and Cypress tests pass in CI
- Optionally run tests in `utilities` package
- Optionally run CloudPulse Cypress tests

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
