### PR TITLE
test: [M3-9634] - Add Cypress tests for Host Maintenance Policy account settings section

### DIFF
--- a/packages/manager/.changeset/pr-12433-tests-1750885668250.md
+++ b/packages/manager/.changeset/pr-12433-tests-1750885668250.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Add Host Maintenance Policy account settings Cypress tests ([#12433](https://github.com/linode/manager/pull/12433))

--- a/packages/manager/cypress/e2e/core/account/host-maintenance-policy.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/host-maintenance-policy.spec.ts
@@ -1,0 +1,155 @@
+/**
+ * Integration tests involving Host Maintenance Policy account settings.
+ */
+
+import {
+  mockGetAccountSettings,
+  mockUpdateAccountSettings,
+  mockUpdateAccountSettingsError,
+} from 'support/intercepts/account';
+import { mockAppendFeatureFlags } from 'support/intercepts/feature-flags';
+import { mockGetMaintenancePolicies } from 'support/intercepts/maintenance';
+import { ui } from 'support/ui';
+
+import { accountSettingsFactory } from 'src/factories';
+import { maintenancePolicyFactory } from 'src/factories/maintenancePolicy';
+
+describe('Host Maintenance Policy account settings', () => {
+  const mockMaintenancePolicies = [
+    maintenancePolicyFactory.build({
+      slug: 'linode/migrate',
+      label: 'Migrate',
+      type: 'linode_migrate',
+    }),
+    maintenancePolicyFactory.build({
+      slug: 'linode/power_off_on',
+      label: 'Power Off / Power On',
+      type: 'linode_power_off_on',
+    }),
+  ];
+
+  describe('When feature flag is enabled', () => {
+    beforeEach(() => {
+      mockAppendFeatureFlags({
+        vmHostMaintenance: {
+          enabled: true,
+        },
+      });
+      mockGetMaintenancePolicies(mockMaintenancePolicies);
+    });
+
+    /*
+     * - Confirms that the value of the "Maintenance Policy" drop-down matches the account setting on page load.
+     */
+    it('shows the expected maintenance policy in the drop-down', () => {
+      mockMaintenancePolicies.forEach((maintenancePolicy) => {
+        mockGetAccountSettings(
+          accountSettingsFactory.build({
+            maintenance_policy: maintenancePolicy.slug,
+          })
+        );
+
+        cy.visitWithLogin('/account/settings');
+        cy.findByText('Host Maintenance Policy')
+          .should('be.visible')
+          .closest('[data-qa-paper]')
+          .within(() => {
+            cy.findByLabelText('Maintenance Policy').should(
+              'have.value',
+              maintenancePolicy.label
+            );
+          });
+      });
+    });
+
+    /*
+     * - Confirms that the user can update their default maintenance policy.
+     * - Confirms that Cloud Manager displays API errors upon unsuccessful account settings update.
+     * - Confirms that Cloud Manager shows toast notification upon successful account settings update.
+     */
+    it('can update the default maintenance policy type', () => {
+      mockGetAccountSettings(
+        accountSettingsFactory.build({
+          maintenance_policy: 'linode/migrate',
+        })
+      );
+      mockUpdateAccountSettingsError('An unknown error occurred', 500).as(
+        'updateMaintenancePolicy'
+      );
+
+      cy.visitWithLogin('/account/settings');
+      cy.findByText('Host Maintenance Policy')
+        .should('be.visible')
+        .closest('[data-qa-paper]')
+        .within(() => {
+          ui.button
+            .findByTitle('Save Maintenance Policy')
+            .should('be.disabled');
+
+          // Change the maintenance policy selection from "Migrate" to "Power Off / Power On".
+          cy.findByLabelText('Maintenance Policy').clear();
+          ui.autocompletePopper.find().within(() => {
+            cy.contains('Power Off / Power On').should('be.visible').click();
+          });
+          cy.findByLabelText('Maintenance Policy').should(
+            'have.value',
+            'Power Off / Power On'
+          );
+
+          // Confirm that "Save Maintenance Policy" button becomes enabled and click it,
+          // then that Cloud Manager displays an error message if an API error occurs.
+          ui.button
+            .findByTitle('Save Maintenance Policy')
+            .should('be.enabled')
+            .click();
+          cy.wait('@updateMaintenancePolicy');
+          cy.findByText('An unknown error occurred').should('be.visible');
+
+          // Click the "Save Maintenance Policy" button again, this time confirm
+          // that Cloud responds as expected upon receiving a successful API response.
+          mockUpdateAccountSettings(
+            accountSettingsFactory.build({
+              maintenance_policy: 'linode/power_off_on',
+            })
+          ).as('updateMaintenancePolicy');
+
+          ui.button
+            .findByTitle('Save Maintenance Policy')
+            .should('be.enabled')
+            .click();
+          cy.wait('@updateMaintenancePolicy').then((xhr) => {
+            expect(xhr.request.body.maintenance_policy).to.equal(
+              'linode/power_off_on'
+            );
+          });
+        });
+
+      ui.toast.assertMessage('Host Maintenance Policy settings updated.');
+    });
+  });
+
+  // TODO M3-10046 - Delete feature flag negative tests when "vmHostMaintenance" feature flag is removed.
+  describe('When feature flag is disabled', () => {
+    /*
+     * - Confirms that the "Host Maintenance Policy" section is absent when `vmHostMaintenance` is disabled.
+     */
+    it('does not show Host Maintenance Policy section on settings page', () => {
+      mockAppendFeatureFlags({
+        vmHostMaintenance: {
+          enabled: false,
+        },
+      });
+
+      cy.visitWithLogin('/account/settings');
+
+      // Confirm that page contents has loaded by confirming that certain content
+      // is visible. We'll assert that the Linode Managed informational text is present.
+      cy.contains(
+        'Linode Managed includes Backups, Longview Pro, cPanel, and round-the-clock monitoring'
+      );
+
+      // Confirm that the "Host Maintenance Policy" section is absent.
+      cy.findByText('Host Maintenance Policy').should('not.exist');
+    });
+  });
+});

--- a/packages/manager/cypress/support/intercepts/maintenance.ts
+++ b/packages/manager/cypress/support/intercepts/maintenance.ts
@@ -1,0 +1,20 @@
+import { apiMatcher } from 'support/util/intercepts';
+import { paginateResponse } from 'support/util/paginate';
+
+import type { MaintenancePolicy } from '@linode/api-v4';
+
+/**
+ * Intercepts request to retrieve maintenance policies and mocks the response.
+ *
+ * @param policies - Maintenance policies with which to mock response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetMaintenancePolicies = (
+  policies: MaintenancePolicy[]
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    apiMatcher('maintenance/policies*'),
+    paginateResponse(policies)
+  );
+};


### PR DESCRIPTION
## Description 📝

This adds a few Cypress tests to cover changes made to the Account Settings as part of the Host & VM Maintenance project.

## Changes  🔄

- Add tests to cover Host & VM Maintenance account settings changes in `account/host-maintenance-policy.spec.ts`
- Add `mockGetMaintenancePolicies` mock util 

## Target release date 🗓️

N/A.

## How to test 🧪
You can run the tests interactively with `pnpm cy:debug`, or you can run the test via the CLI with:

```bash
pnpm cy:run -s "cypress/e2e/core/account/host-maintenance-policy.spec.ts"
```
