### PR TITLE
fix: [M3-10035] - Fix TOD payload generation when JUnit XML has certain UTF-8 characters

### DIFF
--- a/scripts/tod-payload/index.ts
+++ b/scripts/tod-payload/index.ts
@@ -6,6 +6,20 @@ import { program } from 'commander';
 import * as fs from 'fs/promises';
 import { resolve } from 'path';
 
+/**
+ * Encode a string to base64, accounting for UTF-8 characters.
+ */
+const b64EncodeUnicode = (str: string) => {
+  // Adapted from: https://stackoverflow.com/a/30106551
+  return btoa(
+      encodeURIComponent(str)
+        .replace(
+          /%([0-9A-F]{2})/g,
+          (_match, p1: string) => {
+          return String.fromCharCode(Number(`0x${p1}`));
+  }));
+}
+
 program
   .name('tod-payload')
   .description('Output TOD test result payload')
@@ -48,6 +62,7 @@ const main = async (junitPath: string) => {
     return fs.readFile(junitFile, 'utf8');
   }));
 
+
   const payload = JSON.stringify({
     team: program.opts()['appTeam'],
     name: program.opts()['appName'],
@@ -57,7 +72,7 @@ const main = async (junitPath: string) => {
     pass: !program.opts()['fail'],
     tag: !!program.opts()['tag'] ? program.opts()['tag'] : undefined,
     xunitResults: junitContents.map((junitContent) => {
-      return btoa(junitContent);
+      return b64EncodeUnicode(junitContent);
     }),
   });
 


### PR DESCRIPTION
## Description 📝

This fixes an issue when generating TOD payloads using JUnit XML files that have certain unicode characters.

## Changes  🔄

- Account for UTF-8 characters when encoding JUnit XML data

## Target release date 🗓️

N/A

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-06-25 at 5 19 15 PM](https://github.com/user-attachments/assets/01bf25b1-c366-4776-b6da-62cbaf7b440f) | ![Screenshot 2025-06-25 at 5 19 20 PM](https://github.com/user-attachments/assets/b5819e43-71e7-4d05-a7f0-8fe1a5916959) |

## How to test 🧪

### Prerequisites

- Ensure you have a JUnit XML file containing the "→" character in your `cypress/results` directory
  - (i) There is an XML file attached to the ticket that you can download and place in `packages/manager/cypress/results`

### Reproduction steps

On `develop`, run the following command:

```bash
pnpm generate-tod ./packages/manager/cypress/results
```

Observe the script fails with a `lazyDOMException` error

### Verification steps

On this branch, run the same command:

```
pnpm generate-tod ./packages/manager/cypress/results
```

Confirm that the script succeeds and outputs JSON containing the encoded JUnit XML contents. Copy/paste the base64-encoded data and decode it to confirm that it is not mangled.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
