### PR TITLE
upcoming: [DI-25888] - Added alert regions component to show list of regions

### DIFF
--- a/packages/manager/src/features/CloudPulse/Alerts/AlertRegions/AlertRegions.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertRegions/AlertRegions.test.tsx
@@ -1,0 +1,76 @@
+import { regionFactory } from '@linode/utilities';
+import { screen } from '@testing-library/react';
+import React from 'react';
+
+import { databaseFactory } from 'src/factories';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { AlertRegions } from './AlertRegions';
+
+import type { AlertServiceType } from '@linode/api-v4';
+import type { Flags } from 'src/featureFlags';
+
+const regions = regionFactory.buildList(6);
+const serviceType: AlertServiceType = 'dbaas';
+
+const flags: Partial<Flags> = {
+  aclpResourceTypeMap: [
+    {
+      serviceType,
+      supportedRegionIds: regions.map(({ id }) => id).join(','),
+      dimensionKey: 'region',
+    },
+  ],
+};
+
+const queryMocks = vi.hoisted(() => ({
+  useFlags: vi.fn(),
+  useRegionsQuery: vi.fn(),
+  useResourcesQuery: vi.fn(),
+}));
+
+vi.mock('@linode/queries', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useRegionsQuery: queryMocks.useRegionsQuery,
+}));
+
+vi.mock('src/queries/cloudpulse/resources', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useResourcesQuery: queryMocks.useResourcesQuery,
+}));
+
+vi.mock('src/hooks/useFlags', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useFlags: queryMocks.useFlags,
+}));
+
+queryMocks.useRegionsQuery.mockReturnValue({
+  data: regions,
+  isLoading: false,
+  isErrro: false,
+});
+
+queryMocks.useResourcesQuery.mockReturnValue({
+  data: databaseFactory.buildList(6, { region: regions[0].id }),
+  isLoading: false,
+  isError: false,
+});
+
+queryMocks.useFlags.mockReturnValue({
+  flags: {},
+});
+
+const component = (
+  <AlertRegions handleChange={vi.fn()} serviceType={serviceType} />
+);
+describe('Alert Regions', () => {
+  it('Should render the filters and notices ', () => {
+    renderWithTheme(component, { flags });
+
+    const regionSearch = screen.getByTestId('region-search');
+    const showSelectedOnly = screen.getByTestId('show-selected-only');
+
+    expect(regionSearch).toBeInTheDocument();
+    expect(showSelectedOnly).toBeInTheDocument();
+  });
+});

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertRegions/AlertRegions.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertRegions/AlertRegions.tsx
@@ -1,0 +1,153 @@
+import { useRegionsQuery } from '@linode/queries';
+import { Box, Checkbox, CircleProgress, Stack } from '@linode/ui';
+import { Typography } from '@linode/ui';
+import React from 'react';
+
+import { DebouncedSearchTextField } from 'src/components/DebouncedSearchTextField';
+import { useFlags } from 'src/hooks/useFlags';
+import { useResourcesQuery } from 'src/queries/cloudpulse/resources';
+
+import { type AlertFormMode } from '../constants';
+import { AlertListNoticeMessages } from '../Utils/AlertListNoticeMessages';
+import { getSupportedRegions } from '../Utils/utils';
+import { DisplayAlertRegions } from './DisplayAlertRegions';
+
+import type { AlertServiceType, Filter, Region } from '@linode/api-v4';
+
+interface AlertRegionsProps {
+  /**
+   * Error message to be displayed when there is an error.
+   */
+  errorText?: string;
+  /**
+   * Function to handle changes in the selected regions.
+   */
+  handleChange?: (regionIds: string[]) => void;
+  /**
+   * Flag to indicate if the component is in view-only mode.
+   */
+  mode?: AlertFormMode;
+  /**
+   * The service type for which the regions are being selected.
+   */
+  serviceType: AlertServiceType | null;
+  /**
+   * The selected regions.
+   */
+  value?: string[];
+}
+
+export const AlertRegions = React.memo((props: AlertRegionsProps) => {
+  const { serviceType, handleChange, value = [], errorText, mode } = props;
+  const { aclpResourceTypeMap } = useFlags();
+  const [searchText, setSearchText] = React.useState<string>('');
+  const { data: regions, isLoading: isRegionsLoading } = useRegionsQuery();
+
+  // Todo: State variable will be added when checkbox functionality implemented
+  const [, setSelectedRegions] = React.useState<string[]>(value);
+  const [showSelected, setShowSelected] = React.useState<boolean>(false);
+
+  const resourceFilterMap: Record<string, Filter> = {
+    dbaas: {
+      platform: 'rdbms-default',
+    },
+  };
+  const { data: resources, isLoading: isResourcesLoading } = useResourcesQuery(
+    Boolean(serviceType && regions?.length),
+    serviceType === null ? undefined : serviceType,
+    {},
+    {
+      ...(resourceFilterMap[serviceType ?? ''] ?? {}),
+    }
+  );
+
+  const handleSelectionChange = React.useCallback(
+    (regionId: string, isChecked: boolean) => {
+      if (isChecked) {
+        setSelectedRegions((prev) => {
+          const newValue = [...prev, regionId];
+          if (handleChange) {
+            handleChange(newValue);
+          }
+          return newValue;
+        });
+        return;
+      }
+
+      setSelectedRegions((prev) => {
+        const newValue = prev.filter((region) => region !== regionId);
+
+        if (handleChange) {
+          handleChange(newValue);
+        }
+        return newValue;
+      });
+    },
+    [handleChange]
+  );
+
+  const filteredRegionsWithStatus: Region[] = React.useMemo(
+    () =>
+      getSupportedRegions({
+        serviceType,
+        resources,
+        regions,
+        aclpResourceTypeMap,
+      }),
+    [aclpResourceTypeMap, regions, resources, serviceType]
+  );
+
+  if (isRegionsLoading || isResourcesLoading) {
+    return <CircleProgress />;
+  }
+  const filteredRegionsBySearchText = filteredRegionsWithStatus.filter(
+    ({ label }) => label.toLowerCase().includes(searchText.toLowerCase())
+  );
+
+  return (
+    <Stack gap={2}>
+      {mode === 'view' && <Typography variant="h2">Regions</Typography>}
+
+      <Box display="flex" gap={2}>
+        <DebouncedSearchTextField
+          data-testid="region-search"
+          fullWidth
+          hideLabel
+          label="Search for a Region"
+          onSearch={setSearchText}
+          placeholder="Search for a Region"
+          sx={{
+            width: '250px',
+          }}
+          value={searchText}
+        />
+        {mode !== 'view' && (
+          <Checkbox
+            data-testid="show-selected-only"
+            onChange={(_event, checked: boolean) => setShowSelected(checked)}
+            sx={(theme) => ({
+              svg: {
+                backgroundColor: theme.tokens.color.Neutrals.White,
+              },
+            })}
+            sxFormLabel={{
+              marginLeft: -1,
+            }}
+            text="Show Selected Only"
+            value="Show Selected"
+          />
+        )}
+      </Box>
+      {errorText && (
+        <AlertListNoticeMessages errorMessage={errorText} variant="error" />
+      )}
+
+      <DisplayAlertRegions
+        handleSelectionChange={handleSelectionChange}
+        mode={mode}
+        regions={filteredRegionsBySearchText}
+        showSelected={showSelected}
+      />
+    </Stack>
+  );
+});

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertRegions/DisplayAlertRegions.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertRegions/DisplayAlertRegions.test.tsx
@@ -1,0 +1,70 @@
+import { regionFactory } from '@linode/utilities';
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { DisplayAlertRegions } from './DisplayAlertRegions';
+
+const regions = regionFactory.buildList(10).map(({ id, label }) => ({
+  id,
+  label,
+  checked: false,
+  count: Math.random(),
+}));
+
+const handleChange = vi.fn();
+const handleSelectAll = vi.fn();
+
+describe('DisplayAlertRegions', () => {
+  it('should render the regions table', () => {
+    renderWithTheme(
+      <DisplayAlertRegions
+        handleSelectAll={handleSelectAll}
+        handleSelectionChange={handleChange}
+        regions={regions}
+      />
+    );
+
+    const table = screen.getByTestId('region-table');
+    expect(table).toBeInTheDocument();
+
+    const rows = screen.getAllByRole('row');
+    expect(rows.length).toBe(regions.length + 1); // +1 for header row
+  });
+
+  it('should display checkbox and label', () => {
+    renderWithTheme(
+      <DisplayAlertRegions
+        handleSelectAll={handleSelectAll}
+        handleSelectionChange={handleChange}
+        regions={regions}
+      />
+    );
+
+    const row = screen.getByTestId(`region-row-${regions[0].id}`);
+
+    const rowChildren = within(row);
+
+    expect(rowChildren.getByRole('checkbox')).toBeInTheDocument();
+    expect(
+      rowChildren.getByText(`${regions[0].label} (${regions[0].id})`)
+    ).toBeInTheDocument();
+  });
+
+  it('should select checkbox when clicked', async () => {
+    renderWithTheme(
+      <DisplayAlertRegions
+        handleSelectAll={handleSelectAll}
+        handleSelectionChange={handleChange}
+        regions={regions}
+      />
+    );
+    const row = screen.getByTestId(`region-row-${regions[0].id}`);
+    const checkbox = within(row).getByRole('checkbox');
+    await userEvent.click(checkbox);
+
+    expect(handleChange).toHaveBeenCalledWith(regions[0].id, true);
+  });
+});

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertRegions/DisplayAlertRegions.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertRegions/DisplayAlertRegions.tsx
@@ -1,0 +1,126 @@
+import { Box, Checkbox } from '@linode/ui';
+import { TableBody, TableHead } from '@mui/material';
+import React from 'react';
+
+import Paginate from 'src/components/Paginate';
+import { PaginationFooter } from 'src/components/PaginationFooter/PaginationFooter';
+import { Table } from 'src/components/Table';
+import { TableCell } from 'src/components/TableCell/TableCell';
+import { TableContentWrapper } from 'src/components/TableContentWrapper/TableContentWrapper';
+import { TableRow } from 'src/components/TableRow';
+import { TableSortCell } from 'src/components/TableSortCell';
+
+import type { AlertFormMode } from '../constants';
+import type { Region } from '@linode/api-v4';
+
+interface DisplayAlertRegionProps {
+  /**
+   * Function to handle the change in selection of a region.
+   */
+  handleSelectionChange: (regionId: string, isChecked: boolean) => void;
+
+  /**
+   * Flag to indicate the mode of the form
+   */
+  mode?: AlertFormMode;
+  /**
+   * List of regions to be displayed.
+   */
+  regions?: Region[];
+  /**
+   * To indicate whether to show only selected regions or not.
+   */
+  showSelected?: boolean;
+}
+
+export const DisplayAlertRegions = React.memo(
+  (props: DisplayAlertRegionProps) => {
+    const {
+      regions,
+      handleSelectionChange,
+
+      mode,
+    } = props;
+
+    return (
+      <Paginate data={regions ?? []}>
+        {({
+          count,
+          page,
+          pageSize,
+          handlePageChange,
+          handlePageSizeChange,
+          data: paginatedData,
+        }) => (
+          <Box>
+            <Table
+              colCount={2}
+              data-qa="region-tabls"
+              data-testid="region-table"
+              size="small"
+            >
+              <TableHead>
+                <TableRow>
+                  {mode !== 'view' && (
+                    <TableCell>
+                      <Box>
+                        <Checkbox
+                          data-testid="select-all-checkbox"
+                          onChange={(_, _checked) => {}}
+                        />
+                      </Box>
+                    </TableCell>
+                  )}
+                  <TableSortCell
+                    active={true}
+                    data-qa-header="Region"
+                    data-qa-sorting="Region"
+                    direction="asc"
+                    handleClick={() => {}}
+                    label="Region"
+                  >
+                    Region
+                  </TableSortCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                <TableContentWrapper
+                  length={regions?.length ?? 0}
+                  loading={false}
+                >
+                  {paginatedData.map(({ label, id }) => {
+                    return (
+                      <TableRow data-testid={`region-row-${id}`} key={id}>
+                        {mode !== 'view' && (
+                          <TableCell>
+                            <Checkbox
+                              onChange={(_, status) =>
+                                handleSelectionChange(id, status)
+                              }
+                            />
+                          </TableCell>
+                        )}
+
+                        <TableCell>
+                          {label} ({id})
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableContentWrapper>
+              </TableBody>
+            </Table>
+            <PaginationFooter
+              count={count}
+              eventCategory="Regions Table"
+              handlePageChange={handlePageChange}
+              handleSizeChange={handlePageSizeChange}
+              page={page}
+              pageSize={pageSize}
+            />
+          </Box>
+        )}
+      </Paginate>
+    );
+  }
+);

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Regions/CloudPulseModifyAlertRegions.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Regions/CloudPulseModifyAlertRegions.tsx
@@ -1,0 +1,59 @@
+import { Box, Typography } from '@linode/ui';
+import React from 'react';
+import {
+  Controller,
+  type FieldPathByValue,
+  useFormContext,
+  useWatch,
+} from 'react-hook-form';
+
+import { AlertRegions } from '../../AlertRegions/AlertRegions';
+import { getAlertBoxStyles } from '../../Utils/utils';
+
+import type { CreateAlertDefinitionForm } from '../types';
+
+interface CloudPulseModifyAlertRegionsProp {
+  name: FieldPathByValue<CreateAlertDefinitionForm, string[] | undefined>;
+}
+
+export const CloudPulseModifyAlertRegions = React.memo(
+  (props: CloudPulseModifyAlertRegionsProp) => {
+    const { name } = props;
+    const { control, setValue } = useFormContext<CreateAlertDefinitionForm>();
+    const serviceTypeWatcher = useWatch({ control, name: 'serviceType' });
+
+    const handleRegionsChange = (regionIds: string[]) => {
+      setValue(name, regionIds, {
+        shouldTouch: true,
+        shouldValidate: true,
+      });
+    };
+    const titleRef = React.useRef<HTMLDivElement>(null);
+    return (
+      <Controller
+        control={control}
+        name={name}
+        render={({ field, fieldState }) => (
+          <Box display="flex" flexDirection="column" gap={3} paddingTop={3}>
+            <Typography ref={titleRef} variant="h2">
+              2. Regions
+            </Typography>
+            <Box
+              sx={(theme) => ({
+                ...getAlertBoxStyles(theme),
+                overflow: 'auto',
+              })}
+            >
+              <AlertRegions
+                errorText={fieldState.error?.message}
+                handleChange={handleRegionsChange}
+                serviceType={serviceTypeWatcher}
+                value={field.value}
+              />
+            </Box>
+          </Box>
+        )}
+      />
+    );
+  }
+);

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Resources/CloudPulseModifyAlertResources.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Resources/CloudPulseModifyAlertResources.tsx
@@ -14,7 +14,7 @@ export interface CloudPulseModifyAlertResourcesProp {
   /**
    * Name used for the component in the form
    */
-  name: FieldPathByValue<CreateAlertDefinitionForm, string[]>;
+  name: FieldPathByValue<CreateAlertDefinitionForm, string[] | undefined>;
 }
 
 export const CloudPulseModifyAlertResources = React.memo(
@@ -61,7 +61,7 @@ export const CloudPulseModifyAlertResources = React.memo(
               })}
             >
               <AlertResources
-                alertResourceIds={field.value}
+                alertResourceIds={field.value ?? []}
                 alertType="user"
                 errorText={fieldState.error?.message}
                 handleResourcesSelection={handleResourcesSelection}

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/types.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/types.ts
@@ -17,7 +17,8 @@ export interface CreateAlertDefinitionForm
     CreateAlertDefinitionPayload,
     'rule_criteria' | 'severity' | 'trigger_conditions'
   > {
-  entity_ids: string[];
+  entity_ids?: string[];
+  regions?: string[];
   rule_criteria: {
     rules: MetricCriteriaForm[];
   };

--- a/packages/manager/src/features/CloudPulse/Alerts/Utils/utils.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/Utils/utils.ts
@@ -3,6 +3,7 @@ import { array, object, string } from 'yup';
 
 import { aggregationTypeMap, metricOperatorTypeMap } from '../constants';
 
+import type { CloudPulseResources } from '../../shared/CloudPulseResourcesSelect';
 import type { AlertDimensionsProp } from '../AlertsDetail/DisplayAlertDetailChips';
 import type { CreateAlertDefinitionForm } from '../CreateAlert/types';
 import type {
@@ -13,10 +14,14 @@ import type {
   APIError,
   EditAlertPayloadWithService,
   NotificationChannel,
+  Region,
   ServiceTypesList,
 } from '@linode/api-v4';
 import type { Theme } from '@mui/material';
-import type { AclpAlertServiceTypeConfig } from 'src/featureFlags';
+import type {
+  AclpAlertServiceTypeConfig,
+  CloudPulseResourceTypeMapFlag,
+} from 'src/featureFlags';
 import type { ObjectSchema } from 'yup';
 
 interface AlertChipBorderProps {
@@ -101,6 +106,25 @@ interface HandleMultipleErrorProps<T extends FieldValues> {
    * Separator for multiple errors on fields that are rendered by the component. Ex: errorText prop in Autocomplete, TextField component
    */
   singleLineErrorSeparator: string;
+}
+
+interface SupportedRegionsProps {
+  /**
+   * The resource type map flag
+   */
+  aclpResourceTypeMap?: CloudPulseResourceTypeMapFlag[];
+  /**
+   * The list of regions
+   */
+  regions?: Region[];
+  /**
+   * The list of resources
+   */
+  resources?: CloudPulseResources[];
+  /**
+   * The service type for which the regions are being filtered
+   */
+  serviceType: AlertServiceType | null;
 }
 
 /**
@@ -413,4 +437,36 @@ export const handleMultipleError = <T extends FieldValues>(
 
     setError(errorFieldToSet, { message: errorMap.get(errorFieldToSet) });
   }
+};
+
+/**
+ *
+ * @param props The props required to get the supported regions
+ * @returns The filtered regions based on the supported and resources
+ */
+export const getSupportedRegions = (props: SupportedRegionsProps) => {
+  const { aclpResourceTypeMap, serviceType, regions, resources } = props;
+  const resourceTypeFlag = aclpResourceTypeMap?.find(
+    (item: CloudPulseResourceTypeMapFlag) => item.serviceType === serviceType
+  );
+  let supportedRegions = regions;
+  if (
+    resourceTypeFlag?.supportedRegionIds !== null &&
+    resourceTypeFlag?.supportedRegionIds !== undefined
+  ) {
+    const supportedRegionsIdList = resourceTypeFlag.supportedRegionIds
+      .split(',')
+      .map((regionId: string) => regionId.trim());
+
+    supportedRegions =
+      supportedRegions?.filter(({ id }) =>
+        supportedRegionsIdList.includes(id)
+      ) ?? [];
+  }
+
+  return (
+    supportedRegions?.filter(({ id }) =>
+      resources?.some(({ region }) => region === id)
+    ) ?? []
+  );
 };

--- a/packages/validation/src/cloudpulse.schema.ts
+++ b/packages/validation/src/cloudpulse.schema.ts
@@ -77,6 +77,7 @@ export const createAlertDefinitionSchema = object({
     .min(1, 'At least one notification channel is required.'),
   tags: array().of(string().defined()).optional(),
   entity_ids: array().of(string().defined()).optional(),
+  regions: array().of(string().defined()).optional(),
   scope: string()
     .oneOf(['entity', 'region', 'account'])
     .defined()
@@ -125,4 +126,5 @@ export const editAlertDefinitionSchema = object({
     .oneOf(['enabled', 'disabled', 'in progress', 'failed'])
     .optional(),
   scope: string().oneOf(['entity', 'region', 'account']).required(),
+  regions: array().of(string().defined()).optional(),
 });


### PR DESCRIPTION
## Description 📝

A regions list table is added for create alert form

> [!NOTE]
Functionality of checkboxes and more columns and computation is not covered as part of this PR to reduce the line changes. Those will be covered in the next PR post this one is merged

## Changes  🔄

List any change(s) relevant to the reviewer.

1. CloudPulseModifyAlertRegions, AlertRegions and DisplayAlertRegions component is added to show list of regions
2. Added regions key for alert types
3. Added getSupportedRegions function is added in alerts utils.

## Target release date 🗓️

15th July

## Preview 📷

**Include a screenshot or screen recording of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
|![Screenshot 2025-06-26 at 5 01 35 PM](https://github.com/user-attachments/assets/1cea57d7-97af-41dc-a7ce-63954aae279e)|![Screenshot 2025-06-26 at 5 01 58 PM](https://github.com/user-attachments/assets/17b33710-0391-4a2f-84ea-7ad93f78ced0)|

## How to test 🧪
1. Switch as mock user
2. Go to alert tab from mega menu
3. Click on `Create Alert` button
4. Open CreateAlertDefinition.tsx file and comment line 214 and put below line.
`<CloudPulseModifyAlertRegions name="regions" />`

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>