### PR TITLE
fix: fixed incorrect filter for in progress maintenance

### DIFF
--- a/packages/manager/src/features/Account/Maintenance/utilities.ts
+++ b/packages/manager/src/features/Account/Maintenance/utilities.ts
@@ -5,7 +5,7 @@ export const COMPLETED_MAINTENANCE_FILTER = Object.freeze({
 });
 
 export const IN_PROGRESS_MAINTENANCE_FILTER = Object.freeze({
-  status: { '+or': ['in-progress', 'started'] },
+  status: { '+or': ['in_progress', 'started'] },
 });
 
 export const UPCOMING_MAINTENANCE_FILTER = Object.freeze({
@@ -17,7 +17,7 @@ export const PENDING_MAINTENANCE_FILTER = Object.freeze({
 });
 
 export const PENDING_AND_IN_PROGRESS_MAINTENANCE_FILTER = Object.freeze({
-  status: { '+or': ['pending', 'started', 'scheduled', 'in-progress'] },
+  status: { '+or': ['pending', 'started', 'scheduled', 'in_progress'] },
 });
 
 export const PLATFORM_MAINTENANCE_TYPE =


### PR DESCRIPTION
## Description 📝

Fixes the `in_progress` filter which currently incorrectly uses a hyphen instead of an underscore.

## Changes  🔄

List any change(s) relevant to the reviewer.

- in progress filter changed from `in-progress` to `in_progress` 

## Target release date 🗓️

06/30 or earlier

## Preview 📷

N/ A

## How to test 🧪

Loading locally with Maintenances populated, you can observe this filter does not currently work to filter in progress events. It will work with this change.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>