### PR TITLE
bug: [DI-25992] - Set scope to optional in cloudpulse schema

### DIFF
--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/GeneralInformation/AlertEntityScopeSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/GeneralInformation/AlertEntityScopeSelect.tsx
@@ -25,7 +25,7 @@ interface AlertEntityScopeSelectProps {
   formMode?: AlertFormMode;
   name: FieldPathByValue<
     CreateAlertDefinitionForm,
-    AlertDefinitionScope | null
+    AlertDefinitionScope | null | undefined
   >;
   serviceType: AlertServiceType | null;
 }
@@ -124,7 +124,7 @@ export const AlertEntityScopeSelect = (props: AlertEntityScopeSelectProps) => {
             textFieldProps={{
               labelTooltipText: ALERT_SCOPE_TOOLTIP_TEXT,
             }}
-            value={getSelectedOption(field.value, options)}
+            value={getSelectedOption(field?.value ?? null, options)}
           />
         );
       }}

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/types.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/types.ts
@@ -22,7 +22,7 @@ export interface CreateAlertDefinitionForm
   rule_criteria: {
     rules: MetricCriteriaForm[];
   };
-  scope: AlertDefinitionScope | null;
+  scope?: AlertDefinitionScope | null;
   serviceType: AlertServiceType | null;
   severity: AlertSeverityType | null;
   trigger_conditions: TriggerConditionForm;

--- a/packages/validation/src/cloudpulse.schema.ts
+++ b/packages/validation/src/cloudpulse.schema.ts
@@ -78,10 +78,7 @@ export const createAlertDefinitionSchema = object({
   tags: array().of(string().defined()).optional(),
   entity_ids: array().of(string().defined()).optional(),
   regions: array().of(string().defined()).optional(),
-  scope: string()
-    .oneOf(['entity', 'region', 'account', undefined])
-    .nullable()
-    .optional(),
+  scope: string().oneOf(['entity', 'region', 'account']).nullable().optional(),
 });
 
 export const editAlertDefinitionSchema = object({
@@ -125,9 +122,6 @@ export const editAlertDefinitionSchema = object({
   status: string()
     .oneOf(['enabled', 'disabled', 'in progress', 'failed'])
     .optional(),
-  scope: string()
-    .oneOf(['entity', 'region', 'account', undefined])
-    .nullable()
-    .optional(),
+  scope: string().oneOf(['entity', 'region', 'account']).nullable().optional(),
   regions: array().of(string().defined()).optional(),
 });


### PR DESCRIPTION
## Description 📝

Edit alert not submitting issue fixed 

## Changes  🔄

List any change(s) relevant to the reviewer.

1. Set scope to optional in cloudpulse.schema

## Target release date 🗓️

1st July

## Preview 📷

**Include a screenshot or screen recording of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
|<video src="https://github.com/user-attachments/assets/d65ea053-27e4-45c5-b4fb-8d3fe4509378"/>|<video src="https://github.com/user-attachments/assets/a0161971-87b1-4673-830b-41ffc3ba01e2"/>|

## How to test 🧪

1. Go to alert tab from mega menu
2. On alert list table select 3 dots of any alert row & select edit 
3. Click submit button. 
> [!NOTE]
in current alpha version it'll not submit but with this change it will submit

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>