### PR TITLE
test: [M3-10253] - Add integration test to confirm manually assigning a VPC IPv4 when assigning a Linode to subnet

### DIFF
--- a/packages/manager/cypress/support/intercepts/configs.ts
+++ b/packages/manager/cypress/support/intercepts/configs.ts
@@ -206,13 +206,14 @@ export const mockCreateLinodeConfigs = (
  *
  * @returns Cypress chainable.
  */
-export const mockCreateLinodeConfigInterfaces = (
+export const mockAppendConfigInterface = (
   linodeId: number,
-  config: Config
+  configId: number,
+  iface: Interface
 ): Cypress.Chainable<null> => {
   return cy.intercept(
     'POST',
-    apiMatcher(`linode/instances/${linodeId}/configs/${config.id}/interfaces`),
-    config.interfaces ?? undefined
+    apiMatcher(`linode/instances/${linodeId}/configs/${configId}/interfaces`),
+    iface
   );
 };

--- a/packages/manager/cypress/support/intercepts/linodes.ts
+++ b/packages/manager/cypress/support/intercepts/linodes.ts
@@ -103,6 +103,25 @@ export const interceptGetLinode = (
 };
 
 /**
+ * Intercepts GET request to get a Linode and mocks response
+ *
+ * @param linodeId - ID of Linode to fetch.
+ * @param linode - linode to return
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetLinode = (
+  linodeId: number,
+  linode: Linode
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'GET',
+    apiMatcher(`linode/instances/${linodeId}`),
+    makeResponse(linode)
+  );
+};
+
+/**
  * Intercepts GET request to get all Linodes.
  *
  * @returns Cypress chainable.


### PR DESCRIPTION
## Description 📝
- I'd removed a skipped/failing unit test in [M3-10245](https://github.com/linode/manager/pull/12429#discussion_r2172073293), so this PR adds an integration test to cover that flow as a follow up

## Changes  🔄
- Add integration test to confirm we can manually assign a VPC IPv4
- Add/touch up relevant mock intercepts

## Target release date 🗓️
n/a

## How to test 🧪
```
pnpm cy:run -s "cypress/e2e/core/vpc/vpc-linodes-update.spec.ts"
```
<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
