### PR TITLE
fix: [M3-10257] - Invalidate VLAN queries for newly created Linodes using a VLAN Interface

### DIFF
--- a/packages/queries/src/linodes/linodes.ts
+++ b/packages/queries/src/linodes/linodes.ts
@@ -342,7 +342,7 @@ export const useCreateLinodeMutation = () => {
 
       // If a restricted user creates an entity, we must make sure grants are up to date.
       queryClient.invalidateQueries(profileQueries.grants);
-      // @TODO Linode Interfaces - need to handle case if interface is not legacy
+
       if (getIsLegacyInterfaceArray(variables.interfaces)) {
         if (variables.interfaces?.some((i) => i.purpose === 'vlan')) {
           // If a Linode is created with a VLAN, invalidate vlans because
@@ -365,16 +365,26 @@ export const useCreateLinodeMutation = () => {
           });
         }
       } else {
-        // invalidate firewall queries if a new Linode interface is assigned to a firewall
-        if (variables.interfaces?.some((iface) => iface.firewall_id)) {
+        // Invalidate Firewall "list" queries if any interface has a Firewall
+        if (variables.interfaces?.some((i) => i.firewall_id)) {
           queryClient.invalidateQueries({
             queryKey: firewallQueries.firewalls.queryKey,
           });
         }
-        for (const iface of variables.interfaces ?? []) {
-          if (iface.firewall_id) {
+
+        // Invalidate VLAN queries if the Linode was created with a VLAN
+        if (variables.interfaces?.some((i) => i.vlan?.vlan_label)) {
+          queryClient.invalidateQueries({
+            queryKey: vlanQueries._def,
+          });
+        }
+
+        for (const linodeInterface of variables.interfaces ?? []) {
+          if (linodeInterface.firewall_id) {
+            // If the interface has a Firewall, invalidate that Firewall
             queryClient.invalidateQueries({
-              queryKey: firewallQueries.firewall(iface.firewall_id).queryKey,
+              queryKey: firewallQueries.firewall(linodeInterface.firewall_id)
+                .queryKey,
             });
           }
         }


### PR DESCRIPTION
## Description 📝

- Adds code to "invalidate" VLAN queries when a Linode is created with a VLAN (using Linode Interfaces)
- This fixes an issue where: You would create a Linode with a new VLAN, you go back to create another Linode in the same region, and that VLAN you created does not appear as expected

## Preview 📷

![Screenshot 2025-06-30 at 10 17 08 AM](https://github.com/user-attachments/assets/7c20f99c-5b8e-4de0-b24d-d38c17c0c917)

## How to test 🧪

### Prerequisites

- `new-interfaces-beta` internal customer tag

### Verification steps

- Checkout this PR or use a preview link
- Go to the Linode create page
- Create a Linode that uses Linode Interfaces with a new VLAN attached
- Go back to the Linode Create flow
- Start creating a Linode in the same region as the last one
- When you open the VLAN select, verify you see that VLAN you created last time without needing to refresh the page

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>