### PR TITLE
fix: Missing env defaults due to auth changes

### DIFF
--- a/packages/manager/src/OAuth/constants.ts
+++ b/packages/manager/src/OAuth/constants.ts
@@ -8,7 +8,7 @@ const DEFAULT_LOGIN_ROOT = 'https://login.linode.com';
  *
  * Specify a `REACT_APP_LOGIN_ROOT` in your environment to set this value.
  *
- * In local dev, a this URL may be pulled from localstorage to allow for environment switching.
+ * In local dev, this URL may be pulled from localstorage to allow for environment switching.
  *
  * @returns The Login server's root URL
  * @default https://login.linode.com

--- a/packages/manager/src/OAuth/constants.ts
+++ b/packages/manager/src/OAuth/constants.ts
@@ -1,0 +1,58 @@
+import { getEnvLocalStorageOverrides } from 'src/utilities/storage';
+
+const DEFAULT_APP_ROOT = 'http://localhost:3000';
+const DEFAULT_LOGIN_ROOT = 'https://login.linode.com';
+
+/**
+ * Use this as the source of truth for getting the login server's root URL.
+ *
+ * Specify a `REACT_APP_LOGIN_ROOT` in your environment to set this value.
+ *
+ * In local dev, a this URL may be pulled from localstorage to allow for environment switching.
+ *
+ * @returns The Login server's root URL
+ * @default https://login.linode.com
+ */
+export function getLoginURL() {
+  const localStorageOverrides = getEnvLocalStorageOverrides();
+
+  return (
+    localStorageOverrides?.loginRoot ??
+    import.meta.env.REACT_APP_LOGIN_ROOT ??
+    DEFAULT_LOGIN_ROOT
+  );
+}
+
+/**
+ * Use this as the source of truth for getting the app's client id.
+ *
+ * `REACT_APP_CLIENT_ID` is required for the app to function
+ *
+ * You can generate a client id by navigating to https://cloud.linode.com/profile/clients
+ *
+ * In local dev, a CLIENT_ID may be pulled from localstorage to allow for environment switching.
+ */
+export function getClientId() {
+  const localStorageOverrides = getEnvLocalStorageOverrides();
+
+  const clientId =
+    localStorageOverrides?.clientID ?? import.meta.env.REACT_APP_CLIENT_ID;
+
+  if (!clientId) {
+    throw new Error('No CLIENT_ID specified.');
+  }
+
+  return clientId;
+}
+
+/**
+ * Use this as the source of truth for getting the app's root URL.
+ *
+ * Specify a `REACT_APP_APP_ROOT` in your environment to set this value.
+ *
+ * @returns The apps root URL
+ * @default http://localhost:3000
+ */
+export function getAppRoot() {
+  return import.meta.env.REACT_APP_APP_ROOT ?? DEFAULT_APP_ROOT;
+}

--- a/packages/manager/src/OAuth/oauth.ts
+++ b/packages/manager/src/OAuth/oauth.ts
@@ -5,6 +5,7 @@ import {
 } from '@linode/utilities';
 import * as Sentry from '@sentry/react';
 
+import { DEFAULT_APP_ROOT, DEFAULT_LOGIN_ROOT } from 'src/constants';
 import {
   clearUserInput,
   getEnvLocalStorageOverrides,
@@ -56,11 +57,13 @@ export function clearStorageAndRedirectToLogout() {
   window.location.assign(loginUrl + '/logout');
 }
 
-function getLoginURL() {
+export function getLoginURL() {
   const localStorageOverrides = getEnvLocalStorageOverrides();
 
   return (
-    localStorageOverrides?.loginRoot ?? import.meta.env.REACT_APP_LOGIN_ROOT
+    localStorageOverrides?.loginRoot ??
+    import.meta.env.REACT_APP_LOGIN_ROOT ??
+    DEFAULT_LOGIN_ROOT
   );
 }
 
@@ -77,8 +80,8 @@ function getClientId() {
   return clientId;
 }
 
-function getAppRoot() {
-  return import.meta.env.REACT_APP_APP_ROOT;
+export function getAppRoot() {
+  return import.meta.env.REACT_APP_APP_ROOT ?? DEFAULT_APP_ROOT;
 }
 
 export function getIsAdminToken(token: string) {

--- a/packages/manager/src/OAuth/oauth.ts
+++ b/packages/manager/src/OAuth/oauth.ts
@@ -5,13 +5,9 @@ import {
 } from '@linode/utilities';
 import * as Sentry from '@sentry/react';
 
-import { DEFAULT_APP_ROOT, DEFAULT_LOGIN_ROOT } from 'src/constants';
-import {
-  clearUserInput,
-  getEnvLocalStorageOverrides,
-  storage,
-} from 'src/utilities/storage';
+import { clearUserInput, storage } from 'src/utilities/storage';
 
+import { getAppRoot, getClientId, getLoginURL } from './constants';
 import { generateCodeChallenge, generateCodeVerifier } from './pkce';
 import {
   LoginAsCustomerCallbackParamsSchema,
@@ -55,33 +51,6 @@ export function clearStorageAndRedirectToLogout() {
   clearAllAuthDataFromLocalStorage();
   const loginUrl = getLoginURL();
   window.location.assign(loginUrl + '/logout');
-}
-
-export function getLoginURL() {
-  const localStorageOverrides = getEnvLocalStorageOverrides();
-
-  return (
-    localStorageOverrides?.loginRoot ??
-    import.meta.env.REACT_APP_LOGIN_ROOT ??
-    DEFAULT_LOGIN_ROOT
-  );
-}
-
-function getClientId() {
-  const localStorageOverrides = getEnvLocalStorageOverrides();
-
-  const clientId =
-    localStorageOverrides?.clientID ?? import.meta.env.REACT_APP_CLIENT_ID;
-
-  if (!clientId) {
-    throw new Error('No CLIENT_ID specified.');
-  }
-
-  return clientId;
-}
-
-export function getAppRoot() {
-  return import.meta.env.REACT_APP_APP_ROOT ?? DEFAULT_APP_ROOT;
 }
 
 export function getIsAdminToken(token: string) {

--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -1,8 +1,7 @@
-// whether or not this is a Vite production build
-// This does not necessarily mean Cloud is running in a production environment.
-
 import { getBooleanEnv } from '@linode/utilities';
 
+// Whether or not this is a Vite production build
+// This does not necessarily mean Cloud is running in a production environment.
 // For example, cloud.dev.linode.com is technically a production build.
 export const isProductionBuild = import.meta.env.PROD;
 
@@ -25,16 +24,7 @@ export const ENABLE_MAINTENANCE_MODE =
  */
 export const FORCE_SEARCH_TYPE = import.meta.env.REACT_APP_FORCE_SEARCH_TYPE;
 
-export const DEFAULT_APP_ROOT = 'http://localhost:3000';
-export const DEFAULT_LOGIN_ROOT = 'https://login.linode.com';
 export const DEFAULT_API_ROOT = 'https://api.linode.com/v4';
-
-/**
- * `REACT_APP_CLIENT_ID` is required for the app to function
- *
- * You can generate a client id by navigating to https://cloud.linode.com/profile/clients
- */
-export const CLIENT_ID = import.meta.env.REACT_APP_CLIENT_ID;
 
 /** All of the following used specifically for Algolia search */
 export const DOCS_BASE_URL = 'https://linode.com';

--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -25,16 +25,17 @@ export const ENABLE_MAINTENANCE_MODE =
  */
 export const FORCE_SEARCH_TYPE = import.meta.env.REACT_APP_FORCE_SEARCH_TYPE;
 
-/** required for the app to function */
-export const APP_ROOT =
-  import.meta.env.REACT_APP_APP_ROOT || 'http://localhost:3000';
-export const LOGIN_ROOT =
-  import.meta.env.REACT_APP_LOGIN_ROOT || 'https://login.linode.com';
-export const API_ROOT =
-  import.meta.env.REACT_APP_API_ROOT || 'https://api.linode.com/v4';
-export const BETA_API_ROOT = API_ROOT + 'beta';
-/** generate a client_id by navigating to https://cloud.linode.com/profile/clients */
+export const DEFAULT_APP_ROOT = 'http://localhost:3000';
+export const DEFAULT_LOGIN_ROOT = 'https://login.linode.com';
+export const DEFAULT_API_ROOT = 'https://api.linode.com/v4';
+
+/**
+ * `REACT_APP_CLIENT_ID` is required for the app to function
+ *
+ * You can generate a client id by navigating to https://cloud.linode.com/profile/clients
+ */
 export const CLIENT_ID = import.meta.env.REACT_APP_CLIENT_ID;
+
 /** All of the following used specifically for Algolia search */
 export const DOCS_BASE_URL = 'https://linode.com';
 export const COMMUNITY_BASE_URL = 'https://linode.com/community/';

--- a/packages/manager/src/features/Linodes/LinodeCreate/Tabs/Marketplace/AppSelectionCard.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Tabs/Marketplace/AppSelectionCard.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 
 import Info from 'src/assets/icons/info.svg';
 import { SelectionCard } from 'src/components/SelectionCard/SelectionCard';
-import { getAppRoot } from 'src/OAuth/oauth';
 
 import { getMarketplaceAppLabel } from './utilities';
 
@@ -15,7 +14,7 @@ interface Props {
   checked: boolean;
   /**
    * The path to the app icon
-   * @example "assets/postgresqlmarketplaceocc.svg"
+   * @example "/assets/postgresqlmarketplaceocc.svg"
    */
   iconUrl: string;
   /**
@@ -54,7 +53,7 @@ export const AppSelectionCard = (props: Props) => {
   const renderIcon =
     iconUrl === ''
       ? () => <span className="fl-tux" />
-      : () => <img alt={`${label} logo`} src={`${getAppRoot()}${iconUrl}`} />;
+      : () => <img alt={`${label} logo`} src={iconUrl} />;
 
   const renderVariant = () => (
     <IconButton

--- a/packages/manager/src/features/Linodes/LinodeCreate/Tabs/Marketplace/AppSelectionCard.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Tabs/Marketplace/AppSelectionCard.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 
 import Info from 'src/assets/icons/info.svg';
 import { SelectionCard } from 'src/components/SelectionCard/SelectionCard';
-import { APP_ROOT } from 'src/constants';
+import { getAppRoot } from 'src/OAuth/oauth';
 
 import { getMarketplaceAppLabel } from './utilities';
 
@@ -54,7 +54,7 @@ export const AppSelectionCard = (props: Props) => {
   const renderIcon =
     iconUrl === ''
       ? () => <span className="fl-tux" />
-      : () => <img alt={`${label} logo`} src={`${APP_ROOT}${iconUrl}`} />;
+      : () => <img alt={`${label} logo`} src={`${getAppRoot()}${iconUrl}`} />;
 
   const renderVariant = () => (
     <IconButton

--- a/packages/manager/src/features/Profile/AuthenticationSettings/ResetPassword.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/ResetPassword.tsx
@@ -3,7 +3,7 @@ import { styled, useTheme } from '@mui/material/styles';
 import * as React from 'react';
 
 import { Link } from 'src/components/Link';
-import { getLoginURL } from 'src/OAuth/oauth';
+import { getLoginURL } from 'src/OAuth/constants';
 
 interface Props {
   username?: string;

--- a/packages/manager/src/features/Profile/AuthenticationSettings/ResetPassword.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/ResetPassword.tsx
@@ -3,7 +3,7 @@ import { styled, useTheme } from '@mui/material/styles';
 import * as React from 'react';
 
 import { Link } from 'src/components/Link';
-import { LOGIN_ROOT } from 'src/constants';
+import { getLoginURL } from 'src/OAuth/oauth';
 
 interface Props {
   username?: string;
@@ -20,7 +20,7 @@ export const ResetPassword = (props: Props) => {
         If you’ve forgotten your password or would like to change it, we’ll send
         you an e-mail with instructions.
       </StyledCopy>
-      <StyledLink to={`${LOGIN_ROOT}/forgot/password?username=${username}`}>
+      <StyledLink to={`${getLoginURL()}/forgot/password?username=${username}`}>
         Reset Password
       </StyledLink>
     </Box>

--- a/packages/manager/src/features/Profile/AuthenticationSettings/TPADialog.test.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/TPADialog.test.tsx
@@ -2,7 +2,7 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
-import { getLoginURL } from 'src/OAuth/oauth';
+import { getLoginURL } from 'src/OAuth/constants';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { TPADialog } from './TPADialog';

--- a/packages/manager/src/features/Profile/AuthenticationSettings/TPADialog.test.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/TPADialog.test.tsx
@@ -2,7 +2,7 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
-import { LOGIN_ROOT } from 'src/constants';
+import { getLoginURL } from 'src/OAuth/oauth';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { TPADialog } from './TPADialog';
@@ -84,7 +84,7 @@ describe('TPADialog', () => {
     expect(props.onClose).toBeCalled();
   });
   it('Should redirect to disable TPA', async () => {
-    const expectedUrl = `${LOGIN_ROOT}/tpa/disable`;
+    const expectedUrl = `${getLoginURL()}/tpa/disable`;
     const mockWindow = vi.spyOn(window, 'open').mockReturnValue(null);
     renderWithTheme(<TPADialog {...props} />);
 
@@ -109,7 +109,7 @@ describe('TPADialog', () => {
       },
       newProvider: 'google',
     };
-    const expectedUrl = `${LOGIN_ROOT}/tpa/enable/google`;
+    const expectedUrl = `${getLoginURL()}/tpa/enable/google`;
     const mockWindow = vi.spyOn(window, 'open').mockReturnValue(null);
     renderWithTheme(<TPADialog {...newProps} />);
 
@@ -134,7 +134,7 @@ describe('TPADialog', () => {
       },
       newProvider: 'github',
     };
-    const expectedUrl = `${LOGIN_ROOT}/tpa/enable/github`;
+    const expectedUrl = `${getLoginURL()}/tpa/enable/github`;
     const mockWindow = vi.spyOn(window, 'open').mockReturnValue(null);
     renderWithTheme(<TPADialog {...newProps} />);
 

--- a/packages/manager/src/features/Profile/AuthenticationSettings/TPADialog.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/TPADialog.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 
 import { ConfirmationDialog } from 'src/components/ConfirmationDialog/ConfirmationDialog';
 import { useFlags } from 'src/hooks/useFlags';
-import { getLoginURL } from 'src/OAuth/oauth';
+import { getLoginURL } from 'src/OAuth/constants';
 
 import type { TPAProvider } from '@linode/api-v4/lib/profile';
 import type { Provider } from 'src/featureFlags';

--- a/packages/manager/src/features/Profile/AuthenticationSettings/TPADialog.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/TPADialog.tsx
@@ -3,11 +3,12 @@ import { styled } from '@mui/material/styles';
 import * as React from 'react';
 
 import { ConfirmationDialog } from 'src/components/ConfirmationDialog/ConfirmationDialog';
-import { LOGIN_ROOT } from 'src/constants';
 import { useFlags } from 'src/hooks/useFlags';
+import { getLoginURL } from 'src/OAuth/oauth';
 
 import type { TPAProvider } from '@linode/api-v4/lib/profile';
 import type { Provider } from 'src/featureFlags';
+
 export interface TPADialogProps {
   currentProvider: Provider;
   newProvider: TPAProvider;
@@ -46,9 +47,13 @@ const handleLoginChange = (provider: TPAProvider) => {
   // If the selected provider is 'password', that means the user has decided
   // to disable TPA and revert to using Linode credentials
   return provider === 'password'
-    ? window.open(`${LOGIN_ROOT}/tpa/disable`, '_blank', 'noopener noreferrer')
+    ? window.open(
+        `${getLoginURL()}/tpa/disable`,
+        '_blank',
+        'noopener noreferrer'
+      )
     : window.open(
-        `${LOGIN_ROOT}/tpa/enable/` + `${provider}`,
+        `${getLoginURL()}/tpa/enable/` + `${provider}`,
         '_blank',
         'noopener noreferrer'
       );

--- a/packages/manager/src/hooks/usePendo.ts
+++ b/packages/manager/src/hooks/usePendo.ts
@@ -4,7 +4,7 @@ import React from 'react';
 
 import { ADOBE_ANALYTICS_URL, PENDO_API_KEY } from 'src/constants';
 import { reportException } from 'src/exceptionReporting';
-import { getAppRoot } from 'src/OAuth/oauth';
+import { getAppRoot } from 'src/OAuth/constants';
 
 declare global {
   interface Window {

--- a/packages/manager/src/hooks/usePendo.ts
+++ b/packages/manager/src/hooks/usePendo.ts
@@ -2,8 +2,9 @@ import { useAccount, useProfile } from '@linode/queries';
 import { loadScript } from '@linode/utilities'; // `loadScript` from `useScript` hook
 import React from 'react';
 
-import { ADOBE_ANALYTICS_URL, APP_ROOT, PENDO_API_KEY } from 'src/constants';
+import { ADOBE_ANALYTICS_URL, PENDO_API_KEY } from 'src/constants';
 import { reportException } from 'src/exceptionReporting';
+import { getAppRoot } from 'src/OAuth/oauth';
 
 declare global {
   interface Window {
@@ -17,9 +18,11 @@ declare global {
  * @returns Unique ID for the environment; else, undefined if missing values.
  */
 const getUniquePendoId = (id: string | undefined) => {
-  const isProdEnv = APP_ROOT === 'https://cloud.linode.com';
+  const appRoot = getAppRoot();
 
-  if (!id || !APP_ROOT) {
+  const isProdEnv = appRoot === 'https://cloud.linode.com';
+
+  if (!id || !appRoot) {
     return;
   }
 

--- a/packages/manager/src/initSentry.ts
+++ b/packages/manager/src/initSentry.ts
@@ -4,7 +4,7 @@ import { init } from '@sentry/react';
 import { SENTRY_URL } from 'src/constants';
 
 import packageJson from '../package.json';
-import { getAppRoot } from './OAuth/oauth';
+import { getAppRoot } from './OAuth/constants';
 
 import type { APIError } from '@linode/api-v4';
 import type { ErrorEvent as SentryErrorEvent } from '@sentry/react';

--- a/packages/manager/src/initSentry.ts
+++ b/packages/manager/src/initSentry.ts
@@ -1,9 +1,10 @@
 import { deepStringTransform, redactAccessToken } from '@linode/utilities';
 import { init } from '@sentry/react';
 
-import { APP_ROOT, SENTRY_URL } from 'src/constants';
+import { SENTRY_URL } from 'src/constants';
 
 import packageJson from '../package.json';
+import { getAppRoot } from './OAuth/oauth';
 
 import type { APIError } from '@linode/api-v4';
 import type { ErrorEvent as SentryErrorEvent } from '@sentry/react';
@@ -218,13 +219,14 @@ const customFingerPrintMap = {
  * so a Sentry issue is identified by the correct environment name.
  */
 const getSentryEnvironment = () => {
-  if (APP_ROOT === 'https://cloud.linode.com') {
+  const appRoot = getAppRoot();
+  if (appRoot === 'https://cloud.linode.com') {
     return 'production';
   }
-  if (APP_ROOT.includes('staging')) {
+  if (appRoot.includes('staging')) {
     return 'staging';
   }
-  if (APP_ROOT.includes('dev')) {
+  if (appRoot.includes('dev')) {
     return 'dev';
   }
   return 'local';

--- a/packages/manager/src/request.tsx
+++ b/packages/manager/src/request.tsx
@@ -1,7 +1,11 @@
 import { baseRequest } from '@linode/api-v4/lib/request';
 import { AxiosHeaders } from 'axios';
 
-import { ACCESS_TOKEN, API_ROOT, DEFAULT_ERROR_MESSAGE } from 'src/constants';
+import {
+  ACCESS_TOKEN,
+  DEFAULT_API_ROOT,
+  DEFAULT_ERROR_MESSAGE,
+} from 'src/constants';
 import { setErrors } from 'src/store/globalErrors/globalErrors.actions';
 
 import { clearAuthDataFromLocalStorage, redirectToLogin } from './OAuth/oauth';
@@ -85,7 +89,7 @@ export const getURL = ({ baseURL, url }: AxiosRequestConfig) => {
 
   const localStorageOverrides = getEnvLocalStorageOverrides();
 
-  const apiRoot = localStorageOverrides?.apiRoot ?? API_ROOT;
+  const apiRoot = localStorageOverrides?.apiRoot ?? DEFAULT_API_ROOT;
 
   // If we have environment overrides in local storage, use those. Otherwise,
   // override the baseURL (from @linode/api-v4) with the one we have defined


### PR DESCRIPTION
## Description 📝

- Changes from https://github.com/linode/manager/pull/12405 made it so that there was no fallback if `REACT_APP_APP_ROOT` was not defined in the environment. This broke local dev for some people because the expectation is that the default app root should be `http://localhost:3000` if  `REACT_APP_APP_ROOT` is not defined 

## How to test 🧪

- Remove `REACT_APP_APP_ROOT` from your `.env`
- Clear local storage
- Verify you can still authenticate when visiting http://localhost:3000 even if there is no `REACT_APP_APP_ROOT` in your env

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>