### PR TITLE
fix: [M3-10270] - Extra background on code block copy icon

### DIFF
--- a/packages/manager/.changeset/pr-12456-fixed-1751400242708.md
+++ b/packages/manager/.changeset/pr-12456-fixed-1751400242708.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Extra background on code block copy icon ([#12456](https://github.com/linode/manager/pull/12456))

--- a/packages/manager/src/components/CodeBlock/CodeBlock.styles.ts
+++ b/packages/manager/src/components/CodeBlock/CodeBlock.styles.ts
@@ -15,7 +15,6 @@ export const useCodeBlockStyles = makeStyles()((theme) => ({
     right: 0,
     paddingRight: `${theme.spacing(1)}`,
     top: `${theme.spacing(1)}`,
-    backgroundColor: theme.tokens.alias.Background.Neutral,
   },
   lineNumbers: {
     code: {


### PR DESCRIPTION
## Description 📝

- The copy icon on our code blocks have an extra background
- This PR fixes the extra background by removing the extra style

## Preview 📷

### Light Mode

It's harder to tell in light mode

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-07-01 at 3 47 09 PM](https://github.com/user-attachments/assets/8690dbf8-8906-4284-ba92-5e16c31f39e8) | ![Screenshot 2025-07-01 at 4 00 36 PM](https://github.com/user-attachments/assets/0c196b21-3226-4a6a-88f3-23c0dd3e4683) |

### Dark Mode

The issue is more obvious in dark mode

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-07-01 at 3 47 00 PM](https://github.com/user-attachments/assets/d9759f2f-212e-43f3-abd8-28d6d047420c) | ![Screenshot 2025-07-01 at 4 00 49 PM](https://github.com/user-attachments/assets/9943bde7-9736-4c90-8024-58509e3c3b05) |


## How to test 🧪

- Find a code snippet in Cloud Manager (I went to a StackScript's details page to see one)
- Look at the copy icon and verify there is no extra background 📋 

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>