### PR TITLE
fix: Cloud Manager not respecting `REACT_APP_API_ROOT`

### DIFF
--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -24,7 +24,8 @@ export const ENABLE_MAINTENANCE_MODE =
  */
 export const FORCE_SEARCH_TYPE = import.meta.env.REACT_APP_FORCE_SEARCH_TYPE;
 
-export const DEFAULT_API_ROOT = 'https://api.linode.com/v4';
+export const API_ROOT =
+  import.meta.env.REACT_APP_API_ROOT || 'https://api.linode.com/v4';
 
 /** All of the following used specifically for Algolia search */
 export const DOCS_BASE_URL = 'https://linode.com';

--- a/packages/manager/src/request.tsx
+++ b/packages/manager/src/request.tsx
@@ -1,11 +1,7 @@
 import { baseRequest } from '@linode/api-v4/lib/request';
 import { AxiosHeaders } from 'axios';
 
-import {
-  ACCESS_TOKEN,
-  DEFAULT_API_ROOT,
-  DEFAULT_ERROR_MESSAGE,
-} from 'src/constants';
+import { ACCESS_TOKEN, API_ROOT, DEFAULT_ERROR_MESSAGE } from 'src/constants';
 import { setErrors } from 'src/store/globalErrors/globalErrors.actions';
 
 import { clearAuthDataFromLocalStorage, redirectToLogin } from './OAuth/oauth';
@@ -89,7 +85,7 @@ export const getURL = ({ baseURL, url }: AxiosRequestConfig) => {
 
   const localStorageOverrides = getEnvLocalStorageOverrides();
 
-  const apiRoot = localStorageOverrides?.apiRoot ?? DEFAULT_API_ROOT;
+  const apiRoot = localStorageOverrides?.apiRoot ?? API_ROOT;
 
   // If we have environment overrides in local storage, use those. Otherwise,
   // override the baseURL (from @linode/api-v4) with the one we have defined


### PR DESCRIPTION
## Description 📝

- Hopefully the last fix related to env vars 🤦 
- In https://github.com/linode/manager/pull/12453, I forgot to make Cloud Manager account for the `REACT_APP_API_ROOT` environment variable, which is why dev is broken right now