### PR TITLE
feat: [UIE-8941] - DBaaS - Implementing premium plans tab

### DIFF
--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -45,6 +45,7 @@ const options: { flag: keyof Flags; label: string }[] = [
   { flag: 'databaseResize', label: 'Database Resize' },
   { flag: 'databaseAdvancedConfig', label: 'Database Advanced Config' },
   { flag: 'databaseVpc', label: 'Database VPC' },
+  { flag: 'databasePremium', label: 'Database Premium' },
   { flag: 'apicliButtonCopy', label: 'APICLI Button Copy' },
   { flag: 'iam', label: 'Identity and Access Beta' },
   {

--- a/packages/manager/src/factories/databases.ts
+++ b/packages/manager/src/factories/databases.ts
@@ -238,11 +238,7 @@ export const databaseFactory = Factory.Sync.makeFactory<Database>({
   },
   oldest_restore_time: '2024-09-15T17:15:12',
   platform: Factory.each((i) => (adb10(i) ? 'rdbms-legacy' : 'rdbms-default')),
-  private_network: {
-    public_access: false,
-    subnet_id: 1,
-    vpc_id: 123,
-  },
+  private_network: null,
   port: 3306,
   region: 'us-east',
   ssl_connection: false,

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -128,6 +128,7 @@ export interface Flags {
   cloudNat: CloudNatFlag;
   databaseAdvancedConfig: boolean;
   databaseBeta: boolean;
+  databasePremium: boolean;
   databaseResize: boolean;
   databases: boolean;
   databaseVpc: boolean;

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -254,6 +254,9 @@ export const DatabaseCreate = () => {
   };
 
   const handleTabChange = (index: number) => {
+    if (selectedTab === index) {
+      return;
+    }
     setSelectedTab(index);
     setFieldValue('type', undefined);
     setFieldValue('cluster_size', 3);
@@ -285,6 +288,14 @@ export const DatabaseCreate = () => {
       });
     } else {
       resetForm();
+    }
+  };
+
+  const handleClearPlanSelection = () => {
+    if (flags.databasePremium) {
+      handleResetForm({
+        type: undefined,
+      });
     }
   };
 
@@ -341,6 +352,7 @@ export const DatabaseCreate = () => {
               handleTabChange={handleTabChange}
               header="Choose a Plan"
               isCreate
+              onPlanSelectionInvalidated={handleClearPlanSelection}
               onSelect={(selected: string) => {
                 setFieldValue('type', selected);
               }}

--- a/packages/manager/src/features/components/PlansPanel/PlansPanel.test.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlansPanel.test.tsx
@@ -1,3 +1,4 @@
+import { regionFactory } from '@linode/utilities';
 import * as React from 'react';
 
 import { planSelectionTypeFactory } from 'src/factories';
@@ -7,8 +8,29 @@ import { PlansPanel } from './PlansPanel';
 
 import type { PlansPanelProps } from './PlansPanel';
 
+const mockRegionsData = [
+  regionFactory.build({
+    id: 'us-east',
+    label: 'Newark, NJ',
+    capabilities: ['Linodes', 'Premium Plans'],
+  }),
+  regionFactory.build({
+    id: 'us-central',
+    label: 'Dallas, TX',
+    capabilities: ['Linodes', 'Premium Plans'],
+  }),
+  regionFactory.build({
+    id: 'us-southeast',
+    label: 'Atlanta, GA',
+    capabilities: ['Linodes'],
+  }),
+];
+
+const mockPremiumPlanId = 'premium-32';
+
 const defaultProps: PlansPanelProps = {
   onSelect: vi.fn(),
+  regionsData: mockRegionsData,
   selectedRegionID: 'us-east',
   types: [
     {
@@ -31,11 +53,42 @@ const defaultProps: PlansPanelProps = {
     {
       ...planSelectionTypeFactory.build(),
       class: 'premium',
+      id: mockPremiumPlanId,
     },
   ],
 };
 
+const mockRegionAvailabilities = [
+  {
+    region: 'us-central',
+    plan: mockPremiumPlanId,
+    available: false,
+  },
+];
+
+const defaultFlags = { soldOutChips: true };
+
+// Hoist query mocks
+const queryMocks = vi.hoisted(() => ({
+  useRegionAvailabilityQuery: vi.fn().mockReturnValue({ data: [] }),
+}));
+
+vi.mock('@linode/queries', async () => {
+  const actual = await vi.importActual('@linode/queries');
+  return {
+    ...actual,
+    useRegionAvailabilityQuery: queryMocks.useRegionAvailabilityQuery,
+  };
+});
+
 describe('plans panel', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    queryMocks.useRegionAvailabilityQuery.mockReturnValue({
+      data: mockRegionAvailabilities,
+    });
+  });
+
   it('should render a tabbed panel based on plan selection types types', () => {
     const { getByRole, getByText } = renderWithTheme(
       <PlansPanel {...defaultProps} />
@@ -46,5 +99,66 @@ describe('plans panel', () => {
     expect(getByRole('tab', { name: /shared cpu/i })).toBeInTheDocument();
     expect(getByRole('tab', { name: /gpu/i })).toBeInTheDocument();
     expect(getByRole('tab', { name: /premium cpu/i })).toBeInTheDocument();
+  });
+
+  it('should call onPlanSelectionInvalidated when the selected plan is has limited availability for the region', () => {
+    queryMocks.useRegionAvailabilityQuery.mockReturnValue({
+      data: mockRegionAvailabilities,
+    });
+    const onPlanSelectionInvalidated = vi.fn();
+    // Render Plans Panel with a premium plan selected for a region that has limited availability for that plan
+    const propsWithPremiumPlanSelected = {
+      ...defaultProps,
+      selectedId: mockPremiumPlanId,
+    };
+    renderWithTheme(
+      <PlansPanel
+        {...propsWithPremiumPlanSelected}
+        onPlanSelectionInvalidated={onPlanSelectionInvalidated}
+        selectedRegionID="us-central"
+      />,
+      { flags: defaultFlags }
+    );
+
+    expect(onPlanSelectionInvalidated).toHaveBeenCalled();
+  });
+
+  it('should call onPlanSelectionInvalidated when the panel for that plan is disabled for the region', () => {
+    const onPlanSelectionInvalidated = vi.fn();
+    // Render Plans Panel with the premium plans panel disabled for the selected region
+    const propsWithPremiumPlanSelected = {
+      ...defaultProps,
+      selectedId: mockPremiumPlanId,
+    };
+    renderWithTheme(
+      <PlansPanel
+        {...propsWithPremiumPlanSelected}
+        onPlanSelectionInvalidated={onPlanSelectionInvalidated}
+        selectedRegionID="us-southeast"
+      />,
+      { flags: defaultFlags }
+    );
+    expect(onPlanSelectionInvalidated).toHaveBeenCalled();
+  });
+
+  it('should not call onPlanSelectionInvalidated when the selected plan is available for that region', () => {
+    queryMocks.useRegionAvailabilityQuery.mockReturnValue({
+      data: mockRegionAvailabilities,
+    });
+    const onPlanSelectionInvalidated = vi.fn();
+    // Render Plans Panel with a premium plan selected for a region that has that plan available
+    const propsWithPremiumPlanSelected = {
+      ...defaultProps,
+      selectedId: mockPremiumPlanId,
+    };
+    renderWithTheme(
+      <PlansPanel
+        {...propsWithPremiumPlanSelected}
+        onPlanSelectionInvalidated={onPlanSelectionInvalidated}
+        selectedRegionID="us-east"
+      />,
+      { flags: defaultFlags }
+    );
+    expect(onPlanSelectionInvalidated).not.toHaveBeenCalled();
   });
 });

--- a/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
@@ -21,6 +21,7 @@ import { PlanInformation } from './PlanInformation';
 import {
   determineInitialPlanCategoryTab,
   extractPlansInformation,
+  getIsLimitedAvailability,
   getPlanSelectionsByPlanType,
   isMTCPlan,
   planTabInfoContent,
@@ -48,6 +49,7 @@ export interface PlansPanelProps {
   isLegacyDatabase?: boolean;
   isResize?: boolean;
   linodeID?: number | undefined;
+  onPlanSelectionInvalidated?: () => void;
   onSelect: (key: string) => void;
   regionsData?: Region[];
   selectedId?: string;
@@ -82,6 +84,7 @@ export const PlansPanel = (props: PlansPanelProps) => {
     isLegacyDatabase,
     isResize,
     linodeID,
+    onPlanSelectionInvalidated,
     onSelect,
     regionsData,
     selectedId,
@@ -155,6 +158,27 @@ export const PlansPanel = (props: PlansPanelProps) => {
     regionsData,
     selectedRegionID,
   });
+
+  const selectedPlan = selectedId
+    ? Object.values(plans)
+        .flat()
+        .find((plan) => plan.id === selectedId)
+    : null;
+
+  // Clear the selected plan if that plan would be rendered invalid after a region change
+  React.useEffect(() => {
+    const shouldClearPlanSelection =
+      !!selectedPlan &&
+      (isPlanPanelDisabled(selectedPlan.class) ||
+        getIsLimitedAvailability({
+          plan: selectedPlan,
+          regionAvailabilities,
+          selectedRegionId: selectedRegionID,
+        }));
+    if (shouldClearPlanSelection) {
+      onPlanSelectionInvalidated?.();
+    }
+  }, [isPlanPanelDisabled, regionAvailabilities, selectedRegionID]);
 
   const tabs = Object.keys(plans).map(
     (plan: Exclude<LinodeTypeClass, 'nanode' | 'standard'>) => {

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -119,6 +119,8 @@ import { LinodeKernelFactory } from 'src/factories/linodeKernel';
 import { quotaFactory } from 'src/factories/quotas';
 import { getStorage } from 'src/utilities/storage';
 
+import type { PathParams } from 'msw';
+
 const getRandomWholeNumber = (min: number, max: number) =>
   Math.floor(Math.random() * (max - min + 1) + min);
 
@@ -140,6 +142,7 @@ import type {
   CreateAlertDefinitionPayload,
   CreateObjectStorageKeyPayload,
   Dashboard,
+  Database,
   FirewallStatus,
   NotificationType,
   ObjectStorageEndpointTypes,
@@ -163,6 +166,37 @@ export const makeResourcePage = <T>(
   pages: override.pages ?? 1,
   results: override.results ?? e.length,
 });
+
+const makeMockDatabase = (params: PathParams): Database => {
+  const isDefault = Number(params.id) % 2 !== 0;
+  const db: Record<string, boolean | number | string | undefined> = {
+    engine: params.engine as 'mysql',
+    id: Number(params.id),
+    label: `database-${params.id}`,
+    platform: isDefault ? 'rdbms-default' : 'rdbms-legacy',
+  };
+  if (!isDefault) {
+    db.replication_commit_type =
+      params.engine === 'postgresql' ? 'local' : undefined;
+
+    db.replication_type =
+      params.engine === 'mysql'
+        ? pickRandom(possibleMySQLReplicationTypes)
+        : undefined;
+
+    db.replication_type =
+      params.engine === 'postgresql'
+        ? pickRandom(possiblePostgresReplicationTypes)
+        : undefined;
+
+    db.ssl_connection = true;
+  }
+  const database = databaseFactory.build(db);
+  if (database.platform !== 'rdbms-default') {
+    delete database.private_network;
+  }
+  return database;
+};
 
 const statusPage = [
   http.get('*/api/v2/incidents*', () => {
@@ -279,8 +313,21 @@ const databases = [
     const dedicatedTypes = databaseTypeFactory.buildList(7, {
       class: 'dedicated',
     });
+
+    const planSizes = [4, 8, 16, 32, 64, 96, 128, 256];
+    const premiumPlans = planSizes.map((size) => {
+      return databaseTypeFactory.build({
+        class: 'premium',
+        id: `premium-${size}`,
+        label: `DBaaS - Premium ${size} GB`,
+        memory: size * 1024,
+      });
+    });
+
+    const premiumTypes = [...premiumPlans];
+
     return HttpResponse.json(
-      makeResourcePage([...standardTypes, ...dedicatedTypes])
+      makeResourcePage([...standardTypes, ...dedicatedTypes, ...premiumTypes])
     );
   }),
 
@@ -296,28 +343,12 @@ const databases = [
   }),
 
   http.get('*/databases/:engine/instances/:id', ({ params }) => {
-    const isDefault = Number(params.id) % 2 !== 0;
-    const db: Record<string, boolean | number | string | undefined> = {
-      engine: params.engine as 'mysql',
-      id: Number(params.id),
-      label: `database-${params.id}`,
-      platform: isDefault ? 'rdbms-default' : 'rdbms-legacy',
-    };
-    if (!isDefault) {
-      db.replication_commit_type =
-        params.engine === 'postgresql' ? 'local' : undefined;
-      db.replication_type =
-        params.engine === 'mysql'
-          ? pickRandom(possibleMySQLReplicationTypes)
-          : params.engine === 'postgresql'
-            ? pickRandom(possiblePostgresReplicationTypes)
-            : (undefined as any);
-      db.ssl_connection = true;
-    }
-    const database = databaseFactory.build(db);
-    if (database.platform !== 'rdbms-default') {
-      delete database.private_network;
-    }
+    const database = makeMockDatabase(params);
+    return HttpResponse.json(database);
+  }),
+
+  http.put('*/databases/:engine/instances/:id', ({ params }) => {
+    const database = makeMockDatabase(params);
     return HttpResponse.json(database);
   }),
 
@@ -2422,6 +2453,11 @@ export const handlers = [
       regionAvailabilityFactory.build({
         plan: 'g6-standard-7',
         region: selectedRegion,
+      }),
+      regionAvailabilityFactory.build({
+        plan: 'premium-32',
+        region: selectedRegion,
+        available: false, // Mock for when a premium plan is not available or sold out in a region.
       }),
       // MTC plans are region-specific. The supported regions list below is hardcoded for testing purposes and will expand over time.
       // The availability of MTC plans is fully handled by this endpoint, which determines the plan's availability status (true/false) for the selected region.


### PR DESCRIPTION
## Description 📝

Implementing the premium plans tab in the databases tab and logic to clear invalid plan selections on region change. This includes updates to the mock data to display premium plans and as well as some additional cleanup.

## Changes  🔄

List any change(s) relevant to the reviewer.

- Database Create now clears a plan when it is rendered invalid after a region change.
- PlansPanel has been updated to provide a way to notify when a plan selection is invalid for this case.
- Mock data has been updated for the serverHandler and some data has been cleaned up

## Target release date 🗓️

7/15/2025

## Preview 📷

| Before  | After   |
| ------- | ------- |
|  ![create-plans-before](https://github.com/user-attachments/assets/c7ebb8a0-d67a-4c27-87bf-2cc7008d5b3c)  | ![create-plans-after](https://github.com/user-attachments/assets/846517c7-7c70-4598-80da-770387704fd2) |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Have access to the databases tab
- Have `databasePremium` feature flag enabled

### Verification steps
Note: The backend isn't updated yet, so mock data has been updated to test these scenarios. These are just examples and the actual availability for plans in these regions may differ when the backend is updated.

Scenario 1: No region is selected. You select a premium plan and switch to a region that does not support premium plans:
- [ ] Using mock data, select Create Database Cluster
- [ ] Select the Premium Plans CPU tab that is now visible
- [ ] Select an enabled premium plan
- [ ] Change to a region that does support premium plans (ie. US, Dallas, TX)
- [ ] Verify that the plan selection is cleared

Scenario 2: Switch from a region that supports a premium plan to one that does not:
- [ ] Using mock data, select Create Database Cluster
- [ ] Change to a region that supports premium plans (ie. US, Washington, DC)
- [ ] Select the Premium Plans CPU tab that is now visible
- [ ] Select an enabled premium plan
- [ ] Change to a region that does support premium plans (ie. US, Dallas, TX)
- [ ] Verify that the plan selection is cleared

Scenario 3: Switch between regions that support premium plans:
- [ ] Using mock data, select Create Database Cluster
- [ ] Change to a region that supports premium plans (ie. US, Washington, DC)
- [ ] Select the Premium Plans CPU tab that is now visible
- [ ] Select an enabled premium plan
- [ ] Change to a region that also supports premium plans (ie. US, Chicago, IL)
- [ ] Verify that the plan selection is maintained and does not clear

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
