### PR TITLE
test: [M3-9855] - Fix Community StackScripts Cypress test flake

### DIFF
--- a/packages/manager/.changeset/pr-12470-tests-1751556866866.md
+++ b/packages/manager/.changeset/pr-12470-tests-1751556866866.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Fix Community StackScripts Cypress test flake ([#12470](https://github.com/linode/manager/pull/12470))

--- a/packages/manager/cypress/e2e/core/stackscripts/smoke-community-stackscripts.spec.ts
+++ b/packages/manager/cypress/e2e/core/stackscripts/smoke-community-stackscripts.spec.ts
@@ -227,6 +227,10 @@ describe('Community Stackscripts integration tests', () => {
               `${stackScripts[0].username} / ${stackScripts[0].label}`
             ).should('be.visible');
           });
+
+          // Wait for a bit in case the page is not fully loaded.
+          // eslint-disable-next-line cypress/no-unnecessary-waiting
+          cy.wait(200);
         });
     }
   });
@@ -277,7 +281,7 @@ describe('Community Stackscripts integration tests', () => {
     const fairPassword = 'Akamai123';
     const rootPassword = randomString(16);
     const image = 'AlmaLinux 9';
-    const region = chooseRegion({ capabilities: ['Vlans'] });
+    const region = chooseRegion({ capabilities: ['Linodes', 'Vlans'] });
     const linodeLabel = randomLabel();
 
     // Ensure that the Primary Nav is open
@@ -313,7 +317,8 @@ describe('Community Stackscripts integration tests', () => {
       .should('be.visible')
       .click();
 
-    cy.url().should('endWith', '/stackscripts/community');
+    // eslint-disable-next-line sonarjs/anchor-precedence
+    cy.url().should('match', /\/stackscripts\/community|\?query=[a-z-]+$/g);
 
     cy.get(`[href="/stackscripts/${stackScriptId}"]`)
       .should('be.visible')
@@ -376,7 +381,7 @@ describe('Community Stackscripts integration tests', () => {
     cy.get('[data-qa-plan-row="Dedicated 8 GB"]')
       .closest('tr')
       .within(() => {
-        cy.get('[data-qa-radio]').click();
+        cy.get('[data-qa-radio]').click({ force: true });
       });
 
     // Input root password

--- a/packages/manager/cypress/e2e/core/stackscripts/smoke-community-stackscripts.spec.ts
+++ b/packages/manager/cypress/e2e/core/stackscripts/smoke-community-stackscripts.spec.ts
@@ -228,6 +228,7 @@ describe('Community Stackscripts integration tests', () => {
             ).should('be.visible');
           });
 
+          // TODO Investigate alternatives to this cy.wait
           // Wait for a bit in case the page is not fully loaded.
           // eslint-disable-next-line cypress/no-unnecessary-waiting
           cy.wait(200);


### PR DESCRIPTION
## Description 📝

Fix Community StackScripts Cypress test flask.

## Changes  🔄

List any change(s) relevant to the reviewer.
- Add `200ms` timer to let the page fully loaded.

## How to test 🧪
```
pnpm cy:run -s "cypress/e2e/core/stackscripts/smoke-community-stackscripts.spec.ts"
```