### PR TITLE
upcoming: [M3-10287] - Add notice when changing policy for scheduled maintenances

### DIFF
--- a/packages/manager/src/components/MaintenancePolicySelect/constants.ts
+++ b/packages/manager/src/components/MaintenancePolicySelect/constants.ts
@@ -32,3 +32,6 @@ export const MAINTENANCE_POLICY_NOT_AVAILABLE_IN_REGION_TEXT =
 
 export const GPU_PLAN_NOTICE =
   'GPU plan does not support live migration and will perform a warm migration and then cold migration as fallbacks.';
+
+export const UPCOMING_MAINTENANCE_NOTICE =
+  'Changes to this policy will not affect this existing planned maintenance event and, instead, will be applied to future maintenance events scheduled after the change is made.';

--- a/packages/manager/src/features/Account/MaintenancePolicy.tsx
+++ b/packages/manager/src/features/Account/MaintenancePolicy.tsx
@@ -4,6 +4,7 @@ import {
   Box,
   Button,
   NewFeatureChip,
+  Notice,
   Paper,
   Stack,
   Typography,
@@ -13,13 +14,15 @@ import * as React from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
 import { Link } from 'src/components/Link';
-import { MAINTENANCE_POLICY_ACCOUNT_DESCRIPTION } from 'src/components/MaintenancePolicySelect/constants';
+import {
+  MAINTENANCE_POLICY_ACCOUNT_DESCRIPTION,
+  UPCOMING_MAINTENANCE_NOTICE,
+} from 'src/components/MaintenancePolicySelect/constants';
 import { MaintenancePolicySelect } from 'src/components/MaintenancePolicySelect/MaintenancePolicySelect';
 import { useFlags } from 'src/hooks/useFlags';
+import { useUpcomingMaintenanceNotice } from 'src/hooks/useUpcomingMaintenanceNotice';
 
-import type { AccountSettings } from '@linode/api-v4';
-
-type MaintenancePolicyValues = Pick<AccountSettings, 'maintenance_policy'>;
+import type { MaintenancePolicyValues } from 'src/hooks/useUpcomingMaintenanceNotice.ts';
 
 export const MaintenancePolicy = () => {
   const { enqueueSnackbar } = useSnackbar();
@@ -43,6 +46,12 @@ export const MaintenancePolicy = () => {
           maintenance_policy: accountSettings.maintenance_policy,
         }
       : undefined,
+  });
+
+  const { showUpcomingMaintenanceNotice } = useUpcomingMaintenanceNotice({
+    control,
+    // For account-level settings, we don't have a specific entity ID
+    // The hook will check for any upcoming maintenance events
   });
 
   const onSubmit = async (values: MaintenancePolicyValues) => {
@@ -70,6 +79,12 @@ export const MaintenancePolicy = () => {
             </Link>
             .
           </Typography>
+          {showUpcomingMaintenanceNotice && (
+            <Notice variant="warning">
+              There are Linodes that have upcoming scheduled maintenance.{' '}
+              {UPCOMING_MAINTENANCE_NOTICE}
+            </Notice>
+          )}
           <Controller
             control={control}
             name="maintenance_policy"

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/LinodeSettingsMaintenancePolicyPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/LinodeSettingsMaintenancePolicyPanel.tsx
@@ -1,5 +1,5 @@
 import { useLinodeQuery, useLinodeUpdateMutation } from '@linode/queries';
-import { Accordion, Box, Button, Stack, Typography } from '@linode/ui';
+import { Accordion, Box, Button, Notice, Stack, Typography } from '@linode/ui';
 import { useSnackbar } from 'notistack';
 import * as React from 'react';
 import { Controller, useForm } from 'react-hook-form';
@@ -9,19 +9,19 @@ import {
   MAINTENANCE_POLICY_DESCRIPTION,
   MAINTENANCE_POLICY_LEARN_MORE_URL,
   MAINTENANCE_POLICY_TITLE,
+  UPCOMING_MAINTENANCE_NOTICE,
 } from 'src/components/MaintenancePolicySelect/constants';
 import { MaintenancePolicySelect } from 'src/components/MaintenancePolicySelect/MaintenancePolicySelect';
 import { getFeatureChip } from 'src/features/Account/MaintenancePolicy';
 import { useFlags } from 'src/hooks/useFlags';
+import { useUpcomingMaintenanceNotice } from 'src/hooks/useUpcomingMaintenanceNotice';
 
-import type { AccountSettings } from '@linode/api-v4';
+import type { MaintenancePolicyValues } from 'src/hooks/useUpcomingMaintenanceNotice.ts';
 
 interface Props {
   isReadOnly?: boolean;
   linodeId: number;
 }
-
-type MaintenancePolicyValues = Pick<AccountSettings, 'maintenance_policy'>;
 
 export const LinodeSettingsMaintenancePolicyPanel = (props: Props) => {
   const { isReadOnly, linodeId } = props;
@@ -43,6 +43,12 @@ export const LinodeSettingsMaintenancePolicyPanel = (props: Props) => {
   } = useForm<MaintenancePolicyValues>({
     defaultValues: values,
     values,
+  });
+
+  const { showUpcomingMaintenanceNotice } = useUpcomingMaintenanceNotice({
+    control,
+    entityId: linodeId,
+    entityType: 'linode',
   });
 
   const onSubmit = async (values: MaintenancePolicyValues) => {
@@ -72,6 +78,12 @@ export const LinodeSettingsMaintenancePolicyPanel = (props: Props) => {
             {MAINTENANCE_POLICY_DESCRIPTION}{' '}
             <Link to={MAINTENANCE_POLICY_LEARN_MORE_URL}>Learn more</Link>.
           </Typography>
+          {showUpcomingMaintenanceNotice && (
+            <Notice variant="warning">
+              This Linode has an upcoming scheduled maintenance.{' '}
+              {UPCOMING_MAINTENANCE_NOTICE}
+            </Notice>
+          )}
           <Controller
             control={control}
             name="maintenance_policy"

--- a/packages/manager/src/hooks/useUpcomingMaintenanceNotice.ts
+++ b/packages/manager/src/hooks/useUpcomingMaintenanceNotice.ts
@@ -1,0 +1,57 @@
+import { useAllAccountMaintenanceQuery } from '@linode/queries';
+import { useWatch } from 'react-hook-form';
+import type { UseFormReturn } from 'react-hook-form';
+
+import { UPCOMING_MAINTENANCE_FILTER } from 'src/features/Account/Maintenance/utilities';
+
+import type { AccountSettings } from '@linode/api-v4';
+
+export type MaintenancePolicyValues = Pick<
+  AccountSettings,
+  'maintenance_policy'
+>;
+
+interface UseUpcomingMaintenanceNoticeProps {
+  control: UseFormReturn<MaintenancePolicyValues>['control'];
+  entityId?: number;
+  entityType?: 'linode' | 'volume';
+}
+
+export const useUpcomingMaintenanceNotice = ({
+  control,
+  entityId,
+  entityType = 'linode',
+}: UseUpcomingMaintenanceNoticeProps) => {
+  const selectedMaintenancePolicy = useWatch({
+    control,
+    name: 'maintenance_policy',
+  });
+
+  const { data: upcomingMaintenance } = useAllAccountMaintenanceQuery(
+    {},
+    UPCOMING_MAINTENANCE_FILTER,
+    true // Always fetch for account-level settings
+  );
+
+  // Check if there's upcoming maintenance for the specific entity or any entity if no entityId provided
+  const entityUpcomingMaintenance = upcomingMaintenance?.find((maintenance) => {
+    const matchesEntityType = maintenance.entity.type === entityType;
+    const matchesEntityId = entityId
+      ? maintenance.entity.id === entityId
+      : true;
+    const isScheduled = maintenance.status === 'scheduled';
+    const policyDiffers =
+      maintenance.maintenance_policy_set !== selectedMaintenancePolicy;
+
+    return matchesEntityType && matchesEntityId && isScheduled && policyDiffers;
+  });
+
+  const showUpcomingMaintenanceNotice =
+    entityUpcomingMaintenance && selectedMaintenancePolicy;
+
+  return {
+    showUpcomingMaintenanceNotice,
+    entityUpcomingMaintenance,
+    selectedMaintenancePolicy,
+  };
+};


### PR DESCRIPTION
## Description 📝
When users attempt to change maintenance policies, they need to be informed if there are upcoming scheduled maintenance events that won't be affected by their changes. 

## Changes  🔄
- New `useUpcomingMaintenanceNotice`: This hook detects such scenarios and provides the necessary state to display appropriate warnings.
- Slightly different language when viewing in Linode settings vs Account settings.

## Target release date 🗓️
7/15

## Preview 📷

| Linode Settings  | Account Settings   |
| ------- | ------- |
| ![Screenshot 2025-07-03 at 1 08 25 PM](https://github.com/user-attachments/assets/f0fa8ba5-619f-4138-9382-6921944f83bf) | ![Screenshot 2025-07-03 at 2 26 34 PM](https://github.com/user-attachments/assets/f61f7f31-9d77-4969-b286-4b909340efde) |

## How to test 🧪
- Use DevCloud

### Verification steps
Important: There is a bug in `/account/maintenance` where `maintenance_policy_set` is not yet in the response, so it comes back undefined. Since `undefined !== selectedPolicy` the banner shows before user makes any new selection. This will never be the case and I didn't want to add an `undefined` check. There will always be a policy associated with events.
- [ ] Banner appears in Account Settings → VM Host Maintenance section
- [ ] Banner appears in Linode Settings → VM Host Maintenance section
- [ ] Banner does not appear for linodes without maintenance event

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>