### PR TITLE
fix: [M3-10289] - Enhance Devtools to support `aclpBetaServices` nested Feature flags

### DIFF
--- a/packages/manager/.changeset/pr-12478-changed-1751654923710.md
+++ b/packages/manager/.changeset/pr-12478-changed-1751654923710.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Enhance devtools to support `aclpBetaServices` nested feature flags ([#12478](https://github.com/linode/manager/pull/12478))

--- a/packages/manager/.changeset/pr-12478-fixed-1751654923710.md
+++ b/packages/manager/.changeset/pr-12478-fixed-1751654923710.md
@@ -1,5 +1,5 @@
 ---
-"@linode/manager": Changed
+'@linode/manager': Fixed
 ---
 
 Enhance devtools to support `aclpBetaServices` nested feature flags ([#12478](https://github.com/linode/manager/pull/12478))

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -174,13 +174,13 @@ export const FeatureFlagTool = withFeatureFlagProvider(() => {
   }: SetNestedValueOptions): NestedObject => {
     const [currentKey, ...restPath] = path;
 
-    // Keep original LD values and apply any overides to preserve siblings at every level
+    // Merge original LD values and stored overrides at the current level
     const base = {
       ...ldFlagsObj, // Keep original LD values
       ...storedFlagsObj, // Apply any existing stored overrides
     };
 
-    // Base case
+    // Base case (final key in the path)
     if (restPath.length === 0) {
       return {
         ...base,
@@ -208,13 +208,14 @@ export const FeatureFlagTool = withFeatureFlagProvider(() => {
 
     const flagParts = flag.split('.');
 
-    // If the flag is not a nested flag, update it directly
+    // If the flag is not a nested flag, update it directly at the root level
     if (flagParts.length === 1) {
       updateFlagStorage({ ...storedFlags, [flag]: updatedValue });
       return;
     }
 
-    // If the flag is a nested flag, Recursively update only the specific property that changed (starts from the parentKey)
+    // If the flag is a nested flag, Recursively update only the specific property that changed,
+    // starting from the parentKey and preserving sibling values at each level
     const [parentKey, ...restPath] = flagParts;
     const updatedNested = setNestedValue({
       ldFlagsObj: ldFlags[parentKey],

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -174,10 +174,10 @@ export const FeatureFlagTool = withFeatureFlagProvider(() => {
   }: SetNestedValueOptions): NestedObject => {
     const [currentKey, ...restPath] = path;
 
-    // Merge original LD values and stored overrides at the current level
+    // Merge original LD values and existing stored overrides at the current recursion level
     const base = {
-      ...ldFlagsObj, // Keep original LD values
-      ...storedFlagsObj, // Apply any existing stored overrides
+      ...ldFlagsObj, // Keep original LD values at this level
+      ...storedFlagsObj, // Apply any existing stored overrides at this level
     };
 
     // Base case (final key in the path)
@@ -214,7 +214,7 @@ export const FeatureFlagTool = withFeatureFlagProvider(() => {
       return;
     }
 
-    // If the flag is a nested flag, Recursively update only the specific property that changed,
+    // If the flag is a nested flag, recursively update only the specific property that changed,
     // starting from the parentKey and preserving sibling values at each level
     const [parentKey, ...restPath] = flagParts;
     const updatedNested = setNestedValue({


### PR DESCRIPTION
## Description 📝

Devtools currently supports toggling only 0 and 1-level feature flags. With the recent addition of 2-level nested flags (for eg., `aclpBetaServices.ServiceType.flagName`) under `aclpBetaServices`, the toggling is not working as expected.

This update should fix the current behavior and support setting nested flags at any depth recursively to ensure correct behavior.

## Changes  🔄
- Updated feature flag toggling to support recursive toggling at any depth, instead of being limited to root (0-level) and 1-level flags

## Target release date 🗓️
N/A

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/user-attachments/assets/506fd088-88f5-490f-9d61-a0ba8339458f" /> | <video src="https://github.com/user-attachments/assets/d51dfb95-aeb4-47b0-b5cd-f68e644be74d" /> |

## How to test 🧪

### Prerequisites
- The Alerts section under Additional Options in the Create Linode flow is only visible for ACLP-supported regions (e.g., US, Washington DC) and when the `aclpBetaServices.linode.alerts` feature flag is enabled

### Reproduction steps
- Follow the steps in the attached video ("Before")

### Verification steps
- Devtools should continue to work as expected for 0-level and 1-level feature flags
- Devtools should support toggling and saving 2-level nested flags (e.g., `aclpBetaServices.ServiceType.flagName`)
- All toggled feature flags should be correctly reflected in `Local Storage` and UI

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules