### PR TITLE
misc: Update contributor documentation to mention tests and CI checks

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -39,6 +39,7 @@ Feel free to open an issue to report a bug or request a feature.
     `Added`, `Fixed`, `Changed`, `Removed`, `Tech Stories`, `Tests`, `Upcoming Features`
       - Select the changeset category that matches the commit type in your PR title. (Where this isn't a 1:1 match: generally, a `feat` commit type falls under an `Added` change and `refactor` falls under `Tech Stories`.)
       - Write your changeset by following our [best practices](#writing-a-changeset).
+9. Automated tests and other CI checks will run automatically against the PR. It is the contributor's responsibility to ensure their changes pass the CI checks.
 
 Two reviews from members of the Cloud Manager team are required before merge. After approval, all pull requests are squash merged.
 

--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -72,7 +72,7 @@ Please specify a release date (and environment, if applicable) to guarantee time
 
 ## As an Author, before moving this PR from Draft to Open, I confirmed ✅
 
-- [ ] All unit tests are passing
+- [ ] All tests and CI checks are passing
 - [ ] TypeScript compilation succeeded without errors
 - [ ] Code passes all linting rules
 

--- a/packages/manager/.changeset/pr-12480-tech-stories-1751902475339.md
+++ b/packages/manager/.changeset/pr-12480-tech-stories-1751902475339.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Improve contribution guidelines related to CI checks ([#12480](https://github.com/linode/manager/pull/12480))


### PR DESCRIPTION
## Description 📝

This PR updates our PR template and contribution guidelines to make it more explicit that it is the responsibility of contributors to ensure that CI checks are passing before their PRs can be merged.

## Changes  🔄

- Update `CONTRIBUTING.md` to mention passing CI checks as a requirement for review and approval
- Update `PULL_REQUEST_TEMPLATE.md` to broaden the requirement regarding tests

## Target release date 🗓️

No specific release in mind, but the sooner this is in `develop` the better.

## How to test 🧪

N/A. Please review for typos, etc., and please let me know if you have any suggestions to improve the language (cc @mjac0bs).

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
