### PR TITLE
fix: [M3-10291] - Region select missing selected icon

### DIFF
--- a/packages/manager/.changeset/pr-12481-fixed-1751919420399.md
+++ b/packages/manager/.changeset/pr-12481-fixed-1751919420399.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Region select missing selected icon ([#12481](https://github.com/linode/manager/pull/12481))

--- a/packages/manager/src/components/RegionSelect/RegionSelect.tsx
+++ b/packages/manager/src/components/RegionSelect/RegionSelect.tsx
@@ -126,7 +126,7 @@ export const RegionSelect = <
         onChange={onChange}
         options={regionOptions}
         placeholder={placeholder ?? 'Select a Region'}
-        renderOption={(props, region) => {
+        renderOption={(props, region, { selected }) => {
           const { key, ...rest } = props;
 
           return (
@@ -136,6 +136,7 @@ export const RegionSelect = <
               item={region}
               key={`${region.id}-${key}`}
               props={rest}
+              selected={selected}
             />
           );
         }}

--- a/packages/ui/.changeset/pr-12481-changed-1751919486678.md
+++ b/packages/ui/.changeset/pr-12481-changed-1751919486678.md
@@ -1,0 +1,5 @@
+---
+"@linode/ui": Changed
+---
+
+Require `selected` prop in `ListItemOptionProps` type ([#12481](https://github.com/linode/manager/pull/12481))

--- a/packages/ui/src/components/ListItemOption/ListItemOption.tsx
+++ b/packages/ui/src/components/ListItemOption/ListItemOption.tsx
@@ -15,7 +15,7 @@ export interface ListItemOptionProps<T> {
   item: T & { id: number | string };
   maxHeight?: number;
   props: React.HTMLAttributes<HTMLLIElement>;
-  selected?: boolean;
+  selected: boolean;
 }
 
 export interface DisableItemOption {


### PR DESCRIPTION
## Description 📝

- Fixes the region select missing the selected icon

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-07-07 at 3 29 50 PM](https://github.com/user-attachments/assets/dfba82bd-0c3f-4e7e-a3f2-a0859f4ba28d) | ![Screenshot 2025-07-07 at 3 29 30 PM](https://github.com/user-attachments/assets/b7d6676a-1d8d-445b-a88e-4a9bb2c93eb1) |

## How to test 🧪

- Verify the selected icon shows in the region select

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
