### PR TITLE
Release v1.146.0 - release → staging

### DIFF
--- a/packages/api-v4/.changeset/pr-12393-upcoming-features-1750250607053.md
+++ b/packages/api-v4/.changeset/pr-12393-upcoming-features-1750250607053.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Upcoming Features
----
-
-CloudPulse: Update types in `alerts.ts` and `types.ts`; Linode: Update type in `types.ts` ([#12393](https://github.com/linode/manager/pull/12393))

--- a/packages/api-v4/.changeset/pr-12401-upcoming-features-1750307003338.md
+++ b/packages/api-v4/.changeset/pr-12401-upcoming-features-1750307003338.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Upcoming Features
----
-
-CloudPulse: Update service type in `types.ts` ([#12401](https://github.com/linode/manager/pull/12401))

--- a/packages/api-v4/.changeset/pr-12435-upcoming-features-1750938332827.md
+++ b/packages/api-v4/.changeset/pr-12435-upcoming-features-1750938332827.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Upcoming Features
----
-
-Add `regions` in `Alert` interface in `types.ts` file for cloudpulse ([#12435](https://github.com/linode/manager/pull/12435))

--- a/packages/api-v4/.changeset/pr-12466-changed-1751546788440.md
+++ b/packages/api-v4/.changeset/pr-12466-changed-1751546788440.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Changed
----
-
-ACLP:Alerting - fixed the typo from evaluation_periods_seconds to evaluation_period_seconds ([#12466](https://github.com/linode/manager/pull/12466))

--- a/packages/api-v4/.changeset/pr-12474-fixed-1751576964549.md
+++ b/packages/api-v4/.changeset/pr-12474-fixed-1751576964549.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Fixed
----
-
-Unnecessary 404 errors when components attempt to fetch deleted resources ([#12474](https://github.com/linode/manager/pull/12474))

--- a/packages/api-v4/CHANGELOG.md
+++ b/packages/api-v4/CHANGELOG.md
@@ -1,3 +1,20 @@
+## [2025-07-15] - v0.144.0
+
+
+### Changed:
+
+- ACLP:Alerting - fixed the typo from evaluation_periods_seconds to evaluation_period_seconds ([#12466](https://github.com/linode/manager/pull/12466))
+
+### Fixed:
+
+- Unnecessary 404 errors when components attempt to fetch deleted resources ([#12474](https://github.com/linode/manager/pull/12474))
+
+### Upcoming Features:
+
+- CloudPulse: Update types in `alerts.ts` and `types.ts`; Linode: Update type in `types.ts` ([#12393](https://github.com/linode/manager/pull/12393))
+- CloudPulse: Update service type in `types.ts` ([#12401](https://github.com/linode/manager/pull/12401))
+- Add `regions` in `Alert` interface in `types.ts` file for cloudpulse ([#12435](https://github.com/linode/manager/pull/12435))
+
 ## [2025-07-01] - v0.143.0
 
 ### Changed:

--- a/packages/api-v4/package.json
+++ b/packages/api-v4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linode/api-v4",
-  "version": "0.143.0",
+  "version": "0.144.0",
   "homepage": "https://github.com/linode/manager/tree/develop/packages/api-v4",
   "bugs": {
     "url": "https://github.com/linode/manager/issues"

--- a/packages/manager/.changeset/pr-12148-changed-1746156198791.md
+++ b/packages/manager/.changeset/pr-12148-changed-1746156198791.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Changed
----
-
-Replace the button component under DBAAS with Akamai CDS button web component ([#12148](https://github.com/linode/manager/pull/12148))

--- a/packages/manager/.changeset/pr-12310-tests-1748890646068.md
+++ b/packages/manager/.changeset/pr-12310-tests-1748890646068.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Smoke tests for when aclpIntegration is disabled given varying user preferences ([#12310](https://github.com/linode/manager/pull/12310))

--- a/packages/manager/.changeset/pr-12348-changed-1749475762763.md
+++ b/packages/manager/.changeset/pr-12348-changed-1749475762763.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Changed
----
-
-TooltipIcon help to info icon ([#12348](https://github.com/linode/manager/pull/12348))

--- a/packages/manager/.changeset/pr-12363-tech-stories-1749762721844.md
+++ b/packages/manager/.changeset/pr-12363-tech-stories-1749762721844.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-Reroute Linodes ([#12363](https://github.com/linode/manager/pull/12363))

--- a/packages/manager/.changeset/pr-12380-changed-1749839658065.md
+++ b/packages/manager/.changeset/pr-12380-changed-1749839658065.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Changed
----
-
-Improve VLANSelect component behavior when creating a new VLAN ([#12380](https://github.com/linode/manager/pull/12380))

--- a/packages/manager/.changeset/pr-12380-upcoming-features-1749839731144.md
+++ b/packages/manager/.changeset/pr-12380-upcoming-features-1749839731144.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Add region filtering for VLANSelect in AddInterface form ([#12380](https://github.com/linode/manager/pull/12380))

--- a/packages/manager/.changeset/pr-12385-added-1750083407791.md
+++ b/packages/manager/.changeset/pr-12385-added-1750083407791.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Added
----
-
-Unsaved Changes modal for Legacy Alerts on Linode Details page ([#12385](https://github.com/linode/manager/pull/12385))

--- a/packages/manager/.changeset/pr-12393-upcoming-features-1750251022301.md
+++ b/packages/manager/.changeset/pr-12393-upcoming-features-1750251022301.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Add scope column, handle bulk alert enablement in `AlertInformationActionTable.tsx`, add new alerts mutation query in `alerts.tsx` ([#12393](https://github.com/linode/manager/pull/12393))

--- a/packages/manager/.changeset/pr-12401-upcoming-features-1750307164427.md
+++ b/packages/manager/.changeset/pr-12401-upcoming-features-1750307164427.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-CloudPulse: Add new port filter config in `FilterConfig.ts`, add new component `CloudPulsePortFilter.tsx`, update utilities in `utils.ts` ([#12401](https://github.com/linode/manager/pull/12401))

--- a/packages/manager/.changeset/pr-12406-removed-1750445509258.md
+++ b/packages/manager/.changeset/pr-12406-removed-1750445509258.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Removed
----
-
-Move EntityTransfers queries and dependencies to shared `queries` package ([#12406](https://github.com/linode/manager/pull/12406))

--- a/packages/manager/.changeset/pr-12408-upcoming-features-1750773595987.md
+++ b/packages/manager/.changeset/pr-12408-upcoming-features-1750773595987.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Show when public IPs are unreachable more accurately ([#12408](https://github.com/linode/manager/pull/12408))

--- a/packages/manager/.changeset/pr-12419-changed-1750749697550.md
+++ b/packages/manager/.changeset/pr-12419-changed-1750749697550.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Changed
----
-
-Alerts banner text in Legacy and Beta modes to match latest UX mocks ([#12419](https://github.com/linode/manager/pull/12419))

--- a/packages/manager/.changeset/pr-12420-upcoming-features-1750750290252.md
+++ b/packages/manager/.changeset/pr-12420-upcoming-features-1750750290252.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Add support for `nodebalancerIpv6` feature flag for NodeBalancer Dual Stack Support ([#12420](https://github.com/linode/manager/pull/12420))

--- a/packages/manager/.changeset/pr-12422-upcoming-features-1750753018905.md
+++ b/packages/manager/.changeset/pr-12422-upcoming-features-1750753018905.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-DataStream: add Destinations empty state and Create Destination views ([#12422](https://github.com/linode/manager/pull/12422))

--- a/packages/manager/.changeset/pr-12424-changed-1751354758031.md
+++ b/packages/manager/.changeset/pr-12424-changed-1751354758031.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Changed
----
-
-Update usePagination hook to use tanstack router instead of react router ([#12424](https://github.com/linode/manager/pull/12424))

--- a/packages/manager/.changeset/pr-12426-removed-1750792667341.md
+++ b/packages/manager/.changeset/pr-12426-removed-1750792667341.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Removed
----
-
-Move Databases queries and dependencies to shared `queries` package ([#12426](https://github.com/linode/manager/pull/12426))

--- a/packages/manager/.changeset/pr-12428-fixed-1750852226481.md
+++ b/packages/manager/.changeset/pr-12428-fixed-1750852226481.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Fix console error in Create NodeBalancer page and columns misalignment in Subnet NodeBalancers Table ([#12428](https://github.com/linode/manager/pull/12428))

--- a/packages/manager/.changeset/pr-12429-tests-1750996385974.md
+++ b/packages/manager/.changeset/pr-12429-tests-1750996385974.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Clean up VPC unit tests and mock queries over relying on server handlers ([#12429](https://github.com/linode/manager/pull/12429))

--- a/packages/manager/.changeset/pr-12430-fixed-1750866239525.md
+++ b/packages/manager/.changeset/pr-12430-fixed-1750866239525.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Disable kubeconfig and upgrade options for users with read-only access ([#12430](https://github.com/linode/manager/pull/12430))

--- a/packages/manager/.changeset/pr-12433-tests-1750885668250.md
+++ b/packages/manager/.changeset/pr-12433-tests-1750885668250.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Add Host Maintenance Policy account settings Cypress tests ([#12433](https://github.com/linode/manager/pull/12433))

--- a/packages/manager/.changeset/pr-12434-fixed-1750886619174.md
+++ b/packages/manager/.changeset/pr-12434-fixed-1750886619174.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-TOD payload script encoding error ([#12434](https://github.com/linode/manager/pull/12434))

--- a/packages/manager/.changeset/pr-12435-upcoming-features-1750937784755.md
+++ b/packages/manager/.changeset/pr-12435-upcoming-features-1750937784755.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Add `CloudPulseModifyAlertRegions`, `AlertRegions` and `DisplayAlertRegions` component, add `getSupportedRegions` function in alert utils.ts file, add `regions` key in `CreateAlertDefinitionForm` ([#12435](https://github.com/linode/manager/pull/12435))

--- a/packages/manager/.changeset/pr-12438-tests-1750959276269.md
+++ b/packages/manager/.changeset/pr-12438-tests-1750959276269.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Block analytics requests in Cypress tests by default ([#12438](https://github.com/linode/manager/pull/12438))

--- a/packages/manager/.changeset/pr-12441-fixed-1751029952198.md
+++ b/packages/manager/.changeset/pr-12441-fixed-1751029952198.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-ACLP: change `scope` in `CreateAlertDefinitionForm` to optional ([#12441](https://github.com/linode/manager/pull/12441))

--- a/packages/manager/.changeset/pr-12443-fixed-1751049872025.md
+++ b/packages/manager/.changeset/pr-12443-fixed-1751049872025.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Upgrade cluster version modal for LKE-E ([#12443](https://github.com/linode/manager/pull/12443))

--- a/packages/manager/.changeset/pr-12445-tests-1751059675449.md
+++ b/packages/manager/.changeset/pr-12445-tests-1751059675449.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Add integration test to confirm manually assigning a VPC IPv4 when assigning a Linode to subnet ([#12445](https://github.com/linode/manager/pull/12445))

--- a/packages/manager/.changeset/pr-12446-upcoming-features-1751288586352.md
+++ b/packages/manager/.changeset/pr-12446-upcoming-features-1751288586352.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Add alerts object to `View Code Snippets` for beta Alerts opt-in users in Create Linode flow ([#12446](https://github.com/linode/manager/pull/12446))

--- a/packages/manager/.changeset/pr-12447-upcoming-features-1751293248193.md
+++ b/packages/manager/.changeset/pr-12447-upcoming-features-1751293248193.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Implement the new RBAC permission hook in Linodes configuration tab ([#12447](https://github.com/linode/manager/pull/12447))

--- a/packages/manager/.changeset/pr-12448-fixed-1751293641095.md
+++ b/packages/manager/.changeset/pr-12448-fixed-1751293641095.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Newly created VLANs not showing up in the VLAN select after creation when using Linode Interfaces ([#12448](https://github.com/linode/manager/pull/12448))

--- a/packages/manager/.changeset/pr-12450-tech-stories-1751320182167.md
+++ b/packages/manager/.changeset/pr-12450-tech-stories-1751320182167.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-Use `REACT_APP_ENVIRONMENT_NAME` to set the Sentry environment ([#12450](https://github.com/linode/manager/pull/12450))

--- a/packages/manager/.changeset/pr-12451-upcoming-features-1751374135790.md
+++ b/packages/manager/.changeset/pr-12451-upcoming-features-1751374135790.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Updating Stream Summary on form values change ([#12451](https://github.com/linode/manager/pull/12451))

--- a/packages/manager/.changeset/pr-12452-tech-stories-1751388936476.md
+++ b/packages/manager/.changeset/pr-12452-tech-stories-1751388936476.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-Clean up getLinodeXFilter function ([#12452](https://github.com/linode/manager/pull/12452))

--- a/packages/manager/.changeset/pr-12455-changed-1751397411789.md
+++ b/packages/manager/.changeset/pr-12455-changed-1751397411789.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Changed
----
-
-Update Linode and NodeBalancer create summary text ([#12455](https://github.com/linode/manager/pull/12455))

--- a/packages/manager/.changeset/pr-12456-fixed-1751400242708.md
+++ b/packages/manager/.changeset/pr-12456-fixed-1751400242708.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Extra background on code block copy icon ([#12456](https://github.com/linode/manager/pull/12456))

--- a/packages/manager/.changeset/pr-12457-fixed-1751405820310.md
+++ b/packages/manager/.changeset/pr-12457-fixed-1751405820310.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Unexpected Linode Create deep link behavior ([#12457](https://github.com/linode/manager/pull/12457))

--- a/packages/manager/.changeset/pr-12458-upcoming-features-1751453800789.md
+++ b/packages/manager/.changeset/pr-12458-upcoming-features-1751453800789.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Implement the new RBAC permission hook in Linode Network tab ([#12458](https://github.com/linode/manager/pull/12458))

--- a/packages/manager/.changeset/pr-12459-fixed-1751453577947.md
+++ b/packages/manager/.changeset/pr-12459-fixed-1751453577947.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Unsaved changes modal for upload image feature ([#12459](https://github.com/linode/manager/pull/12459))

--- a/packages/manager/.changeset/pr-12460-upcoming-features-1751463929607.md
+++ b/packages/manager/.changeset/pr-12460-upcoming-features-1751463929607.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Add "New" badge for VM Host Maintenance; Fix maintenance table loading state; Fix maintenance policy responsive behavior for Linode Create ([#12460](https://github.com/linode/manager/pull/12460))

--- a/packages/manager/.changeset/pr-12461-fixed-1751467428528.md
+++ b/packages/manager/.changeset/pr-12461-fixed-1751467428528.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Add 'New' Badge, Bold Label, GA Code Cleanup ([#12461](https://github.com/linode/manager/pull/12461))

--- a/packages/manager/.changeset/pr-12463-changed-1751473332495.md
+++ b/packages/manager/.changeset/pr-12463-changed-1751473332495.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Changed
----
-
-Use `Paper` in create page sidebars ([#12463](https://github.com/linode/manager/pull/12463))

--- a/packages/manager/.changeset/pr-12464-upcoming-features-1751528121568.md
+++ b/packages/manager/.changeset/pr-12464-upcoming-features-1751528121568.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-CloudPulse: Add filters for new service - `nodebalancer` at `FilterConfig.ts` in metrics ([#12464](https://github.com/linode/manager/pull/12464))

--- a/packages/manager/.changeset/pr-12465-changed-1751523338317.md
+++ b/packages/manager/.changeset/pr-12465-changed-1751523338317.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Changed
----
-
-Alerts subheading text in Legacy and Beta modes to match latest UX mocks ([#12465](https://github.com/linode/manager/pull/12465))

--- a/packages/manager/.changeset/pr-12466-upcoming-features-1751546680834.md
+++ b/packages/manager/.changeset/pr-12466-upcoming-features-1751546680834.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-ACLP-Alerting: using latest /services api data to fetch the evaluation period and polling interval time options ([#12466](https://github.com/linode/manager/pull/12466))

--- a/packages/manager/.changeset/pr-12467-fixed-1751551196129.md
+++ b/packages/manager/.changeset/pr-12467-fixed-1751551196129.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-ACLP-Alerting: added fallback to the AlertsResources and DisplayAlertResources components ([#12467](https://github.com/linode/manager/pull/12467))

--- a/packages/manager/.changeset/pr-12468-removed-1751563731187.md
+++ b/packages/manager/.changeset/pr-12468-removed-1751563731187.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Removed
----
-
-Move Status Page queries and dependencies to shared `queries` package ([#12468](https://github.com/linode/manager/pull/12468))

--- a/packages/manager/.changeset/pr-12472-upcoming-features-1751567991218.md
+++ b/packages/manager/.changeset/pr-12472-upcoming-features-1751567991218.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Add notice when changing policies for scheduled maintenances for VM Host Maintenance ([#12472](https://github.com/linode/manager/pull/12472))

--- a/packages/manager/.changeset/pr-12475-fixed-1751608968657.md
+++ b/packages/manager/.changeset/pr-12475-fixed-1751608968657.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-ACLP-Alerting: spacing instead of using sx: gap for DimensionFilter, add flexWrap, remove unnecessary Box spacing in Metric ([#12475](https://github.com/linode/manager/pull/12475))

--- a/packages/manager/.changeset/pr-12476-upcoming-features-1751624766032.md
+++ b/packages/manager/.changeset/pr-12476-upcoming-features-1751624766032.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Implement the new RBAC permission hook in Linodes alerts and settings tabs ([#12476](https://github.com/linode/manager/pull/12476))

--- a/packages/manager/.changeset/pr-12478-fixed-1751654923710.md
+++ b/packages/manager/.changeset/pr-12478-fixed-1751654923710.md
@@ -1,5 +1,0 @@
----
-'@linode/manager': Fixed
----
-
-Enhance devtools to support `aclpBetaServices` nested feature flags ([#12478](https://github.com/linode/manager/pull/12478))

--- a/packages/manager/.changeset/pr-12479-upcoming-features-1751892877003.md
+++ b/packages/manager/.changeset/pr-12479-upcoming-features-1751892877003.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Update legacy/beta toggle behavior for Metrics, Alerts and Banners ([#12479](https://github.com/linode/manager/pull/12479))

--- a/packages/manager/.changeset/pr-12480-tech-stories-1751902475339.md
+++ b/packages/manager/.changeset/pr-12480-tech-stories-1751902475339.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-Improve contribution guidelines related to CI checks ([#12480](https://github.com/linode/manager/pull/12480))

--- a/packages/manager/.changeset/pr-12481-fixed-1751919420399.md
+++ b/packages/manager/.changeset/pr-12481-fixed-1751919420399.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Region select missing selected icon ([#12481](https://github.com/linode/manager/pull/12481))

--- a/packages/manager/.changeset/pr-12482-tech-stories-1751919348178.md
+++ b/packages/manager/.changeset/pr-12482-tech-stories-1751919348178.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-Clean up unused mock data and constants ([#12482](https://github.com/linode/manager/pull/12482))

--- a/packages/manager/.changeset/pr-12484-upcoming-features-1751978772224.md
+++ b/packages/manager/.changeset/pr-12484-upcoming-features-1751978772224.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Implement the new RBAC permission hook in Linodes storage tab ([#12484](https://github.com/linode/manager/pull/12484))

--- a/packages/manager/.changeset/pr-12485-upcoming-features-1751982198780.md
+++ b/packages/manager/.changeset/pr-12485-upcoming-features-1751982198780.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Implement the new RBAC permission hook in Linodes Landing Page ([#12485](https://github.com/linode/manager/pull/12485))

--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -4,6 +4,87 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2025-07-15] - v1.146.0
+
+
+### Added:
+
+- Unsaved Changes modal for Legacy Alerts on Linode Details page ([#12385](https://github.com/linode/manager/pull/12385))
+- 'New' Badge to APL section of Create Cluster flow ([#12461](https://github.com/linode/manager/pull/12461))
+
+### Changed:
+
+- Replace the button component under DBAAS with Akamai CDS button web component ([#12148](https://github.com/linode/manager/pull/12148))
+- TooltipIcon help to info icon ([#12348](https://github.com/linode/manager/pull/12348))
+- Improve VLANSelect component behavior when creating a new VLAN ([#12380](https://github.com/linode/manager/pull/12380))
+- Alerts banner text in Legacy and Beta modes to match latest UX mocks ([#12419](https://github.com/linode/manager/pull/12419))
+- Update Linode and NodeBalancer create summary text ([#12455](https://github.com/linode/manager/pull/12455))
+- Use `Paper` in create page sidebars ([#12463](https://github.com/linode/manager/pull/12463))
+- Alerts subheading text in Legacy and Beta modes to match latest UX mocks ([#12465](https://github.com/linode/manager/pull/12465))
+
+### Fixed:
+
+- Console error in Create NodeBalancer page and columns misalignment in Subnet NodeBalancers Table ([#12428](https://github.com/linode/manager/pull/12428))
+- Disable kubeconfig and upgrade options for users with read-only access ([#12430](https://github.com/linode/manager/pull/12430))
+- TOD payload script encoding error ([#12434](https://github.com/linode/manager/pull/12434))
+- Upgrade cluster version modal for LKE-E ([#12443](https://github.com/linode/manager/pull/12443))
+- Newly created VLANs not showing up in the VLAN select after creation when using Linode Interfaces ([#12448](https://github.com/linode/manager/pull/12448))
+- Extra background on code block copy icon ([#12456](https://github.com/linode/manager/pull/12456))
+- Unexpected Linode Create deep link behavior ([#12457](https://github.com/linode/manager/pull/12457))
+- Unsaved changes modal for upload image feature ([#12459](https://github.com/linode/manager/pull/12459))
+- APL header bolding in Create Cluster flow and GA code clean up ([#12461](https://github.com/linode/manager/pull/12461))
+- ACLP-Alerting: added fallback to the AlertsResources and DisplayAlertResources components ([#12467](https://github.com/linode/manager/pull/12467))
+- ACLP-Alerting: spacing instead of using sx: gap for DimensionFilter, add flexWrap, remove unnecessary Box spacing in Metric ([#12475](https://github.com/linode/manager/pull/12475))
+- Region select missing selected icon ([#12481](https://github.com/linode/manager/pull/12481))
+
+### Removed:
+
+- Move EntityTransfers queries and dependencies to shared `queries` package ([#12406](https://github.com/linode/manager/pull/12406))
+- Move Databases queries and dependencies to shared `queries` package ([#12426](https://github.com/linode/manager/pull/12426))
+- Move Status Page queries and dependencies to shared `queries` package ([#12468](https://github.com/linode/manager/pull/12468))
+
+### Tech Stories:
+
+- Reroute Linodes ([#12363](https://github.com/linode/manager/pull/12363))
+- Clean up authentication code post PKCE and decoupling of Redux ([#12405](https://github.com/linode/manager/pull/12405))
+- Use `REACT_APP_ENVIRONMENT_NAME` to set the Sentry environment ([#12450](https://github.com/linode/manager/pull/12450))
+- Clean up getLinodeXFilter function ([#12452](https://github.com/linode/manager/pull/12452))
+- Enhance devtools to support `aclpBetaServices` nested feature flags ([#12478](https://github.com/linode/manager/pull/12478))
+- Improve contribution guidelines related to CI checks ([#12480](https://github.com/linode/manager/pull/12480))
+- Clean up unused mock data and constants ([#12482](https://github.com/linode/manager/pull/12482))
+- Update usePagination hook to use TanStack router instead of react router ([#12424](https://github.com/linode/manager/pull/12424))
+
+### Tests:
+
+- Add smoke tests for when aclpIntegration is disabled given varying user preferences ([#12310](https://github.com/linode/manager/pull/12310))
+- Clean up VPC unit tests and mock queries over relying on server handlers ([#12429](https://github.com/linode/manager/pull/12429))
+- Add Host Maintenance Policy account settings Cypress tests ([#12433](https://github.com/linode/manager/pull/12433))
+- Block analytics requests in Cypress tests by default ([#12438](https://github.com/linode/manager/pull/12438))
+- Add integration test to confirm manually assigning a VPC IPv4 when assigning a Linode to subnet ([#12445](https://github.com/linode/manager/pull/12445))
+
+### Upcoming Features:
+
+- Add region filtering for VLANSelect in AddInterface form ([#12380](https://github.com/linode/manager/pull/12380))
+- Add scope column, handle bulk alert enablement in `AlertInformationActionTable.tsx`, add new alerts mutation query in `alerts.tsx` ([#12393](https://github.com/linode/manager/pull/12393))
+- CloudPulse: Add new port filter config in `FilterConfig.ts`, add new component `CloudPulsePortFilter.tsx`, update utilities in `utils.ts` ([#12401](https://github.com/linode/manager/pull/12401))
+- Show when public IPs are unreachable more accurately for Linode Interfaces ([#12408](https://github.com/linode/manager/pull/12408))
+- Add support for `nodebalancerIpv6` feature flag for NodeBalancer Dual Stack Support ([#12420](https://github.com/linode/manager/pull/12420))
+- DataStream: add Destinations empty state and Create Destination views ([#12422](https://github.com/linode/manager/pull/12422))
+- Add `CloudPulseModifyAlertRegions`, `AlertRegions` and `DisplayAlertRegions` component, add `getSupportedRegions` function in alert utils.ts file, add `regions` key in `CreateAlertDefinitionForm` ([#12435](https://github.com/linode/manager/pull/12435))
+- ACLP: change `scope` in `CreateAlertDefinitionForm` to optional ([#12441](https://github.com/linode/manager/pull/12441))
+- Add alerts object to `View Code Snippets` for beta Alerts opt-in users in Create Linode flow ([#12446](https://github.com/linode/manager/pull/12446))
+- Implement the new RBAC permission hook in Linodes configuration tab ([#12447](https://github.com/linode/manager/pull/12447))
+- Updating Stream Summary on form values change ([#12451](https://github.com/linode/manager/pull/12451))
+- Implement the new RBAC permission hook in Linode Network tab ([#12458](https://github.com/linode/manager/pull/12458))
+- Add "New" badge for VM Host Maintenance; Fix maintenance table loading state; Fix maintenance policy responsive behavior for Linode Create ([#12460](https://github.com/linode/manager/pull/12460))
+- CloudPulse: Add filters for new service - `nodebalancer` at `FilterConfig.ts` in metrics ([#12464](https://github.com/linode/manager/pull/12464))
+- ACLP-Alerting: using latest /services api data to fetch the evaluation period and polling interval time options ([#12466](https://github.com/linode/manager/pull/12466))
+- Add notice when changing policies for scheduled maintenances for VM Host Maintenance ([#12472](https://github.com/linode/manager/pull/12472))
+- Implement the new RBAC permission hook in Linodes alerts and settings tabs ([#12476](https://github.com/linode/manager/pull/12476))
+- Update legacy/beta toggle behavior for Metrics, Alerts and Banners ([#12479](https://github.com/linode/manager/pull/12479))
+- Implement the new RBAC permission hook in Linodes storage tab ([#12484](https://github.com/linode/manager/pull/12484))
+- Implement the new RBAC permission hook in Linodes Landing Page ([#12485](https://github.com/linode/manager/pull/12485))
+
 ## [2025-07-01] - v1.145.0
 
 

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.145.0",
+  "version": "1.146.0",
   "private": true,
   "type": "module",
   "bugs": {

--- a/packages/queries/.changeset/pr-12406-added-1750445559603.md
+++ b/packages/queries/.changeset/pr-12406-added-1750445559603.md
@@ -1,5 +1,0 @@
----
-"@linode/queries": Added
----
-
-`entitytransfers/` directory and migrated relevant query keys and hooks ([#12406](https://github.com/linode/manager/pull/12406))

--- a/packages/queries/.changeset/pr-12426-added-1750792750941.md
+++ b/packages/queries/.changeset/pr-12426-added-1750792750941.md
@@ -1,5 +1,0 @@
----
-"@linode/queries": Added
----
-
-Added `databases/` directory and migrated relevant query keys and hooks ([#12426](https://github.com/linode/manager/pull/12426))

--- a/packages/queries/.changeset/pr-12468-added-1751563776473.md
+++ b/packages/queries/.changeset/pr-12468-added-1751563776473.md
@@ -1,5 +1,0 @@
----
-"@linode/queries": Added
----
-
-`statusPage/` directory and migrated relevant query keys and hooks ([#12468](https://github.com/linode/manager/pull/12468))

--- a/packages/queries/CHANGELOG.md
+++ b/packages/queries/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [2025-07-15] - v0.9.0
+
+
+### Added:
+
+- `entitytransfers/` directory and migrated relevant query keys and hooks ([#12406](https://github.com/linode/manager/pull/12406))
+- Added `databases/` directory and migrated relevant query keys and hooks ([#12426](https://github.com/linode/manager/pull/12426))
+- `statusPage/` directory and migrated relevant query keys and hooks ([#12468](https://github.com/linode/manager/pull/12468))
+
 ## [2025-07-01] - v0.8.0
 
 

--- a/packages/queries/package.json
+++ b/packages/queries/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linode/queries",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Linode Utility functions library",
   "main": "src/index.js",
   "module": "src/index.ts",

--- a/packages/shared/.changeset/pr-12479-upcoming-features-1751893011438.md
+++ b/packages/shared/.changeset/pr-12479-upcoming-features-1751893011438.md
@@ -1,5 +1,0 @@
----
-"@linode/shared": Upcoming Features
----
-
-Add a `useIsLinodeAclpSubscribed` hook and its unit tests ([#12479](https://github.com/linode/manager/pull/12479))

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2025-07-15] - v0.5.0
+
+
+### Upcoming Features:
+
+- Add `useIsLinodeAclpSubscribed` hook and unit tests ([#12479](https://github.com/linode/manager/pull/12479))
+
 ## [2025-07-01] - v0.4.0
 
 ### Tech Stories

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linode/shared",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Linode shared feature component library",
   "main": "src/index.ts",
   "module": "src/index.ts",

--- a/packages/ui/.changeset/pr-12348-changed-1749475812172.md
+++ b/packages/ui/.changeset/pr-12348-changed-1749475812172.md
@@ -1,5 +1,0 @@
----
-"@linode/ui": Changed
----
-
-TooltipIcon CDS standardization ([#12348](https://github.com/linode/manager/pull/12348))

--- a/packages/ui/.changeset/pr-12423-changed-1750772203559.md
+++ b/packages/ui/.changeset/pr-12423-changed-1750772203559.md
@@ -1,5 +1,0 @@
----
-"@linode/ui": Changed
----
-
-Add `timeZoneProps` to control `timeZone dropdown` in DateTimeRangePicker.tsx ([#12423](https://github.com/linode/manager/pull/12423))

--- a/packages/ui/.changeset/pr-12460-added-1751463721038.md
+++ b/packages/ui/.changeset/pr-12460-added-1751463721038.md
@@ -1,5 +1,0 @@
----
-"@linode/ui": Added
----
-
-Add `null` as type option for `headingChip` ([#12460](https://github.com/linode/manager/pull/12460))

--- a/packages/ui/.changeset/pr-12481-changed-1751919486678.md
+++ b/packages/ui/.changeset/pr-12481-changed-1751919486678.md
@@ -1,5 +1,0 @@
----
-"@linode/ui": Changed
----
-
-Require `selected` prop in `ListItemOptionProps` type ([#12481](https://github.com/linode/manager/pull/12481))

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [2025-07-15] - v0.16.0
+
+
+### Added:
+
+- Add `null` as type option for `headingChip` ([#12460](https://github.com/linode/manager/pull/12460))
+
+### Changed:
+
+- TooltipIcon CDS standardization ([#12348](https://github.com/linode/manager/pull/12348))
+- Add `timeZoneProps` to control `timeZone dropdown` in DateTimeRangePicker.tsx ([#12423](https://github.com/linode/manager/pull/12423))
+- Require `selected` prop in `ListItemOptionProps` type ([#12481](https://github.com/linode/manager/pull/12481))
+
 ## [2025-07-01] - v0.15.0
 
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -2,7 +2,7 @@
   "name": "@linode/ui",
   "author": "Linode",
   "description": "Linode UI component library",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "type": "module",
   "main": "src/index.ts",
   "module": "src/index.ts",

--- a/packages/validation/.changeset/pr-12421-upcoming-features-1750751504937.md
+++ b/packages/validation/.changeset/pr-12421-upcoming-features-1750751504937.md
@@ -1,5 +1,0 @@
----
-"@linode/validation": Upcoming Features
----
-
-Update validation schemas for the changes in endpoints /v4/nodebalancers & /v4/nodebalancers/configs/{configId}/nodes for NB Dual Stack Support ([#12421](https://github.com/linode/manager/pull/12421))

--- a/packages/validation/.changeset/pr-12435-upcoming-features-1750937947854.md
+++ b/packages/validation/.changeset/pr-12435-upcoming-features-1750937947854.md
@@ -1,5 +1,0 @@
----
-"@linode/validation": Upcoming Features
----
-
-Add `regions` in `createAlertDefinitionSchema` and `editAlertDefinitionSchema` ([#12435](https://github.com/linode/manager/pull/12435))

--- a/packages/validation/.changeset/pr-12441-fixed-1751029941692.md
+++ b/packages/validation/.changeset/pr-12441-fixed-1751029941692.md
@@ -1,5 +1,0 @@
----
-"@linode/validation": Fixed
----
-
-ACLP: update `scope` property in `createAlertDefinitionSchema` and `editAlertDefinitionSchema` to optional and nullable ([#12441](https://github.com/linode/manager/pull/12441))

--- a/packages/validation/CHANGELOG.md
+++ b/packages/validation/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [2025-07-15] - v0.70.0
+
+
+### Fixed:
+
+- ACLP: update `scope` property in `createAlertDefinitionSchema` and `editAlertDefinitionSchema` to optional and nullable ([#12441](https://github.com/linode/manager/pull/12441))
+
+### Upcoming Features:
+
+- Update validation schemas for the changes in endpoints /v4/nodebalancers & /v4/nodebalancers/configs/{configId}/nodes for NB Dual Stack Support ([#12421](https://github.com/linode/manager/pull/12421))
+- Add `regions` in `createAlertDefinitionSchema` and `editAlertDefinitionSchema` ([#12435](https://github.com/linode/manager/pull/12435))
+
 ## [2025-07-01] - v0.69.0
 
 

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linode/validation",
-  "version": "0.69.0",
+  "version": "0.70.0",
   "description": "Yup validation schemas for use with the Linode APIv4",
   "type": "module",
   "main": "lib/index.cjs",


### PR DESCRIPTION
## Cloud Manager - [2025-07-15] - v1.146.0


### Added:

- Unsaved Changes modal for Legacy Alerts on Linode Details page ([#12385](https://github.com/linode/manager/pull/12385))
- 'New' Badge to APL section of Create Cluster flow ([#12461](https://github.com/linode/manager/pull/12461))

### Changed:

- Replace the button component under DBAAS with Akamai CDS button web component ([#12148](https://github.com/linode/manager/pull/12148))
- TooltipIcon help to info icon ([#12348](https://github.com/linode/manager/pull/12348))
- Improve VLANSelect component behavior when creating a new VLAN ([#12380](https://github.com/linode/manager/pull/12380))
- Alerts banner text in Legacy and Beta modes to match latest UX mocks ([#12419](https://github.com/linode/manager/pull/12419))
- Update Linode and NodeBalancer create summary text ([#12455](https://github.com/linode/manager/pull/12455))
- Use `Paper` in create page sidebars ([#12463](https://github.com/linode/manager/pull/12463))
- Alerts subheading text in Legacy and Beta modes to match latest UX mocks ([#12465](https://github.com/linode/manager/pull/12465))

### Fixed:

- Console error in Create NodeBalancer page and columns misalignment in Subnet NodeBalancers Table ([#12428](https://github.com/linode/manager/pull/12428))
- Disable kubeconfig and upgrade options for users with read-only access ([#12430](https://github.com/linode/manager/pull/12430))
- TOD payload script encoding error ([#12434](https://github.com/linode/manager/pull/12434))
- Upgrade cluster version modal for LKE-E ([#12443](https://github.com/linode/manager/pull/12443))
- Newly created VLANs not showing up in the VLAN select after creation when using Linode Interfaces ([#12448](https://github.com/linode/manager/pull/12448))
- Extra background on code block copy icon ([#12456](https://github.com/linode/manager/pull/12456))
- Unexpected Linode Create deep link behavior ([#12457](https://github.com/linode/manager/pull/12457))
- Unsaved changes modal for upload image feature ([#12459](https://github.com/linode/manager/pull/12459))
- APL header bolding in Create Cluster flow and GA code clean up ([#12461](https://github.com/linode/manager/pull/12461))
- ACLP-Alerting: added fallback to the AlertsResources and DisplayAlertResources components ([#12467](https://github.com/linode/manager/pull/12467))
- ACLP-Alerting: spacing instead of using sx: gap for DimensionFilter, add flexWrap, remove unnecessary Box spacing in Metric ([#12475](https://github.com/linode/manager/pull/12475))
- Region select missing selected icon ([#12481](https://github.com/linode/manager/pull/12481))

### Removed:

- Move EntityTransfers queries and dependencies to shared `queries` package ([#12406](https://github.com/linode/manager/pull/12406))
- Move Databases queries and dependencies to shared `queries` package ([#12426](https://github.com/linode/manager/pull/12426))
- Move Status Page queries and dependencies to shared `queries` package ([#12468](https://github.com/linode/manager/pull/12468))

### Tech Stories:

- Reroute Linodes ([#12363](https://github.com/linode/manager/pull/12363))
- Clean up authentication code post PKCE and decoupling of Redux ([#12405](https://github.com/linode/manager/pull/12405))
- Use `REACT_APP_ENVIRONMENT_NAME` to set the Sentry environment ([#12450](https://github.com/linode/manager/pull/12450))
- Clean up getLinodeXFilter function ([#12452](https://github.com/linode/manager/pull/12452))
- Enhance devtools to support `aclpBetaServices` nested feature flags ([#12478](https://github.com/linode/manager/pull/12478))
- Improve contribution guidelines related to CI checks ([#12480](https://github.com/linode/manager/pull/12480))
- Clean up unused mock data and constants ([#12482](https://github.com/linode/manager/pull/12482))
- Update usePagination hook to use TanStack router instead of react router ([#12424](https://github.com/linode/manager/pull/12424))

### Tests:

- Add smoke tests for when aclpIntegration is disabled given varying user preferences ([#12310](https://github.com/linode/manager/pull/12310))
- Clean up VPC unit tests and mock queries over relying on server handlers ([#12429](https://github.com/linode/manager/pull/12429))
- Add Host Maintenance Policy account settings Cypress tests ([#12433](https://github.com/linode/manager/pull/12433))
- Block analytics requests in Cypress tests by default ([#12438](https://github.com/linode/manager/pull/12438))
- Add integration test to confirm manually assigning a VPC IPv4 when assigning a Linode to subnet ([#12445](https://github.com/linode/manager/pull/12445))

### Upcoming Features:

- Add region filtering for VLANSelect in AddInterface form ([#12380](https://github.com/linode/manager/pull/12380))
- Add scope column, handle bulk alert enablement in `AlertInformationActionTable.tsx`, add new alerts mutation query in `alerts.tsx` ([#12393](https://github.com/linode/manager/pull/12393))
- CloudPulse: Add new port filter config in `FilterConfig.ts`, add new component `CloudPulsePortFilter.tsx`, update utilities in `utils.ts` ([#12401](https://github.com/linode/manager/pull/12401))
- Show when public IPs are unreachable more accurately for Linode Interfaces ([#12408](https://github.com/linode/manager/pull/12408))
- Add support for `nodebalancerIpv6` feature flag for NodeBalancer Dual Stack Support ([#12420](https://github.com/linode/manager/pull/12420))
- DataStream: add Destinations empty state and Create Destination views ([#12422](https://github.com/linode/manager/pull/12422))
- Add `CloudPulseModifyAlertRegions`, `AlertRegions` and `DisplayAlertRegions` component, add `getSupportedRegions` function in alert utils.ts file, add `regions` key in `CreateAlertDefinitionForm` ([#12435](https://github.com/linode/manager/pull/12435))
- ACLP: change `scope` in `CreateAlertDefinitionForm` to optional ([#12441](https://github.com/linode/manager/pull/12441))
- Add alerts object to `View Code Snippets` for beta Alerts opt-in users in Create Linode flow ([#12446](https://github.com/linode/manager/pull/12446))
- Implement the new RBAC permission hook in Linodes configuration tab ([#12447](https://github.com/linode/manager/pull/12447))
- Updating Stream Summary on form values change ([#12451](https://github.com/linode/manager/pull/12451))
- Implement the new RBAC permission hook in Linode Network tab ([#12458](https://github.com/linode/manager/pull/12458))
- Add "New" badge for VM Host Maintenance; Fix maintenance table loading state; Fix maintenance policy responsive behavior for Linode Create ([#12460](https://github.com/linode/manager/pull/12460))
- CloudPulse: Add filters for new service - `nodebalancer` at `FilterConfig.ts` in metrics ([#12464](https://github.com/linode/manager/pull/12464))
- ACLP-Alerting: using latest /services api data to fetch the evaluation period and polling interval time options ([#12466](https://github.com/linode/manager/pull/12466))
- Add notice when changing policies for scheduled maintenances for VM Host Maintenance ([#12472](https://github.com/linode/manager/pull/12472))
- Implement the new RBAC permission hook in Linodes alerts and settings tabs ([#12476](https://github.com/linode/manager/pull/12476))
- Update legacy/beta toggle behavior for Metrics, Alerts and Banners ([#12479](https://github.com/linode/manager/pull/12479))
- Implement the new RBAC permission hook in Linodes storage tab ([#12484](https://github.com/linode/manager/pull/12484))
- Implement the new RBAC permission hook in Linodes Landing Page ([#12485](https://github.com/linode/manager/pull/12485))

## APIv4 - [2025-07-15] - v0.144.0


### Changed:

- ACLP:Alerting - fixed the typo from evaluation_periods_seconds to evaluation_period_seconds ([#12466](https://github.com/linode/manager/pull/12466))

### Fixed:

- Unnecessary 404 errors when components attempt to fetch deleted resources ([#12474](https://github.com/linode/manager/pull/12474))

### Upcoming Features:

- CloudPulse: Update types in `alerts.ts` and `types.ts`; Linode: Update type in `types.ts` ([#12393](https://github.com/linode/manager/pull/12393))
- CloudPulse: Update service type in `types.ts` ([#12401](https://github.com/linode/manager/pull/12401))
- Add `regions` in `Alert` interface in `types.ts` file for cloudpulse ([#12435](https://github.com/linode/manager/pull/12435))

## UI - [2025-07-15] - v0.16.0


### Added:

- Add `null` as type option for `headingChip` ([#12460](https://github.com/linode/manager/pull/12460))

### Changed:

- TooltipIcon CDS standardization ([#12348](https://github.com/linode/manager/pull/12348))
- Add `timeZoneProps` to control `timeZone dropdown` in DateTimeRangePicker.tsx ([#12423](https://github.com/linode/manager/pull/12423))
- Require `selected` prop in `ListItemOptionProps` type ([#12481](https://github.com/linode/manager/pull/12481))

## Queries - [2025-07-15] - v0.9.0


### Added:

- `entitytransfers/` directory and migrated relevant query keys and hooks ([#12406](https://github.com/linode/manager/pull/12406))
- Added `databases/` directory and migrated relevant query keys and hooks ([#12426](https://github.com/linode/manager/pull/12426))
- `statusPage/` directory and migrated relevant query keys and hooks ([#12468](https://github.com/linode/manager/pull/12468))

## Validation - [2025-07-15] - v0.70.0


### Fixed:

- ACLP: update `scope` property in `createAlertDefinitionSchema` and `editAlertDefinitionSchema` to optional and nullable ([#12441](https://github.com/linode/manager/pull/12441))

### Upcoming Features:

- Update validation schemas for the changes in endpoints /v4/nodebalancers & /v4/nodebalancers/configs/{configId}/nodes for NB Dual Stack Support ([#12421](https://github.com/linode/manager/pull/12421))
- Add `regions` in `createAlertDefinitionSchema` and `editAlertDefinitionSchema` ([#12435](https://github.com/linode/manager/pull/12435))

## Shared - [2025-07-15] - v0.5.0


### Upcoming Features:

- Add `useIsLinodeAclpSubscribed` hook and unit tests ([#12479](https://github.com/linode/manager/pull/12479))
