### PR TITLE
test: [M3-10311] - Fix Cypress test failures following feature flag flip

### DIFF
--- a/packages/manager/.changeset/pr-12499-tests-1752165592860.md
+++ b/packages/manager/.changeset/pr-12499-tests-1752165592860.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Fix Cypress test failures following feature flag flip ([#12499](https://github.com/linode/manager/pull/12499))


### PR DESCRIPTION
## Description 📝

Quick fix to Cypress test failures due to new `Host & VM Maintenance` feature flag.

## Changes  🔄

List any change(s) relevant to the reviewer.
- Mock feature flag `vmHostMaintenance` to be disabled.

## How to test 🧪
```
pnpm cy:run -s "cypress/e2e/core/account/account-maintenance.spec.ts"
```