### PR TITLE
feat: [UIE-8871] - IAM RBAC: Firewall linodes permissions check

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddLinodeDrawer.test.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddLinodeDrawer.test.tsx
@@ -1,3 +1,5 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
 import { renderWithTheme } from 'src/utilities/testHelpers';
@@ -15,6 +17,15 @@ const props = {
 
 const queryMocks = vi.hoisted(() => ({
   useParams: vi.fn().mockReturnValue({}),
+  userPermissions: vi.fn(() => ({
+    permissions: {
+      create_firewall_device: false,
+    },
+  })),
+}));
+
+vi.mock('src/features/IAM/hooks/usePermissions', () => ({
+  usePermissions: queryMocks.userPermissions,
 }));
 
 vi.mock('@tanstack/react-router', async () => {
@@ -48,5 +59,51 @@ describe('AddLinodeDrawer', () => {
   it('should contain an Add button', () => {
     const { getByText } = renderWithTheme(<AddLinodeDrawer {...props} />);
     expect(getByText('Add')).toBeInTheDocument();
+  });
+
+  it('should disable "Add" button if the user does not have create_firewall_device permission', async () => {
+    queryMocks.userPermissions.mockReturnValue({
+      permissions: {
+        create_firewall_device: false,
+      },
+    });
+
+    const { getByRole } = renderWithTheme(<AddLinodeDrawer {...props} />);
+
+    const autocomplete = screen.getByRole('combobox');
+    await userEvent.click(autocomplete);
+    await userEvent.type(autocomplete, 'linode-5');
+
+    const option = await screen.findByText('linode-5');
+    await userEvent.click(option);
+
+    const addButton = getByRole('button', {
+      name: 'Add',
+    });
+    expect(addButton).toBeInTheDocument();
+    expect(addButton).toBeDisabled();
+  });
+
+  it('should enable "Add" button if the user has create_firewall_device permission', async () => {
+    queryMocks.userPermissions.mockReturnValue({
+      permissions: {
+        create_firewall_device: true,
+      },
+    });
+
+    const { getByRole } = renderWithTheme(<AddLinodeDrawer {...props} />);
+
+    const autocomplete = screen.getByRole('combobox');
+    await userEvent.click(autocomplete);
+    await userEvent.type(autocomplete, 'linode-5');
+
+    const option = await screen.findByText('linode-5');
+    await userEvent.click(option);
+
+    const addButton = getByRole('button', {
+      name: 'Add',
+    });
+    expect(addButton).toBeInTheDocument();
+    expect(addButton).toBeEnabled();
   });
 });

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddLinodeDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddLinodeDrawer.tsx
@@ -23,6 +23,7 @@ import * as React from 'react';
 
 import { Link } from 'src/components/Link';
 import { SupportLink } from 'src/components/SupportLink';
+import { usePermissions } from 'src/features/IAM/hooks/usePermissions';
 import { getLinodeInterfaceType } from 'src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/utilities';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { useIsLinodeInterfacesEnabled } from 'src/utilities/linodes';
@@ -57,6 +58,12 @@ export const AddLinodeDrawer = (props: Props) => {
   const { data, error, isLoading } = useAllFirewallsQuery();
 
   const firewall = data?.find((firewall) => firewall.id === Number(id));
+
+  const { permissions } = usePermissions(
+    'firewall',
+    ['create_firewall_device'],
+    firewall?.id
+  );
 
   const { data: allLinodes } = useAllLinodesQuery({}, {});
 
@@ -371,7 +378,7 @@ export const AddLinodeDrawer = (props: Props) => {
         {isLinodeInterfacesEnabled &&
           selectedLinodesWithMultipleInterfaces.length > 0 && (
             <Typography marginTop={3}>
-              {`${selectedLinodesWithMultipleInterfaces.length === 1 ? 'This Linode has' : 'The following Linodes have'} 
+              {`${selectedLinodesWithMultipleInterfaces.length === 1 ? 'This Linode has' : 'The following Linodes have'}
             multiple interfaces that a firewall can be applied to. Select which interface to apply the firewall to.`}
             </Typography>
           )}
@@ -409,7 +416,9 @@ export const AddLinodeDrawer = (props: Props) => {
           })}
         <ActionsPanel
           primaryButtonProps={{
-            disabled: selectedLinodes.length === 0,
+            disabled:
+              selectedLinodes.length === 0 ||
+              !permissions.create_firewall_device,
             label: 'Add',
             loading: addDeviceIsLoading,
             onClick: handleSubmit,

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallDeviceLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallDeviceLanding.tsx
@@ -5,6 +5,7 @@ import { useLocation, useNavigate } from '@tanstack/react-router';
 import * as React from 'react';
 
 import { DebouncedSearchTextField } from 'src/components/DebouncedSearchTextField';
+import { usePermissions } from 'src/features/IAM/hooks/usePermissions';
 
 import { AddLinodeDrawer } from './AddLinodeDrawer';
 import { AddNodebalancerDrawer } from './AddNodebalancerDrawer';
@@ -27,6 +28,11 @@ export const FirewallDeviceLanding = React.memo(
     const theme = useTheme();
     const navigate = useNavigate();
     const location = useLocation();
+    const { permissions } = usePermissions(
+      'firewall',
+      ['create_firewall_device', 'delete_firewall_device'],
+      firewallId
+    );
     const helperText =
       'Assign one or more services to this firewall. You can add services later if you want to customize your rules first.';
 
@@ -60,6 +66,10 @@ export const FirewallDeviceLanding = React.memo(
     );
 
     const formattedType = formattedTypes[type];
+    const isCreateDeviceDisabled =
+      type === 'linode' ? !permissions.create_firewall_device : disabled;
+    const isRemoveDeviceDisabled =
+      type === 'linode' ? !permissions.delete_firewall_device : disabled;
 
     // If the user initiates a history -/+ to a /remove route and the device is not found,
     // push navigation to the appropriate /linodes or /nodebalancers route.
@@ -119,7 +129,7 @@ export const FirewallDeviceLanding = React.memo(
               <Button
                 buttonType="primary"
                 data-testid="add-device-button"
-                disabled={disabled}
+                disabled={isCreateDeviceDisabled}
                 onClick={handleOpen}
               >
                 Add {formattedType}s to Firewall
@@ -129,7 +139,7 @@ export const FirewallDeviceLanding = React.memo(
         </Grid>
         <FirewallDeviceTable
           deviceType={type}
-          disabled={disabled}
+          disabled={isRemoveDeviceDisabled}
           firewallId={firewallId}
           handleRemoveDevice={(device) => {
             setDevice(device);

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallDeviceRow.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallDeviceRow.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { Link } from 'src/components/Link';
 import { TableCell } from 'src/components/TableCell';
 import { TableRow } from 'src/components/TableRow';
+import { usePermissions } from 'src/features/IAM/hooks/usePermissions';
 import { useIsLinodeInterfacesEnabled } from 'src/utilities/linodes';
 
 import { getDeviceLinkAndLabel } from '../../FirewallLanding/FirewallRow';
@@ -24,12 +25,21 @@ export const FirewallDeviceRow = React.memo((props: FirewallDeviceRowProps) => {
 
   const { entityLabel, entityLink } = getDeviceLinkAndLabel(device.entity);
 
+  const { permissions } = usePermissions(
+    'firewall',
+    ['view_firewall_device'],
+    device.id
+  );
   return (
     <TableRow data-testid={`firewall-device-row-${id}`}>
       <TableCell>
-        <Link tabIndex={0} to={entityLink}>
-          {entityLabel}
-        </Link>
+        {!permissions.view_firewall_device ? (
+          entityLabel
+        ) : (
+          <Link tabIndex={0} to={entityLink}>
+            {entityLabel}
+          </Link>
+        )}
       </TableCell>
       {isLinodeInterfacesEnabled && isLinodeRelatedDevice && (
         <TableCell>

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/RemoveDeviceDialog.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/RemoveDeviceDialog.tsx
@@ -9,6 +9,7 @@ import { useSnackbar } from 'notistack';
 import * as React from 'react';
 
 import { ConfirmationDialog } from 'src/components/ConfirmationDialog/ConfirmationDialog';
+import { usePermissions } from 'src/features/IAM/hooks/usePermissions';
 
 import { formattedTypes } from './constants';
 
@@ -51,6 +52,11 @@ export const RemoveDeviceDialog = React.memo((props: Props) => {
 
   const deviceDialog = formattedTypes[deviceType ?? 'linode'];
 
+  const { permissions } = usePermissions(
+    'firewall',
+    ['delete_firewall_device'],
+    device?.entity.id
+  );
   const onDelete = async () => {
     if (!device) {
       return;
@@ -120,6 +126,7 @@ export const RemoveDeviceDialog = React.memo((props: Props) => {
             label: primaryButtonText,
             loading: isPending,
             onClick: onDelete,
+            disabled: !permissions.delete_firewall_device,
           }}
           secondaryButtonProps={{
             label: 'Cancel',


### PR DESCRIPTION
## Description 📝

Implement the new RBAC permission hook in Firewall Linodes Tab.

## Changes  🔄

List any change(s) relevant to the reviewer.

1. Permissions Refactor
Replaced usage of useRestrictedGlobalGrantCheck and related grant checks with a new usePermissions hook throughout Firewall Linodes Tab.
Disable/Enable 'Add Linodes to Firewall' and Remove buttons.
Disable/Enable Linode item in a table.
Show an error when accessing the Linodes tab if the user does not have the `list_firewall_devices` permission.

2. Test Coverage
Added new tests for permission-based UI states.

## Target release date 🗓️

July 29th

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-07-10 at 4 49 18 PM](https://github.com/user-attachments/assets/6ef35625-2e2d-4b65-9917-ac50911dd72c) | ![Screenshot 2025-07-10 at 4 49 45 PM](https://github.com/user-attachments/assets/ce0b881a-3d3e-4456-9ceb-e5a9fd9b57d2) |

## How to test 🧪

### Prerequisites

(How to setup test environment)

You can test using a DevCloud IAM account or local devenv setup or mock data (use the User Permissions presets);

_Note: The unrestricted account has full access — permission checks are skipped._

**To test permissions using presets**:

1. Enable MSW and use Legacy MSW Handlers.
2. Use the Custom Profile preset with the restricted option selected.
3. For account-related permissions (e.g. const { permissions } = usePermissions('account', ['create_firewall']) ), use the Custom User Account Permissions preset.
4. For entity-related permissions, use the Custom User Entity Permissions preset.
5. Add the required permissions to the appropriate preset in the following format:
```
[
  "view_linode",
  "resize_linode",
  "rebuild_linode",
  "rescue_linode"
]
```
6. Click "Save" and "Apply".

### Verification steps

(How to verify changes)

- [ ] Confirm the buttons are disabled according the grant model with IAM is off, and according to the RBAC model when IAM is on.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>