### PR TITLE
upcoming: [M3-10195] - Add save legacy alerts confirmation modal

### DIFF
--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeAlerts/AlertsPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeAlerts/AlertsPanel.tsx
@@ -337,9 +337,9 @@ export const AlertsPanel = (props: Props) => {
         )}
       </Prompt>
 
-      {/* Save Alerts Confirmation Modal. This Confirmation Modal on "Save" appear
-      only when user already subscribed to Beta/ACLP Mode and making changes in the
-      Legacy mode Interface */}
+      {/* Save Legacy Alerts Confirmation Modal. This modal appears on "Save" only
+      when user already subscribed to Beta/ACLP Mode and makes changes in the
+      Legacy mode Interface. */}
       <AlertConfirmationDialog
         handleCancel={() => setIsDialogOpen(false)}
         handleConfirm={() => formik.handleSubmit()}

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeAlerts/AlertsPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeAlerts/AlertsPanel.tsx
@@ -3,6 +3,7 @@ import {
   useLinodeUpdateMutation,
   useTypeQuery,
 } from '@linode/queries';
+import { useIsLinodeAclpSubscribed } from '@linode/shared';
 import { ActionsPanel, Divider, Notice, Paper, Typography } from '@linode/ui';
 import { styled } from '@mui/material/styles';
 import { useBlocker } from '@tanstack/react-router';
@@ -13,6 +14,7 @@ import * as React from 'react';
 import { ConfirmationDialog } from 'src/components/ConfirmationDialog/ConfirmationDialog';
 // eslint-disable-next-line no-restricted-imports
 import { Prompt } from 'src/components/Prompt/Prompt';
+import { AlertConfirmationDialog } from 'src/features/CloudPulse/Alerts/AlertsLanding/AlertConfirmationDialog';
 import { getAPIErrorFor } from 'src/utilities/getAPIErrorFor';
 
 import { AlertSection } from './AlertSection';
@@ -51,6 +53,9 @@ export const AlertsPanel = (props: Props) => {
 
   const isBareMetalInstance = type?.class === 'metal';
 
+  const isLinodeAclpSubscribed = useIsLinodeAclpSubscribed(linodeId, 'beta');
+  const [isDialogOpen, setIsDialogOpen] = React.useState<boolean>(false);
+
   const isCreateFlow = !linodeId;
 
   const initialValues = isCreateFlow
@@ -72,6 +77,7 @@ export const AlertsPanel = (props: Props) => {
   const formik = useFormik<Linode['alerts']>({
     enableReinitialize: true,
     initialValues,
+
     async onSubmit({ cpu, io, network_in, network_out, transfer_quota }) {
       await updateLinode({
         alerts: {
@@ -81,12 +87,16 @@ export const AlertsPanel = (props: Props) => {
           network_out,
           transfer_quota,
         },
-      });
-
-      enqueueSnackbar(
-        `Successfully updated alert settings for ${linode?.label}`,
-        { variant: 'success' }
-      );
+      })
+        .then(() => {
+          enqueueSnackbar(
+            `Successfully updated alert settings for ${linode?.label}`,
+            { variant: 'success' }
+          );
+        })
+        .finally(() => {
+          setIsDialogOpen(false);
+        });
     },
   });
 
@@ -280,6 +290,14 @@ export const AlertsPanel = (props: Props) => {
     }
   }, [status, reset]);
 
+  const handleSaveClick = () => {
+    if (!isLinodeAclpSubscribed) {
+      formik.handleSubmit();
+    } else {
+      setIsDialogOpen(true);
+    }
+  };
+
   return (
     <>
       {/* Use Prompt for now until Link is coupled with Tanstack router */}
@@ -319,6 +337,24 @@ export const AlertsPanel = (props: Props) => {
         )}
       </Prompt>
 
+      {/* Save Alerts Confirmation Modal. This Confirmation Modal on "Save" appear
+      only when user already subscribed to Beta/ACLP Mode and making changes in the
+      Legacy mode Interface */}
+      <AlertConfirmationDialog
+        handleCancel={() => setIsDialogOpen(false)}
+        handleConfirm={() => formik.handleSubmit()}
+        isLoading={isPending}
+        isOpen={isDialogOpen && isLinodeAclpSubscribed}
+        message={
+          <>
+            Are you sure you want to save Legacy Alerts? <b>Alerts(Beta)</b>{' '}
+            settings will be disabled and replaced by the original Legacy
+            settings.
+          </>
+        }
+        primaryButtonLabel="Save"
+        title="Are you sure you want to save Legacy Alerts?"
+      />
       <Paper
         sx={(theme) =>
           isCreateFlow ? { p: 0 } : { pb: theme.spacingFunction(16) }
@@ -346,7 +382,7 @@ export const AlertsPanel = (props: Props) => {
               disabled: isReadOnly || !formik.dirty,
               label: 'Save',
               loading: isPending,
-              onClick: () => formik.handleSubmit(),
+              onClick: handleSaveClick,
             }}
           />
         )}


### PR DESCRIPTION
## Description 📝

We need to show legacy 'Save Alerts' confirmation modal only if user has already opted/subscribed into Beta Alerts mode in Linode Details page.

## Changes  🔄
- Add save legacy alerts confirmation modal

## Target release date 🗓️
N/A

## Preview 📷
![Screenshot 2025-07-15 at 2 27 52 PM](https://github.com/user-attachments/assets/db2a454d-0010-4176-9d98-bb0bd98efde2)

## How to test 🧪

### Verification steps

- Case 1:
  - DO NOT enable MSW or a feature flag
  - Navigate to any Linode Details page
  - Verify Confirmation Modal does not appear upon Saving
- Case 2: 
  - Enable `MSW` and `aclpBetaServices -> linode -> alerts` feature flag
  - Navigate to the linode's landing page
  - locate `aclp-supported-region-linode-1` (this is an ACLP-subscribed linode in ACLP supported region example)
    - Go to its Details page -> Alerts 
    - Make changes and click Save
    - Ensure the Confirmation Modal appears upon Saving
  - locate `aclp-supported-region-linode-2` (this is a NON-ACLP-subscribed linode in ACLP supported region example)
    - Go to its Details page -> Alerts 
    - Make changes and click Save
    - Ensure the Confirmation Modal does not appear upon saving
 
<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules