### PR TITLE
change: Use v4Beta prefix for maintenance endpoint

### DIFF
--- a/packages/api-v4/CHANGELOG.md
+++ b/packages/api-v4/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Changed:
 
 - ACLP:Alerting - fixed the typo from evaluation_periods_seconds to evaluation_period_seconds ([#12466](https://github.com/linode/manager/pull/12466))
+- Use `v4beta` for `/maintenance` endpoint
 
 ### Fixed:
 

--- a/packages/api-v4/src/account/maintenance.ts
+++ b/packages/api-v4/src/account/maintenance.ts
@@ -1,4 +1,4 @@
-import { API_ROOT, BETA_API_ROOT } from '../constants';
+import { BETA_API_ROOT } from '../constants';
 import Request, { setMethod, setParams, setURL, setXFilter } from '../request';
 
 import type { Filter, Params, ResourcePage } from '../types';
@@ -12,7 +12,7 @@ import type { AccountMaintenance, MaintenancePolicy } from './types';
  */
 export const getAccountMaintenance = (params?: Params, filter?: Filter) =>
   Request<ResourcePage<AccountMaintenance>>(
-    setURL(`${API_ROOT}/account/maintenance`),
+    setURL(`${BETA_API_ROOT}/account/maintenance`),
     setMethod('GET'),
     setParams(params),
     setXFilter(filter),


### PR DESCRIPTION
## Description 📝
We should be using the v4beta endpoint for this specific endpoint.

## Changes  🔄
- Change `v4` to `v4beta` for `/maintenance` endpoint

## Target release date 🗓️
7/15

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <img width="1344" height="574" alt="Screenshot 2025-07-15 at 9 34 00 AM" src="https://github.com/user-attachments/assets/f3a1d892-4403-48f0-9d42-d283519cb9f1" /> | <img width="887" height="780" alt="Screenshot 2025-07-15 at 9 24 56 AM" src="https://github.com/user-attachments/assets/493f2d6e-a9fa-4dd6-873b-d03404190ec3" /> |

## How to test 🧪

### Verification steps
- Go to /account/maintenance in DevCloud
- Observe maintenance linodes are showing

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>