### PR TITLE
fix: CloudPulse alerting validation schemas due to incorrect conflict resolution

### DIFF
--- a/packages/validation/src/cloudpulse.schema.ts
+++ b/packages/validation/src/cloudpulse.schema.ts
@@ -78,10 +78,7 @@ export const createAlertDefinitionSchema = object({
   tags: array().of(string().defined()).optional(),
   entity_ids: array().of(string().defined()).optional(),
   regions: array().of(string().defined()).optional(),
-  scope: string()
-    .oneOf(['entity', 'region', 'account'])
-    .defined()
-    .required(fieldErrorMessage),
+  scope: string().oneOf(['entity', 'region', 'account']).nullable().optional(),
 });
 
 export const editAlertDefinitionSchema = object({
@@ -125,6 +122,6 @@ export const editAlertDefinitionSchema = object({
   status: string()
     .oneOf(['enabled', 'disabled', 'in progress', 'failed'])
     .optional(),
-  scope: string().oneOf(['entity', 'region', 'account']).required(),
+  scope: string().oneOf(['entity', 'region', 'account']).nullable().optional(),
   regions: array().of(string().defined()).optional(),
 });


### PR DESCRIPTION
I think I got something wrong when resolving conflicts when merging `develop` ⬅️  `master` into  after our last release.

The CloudPulse Alerting team requested we fix this in our release.