### PR TITLE
upcoming: [DPS-34037] - Add streams list

### DIFF
--- a/packages/api-v4/.changeset/pr-12524-upcoming-features-1753170038400.md
+++ b/packages/api-v4/.changeset/pr-12524-upcoming-features-1753170038400.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Upcoming Features
+---
+
+API endpoints (GET, POST) for Streams ([#12524](https://github.com/linode/manager/pull/12524))

--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -489,6 +489,7 @@ export const EventActionKeys = [
   'user_ssh_key_delete',
   'user_ssh_key_update',
   'user_update',
+  'stream_create',
   'volume_attach',
   'volume_clone',
   'volume_create',

--- a/packages/api-v4/src/datastream/index.ts
+++ b/packages/api-v4/src/datastream/index.ts
@@ -1,0 +1,3 @@
+export * from './streams';
+
+export * from './types';

--- a/packages/api-v4/src/datastream/streams.ts
+++ b/packages/api-v4/src/datastream/streams.ts
@@ -1,0 +1,47 @@
+import { BETA_API_ROOT } from '../constants';
+import Request, {
+  setData,
+  setMethod,
+  setParams,
+  setURL,
+  setXFilter,
+} from '../request';
+
+import type { Filter, ResourcePage as Page, Params } from '../types';
+import type { CreateStreamPayload, Stream } from './types';
+
+/**
+ * Returns all the information about a specified Stream.
+ *
+ * @param streamId { number } The ID of the Stream to access.
+ *
+ */
+export const getStream = (streamId: number) =>
+  Request<Stream>(
+    setURL(`${BETA_API_ROOT}/monitor/streams/${encodeURIComponent(streamId)}`),
+    setMethod('GET'),
+  );
+
+/**
+ * Returns a paginated list of Streams.
+ *
+ */
+export const getStreams = (params?: Params, filter?: Filter) =>
+  Request<Page<Stream>>(
+    setURL(`${BETA_API_ROOT}/monitor/streams`),
+    setMethod('GET'),
+    setParams(params),
+    setXFilter(filter),
+  );
+
+/**
+ * Adds a new Stream.
+ *
+ * @param data { object } Data for type, label, etc.
+ */
+export const createStream = (data: CreateStreamPayload) =>
+  Request<Stream>(
+    setData(data), // @TODO (DPS-34044) add validation schema
+    setURL(`${BETA_API_ROOT}/monitor/streams`),
+    setMethod('POST'),
+  );

--- a/packages/api-v4/src/datastream/types.ts
+++ b/packages/api-v4/src/datastream/types.ts
@@ -1,0 +1,109 @@
+export const streamStatus = {
+  Active: 'active',
+  Inactive: 'inactive',
+} as const;
+
+export type StreamStatus = (typeof streamStatus)[keyof typeof streamStatus];
+
+export const streamType = {
+  AuditLogs: 'audit_logs',
+  LKEAuditLogs: 'lke_audit_logs',
+} as const;
+
+export type StreamType = (typeof streamType)[keyof typeof streamType];
+
+export interface AuditData {
+  created: string;
+  created_by: string;
+  updated: string;
+  updated_by: string;
+}
+
+export interface Stream extends AuditData {
+  destinations: Destination[];
+  details: StreamDetails;
+  id: number;
+  label: string;
+  primary_destination_id: number;
+  status: StreamStatus;
+  stream_audit_id: number;
+  type: StreamType;
+  version: string;
+}
+
+export interface StreamDetails {
+  cluster_ids?: number[];
+  is_auto_add_all_clusters_enabled?: boolean;
+}
+
+export const destinationType = {
+  CustomHttps: 'custom_https',
+  LinodeObjectStorage: 'linode_object_storage',
+} as const;
+
+export type DestinationType =
+  (typeof destinationType)[keyof typeof destinationType];
+
+export interface Destination {
+  details: DestinationDetails;
+  id: number;
+  label: string;
+  type: DestinationType;
+}
+
+export type DestinationDetails =
+  | CustomHTTPsDetails
+  | LinodeObjectStorageDetails;
+
+export interface LinodeObjectStorageDetails {
+  access_key_id: string;
+  access_key_secret: string;
+  bucket_name: string;
+  host: string;
+  path: string;
+  region: string;
+}
+
+type ContentType = 'application/json' | 'application/json; charset=utf-8';
+type DataCompressionType = 'gzip' | 'None';
+
+export interface CustomHTTPsDetails {
+  authentication: Authentication;
+  client_certificate_details?: ClientCertificateDetails;
+  content_type: ContentType;
+  custom_headers?: CustomHeader[];
+  data_compression: DataCompressionType;
+  endpoint_url: string;
+}
+
+interface ClientCertificateDetails {
+  client_ca_certificate: string;
+  client_certificate: string;
+  client_private_key: string;
+  tls_hostname: string;
+}
+
+type AuthenticationType = 'basic' | 'none';
+
+interface Authentication {
+  details: AuthenticationDetails;
+  type: AuthenticationType;
+}
+
+interface AuthenticationDetails {
+  basic_authentication_password: string;
+  basic_authentication_user: string;
+}
+
+interface CustomHeader {
+  name: string;
+  value: string;
+}
+
+export interface CreateStreamPayload {
+  destinations: number[];
+  details?: StreamDetails;
+  label: string;
+  status?: StreamStatus;
+  type: StreamType;
+}

--- a/packages/api-v4/src/index.ts
+++ b/packages/api-v4/src/index.ts
@@ -8,6 +8,8 @@ export * from './cloudpulse';
 
 export * from './databases';
 
+export * from './datastream';
+
 export * from './domains';
 
 export * from './entities';

--- a/packages/manager/.changeset/pr-12524-upcoming-features-1753079912268.md
+++ b/packages/manager/.changeset/pr-12524-upcoming-features-1753079912268.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add streams list for datastream page. Add GET, POST mock handlers for streams requests ([#12524](https://github.com/linode/manager/pull/12524))

--- a/packages/manager/src/factories/datastream.ts
+++ b/packages/manager/src/factories/datastream.ts
@@ -1,0 +1,34 @@
+import { destinationType, type Stream, streamType } from '@linode/api-v4';
+import { Factory } from '@linode/utilities';
+
+import type { Destination } from '@linode/api-v4';
+
+export const destinationFactory = Factory.Sync.makeFactory<Destination>({
+  details: {
+    access_key_id: 'Access Id',
+    access_key_secret: 'Access Secret',
+    bucket_name: 'Bucket Name',
+    host: '3000',
+    path: 'file',
+    region: 'us-ord',
+  },
+  id: Factory.each((id) => id),
+  label: Factory.each((id) => `Destination ${id}`),
+  type: destinationType.LinodeObjectStorage,
+});
+
+export const streamFactory = Factory.Sync.makeFactory<Stream>({
+  created_by: 'username',
+  destinations: [destinationFactory.build({ id: 1, label: 'Destination 1' })],
+  details: {},
+  updated: '2025-07-30',
+  updated_by: 'username',
+  id: Factory.each((id) => id),
+  label: Factory.each((id) => `Data Stream ${id}`),
+  primary_destination_id: 1,
+  status: 'active',
+  stream_audit_id: 1,
+  type: streamType.AuditLogs,
+  version: '1.0',
+  created: '2025-07-30',
+});

--- a/packages/manager/src/features/DataStream/Destinations/DestinationCreate/DestinationCreate.test.tsx
+++ b/packages/manager/src/features/DataStream/Destinations/DestinationCreate/DestinationCreate.test.tsx
@@ -1,8 +1,8 @@
+import { destinationType } from '@linode/api-v4';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
-import { destinationType } from 'src/features/DataStream/Shared/types';
 import { renderWithThemeAndHookFormContext } from 'src/utilities/testHelpers';
 
 import { DestinationCreate } from './DestinationCreate';

--- a/packages/manager/src/features/DataStream/Destinations/DestinationCreate/DestinationCreate.tsx
+++ b/packages/manager/src/features/DataStream/Destinations/DestinationCreate/DestinationCreate.tsx
@@ -1,3 +1,4 @@
+import { destinationType } from '@linode/api-v4';
 import { Autocomplete, Box, Button, Paper, TextField } from '@linode/ui';
 import { useTheme } from '@mui/material/styles';
 import * as React from 'react';
@@ -7,10 +8,7 @@ import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { LandingHeader } from 'src/components/LandingHeader';
 import { getDestinationTypeOption } from 'src/features/DataStream/dataStreamUtils';
 import { DestinationLinodeObjectStorageDetailsForm } from 'src/features/DataStream/Shared/DestinationLinodeObjectStorageDetailsForm';
-import {
-  destinationType,
-  destinationTypeOptions,
-} from 'src/features/DataStream/Shared/types';
+import { destinationTypeOptions } from 'src/features/DataStream/Shared/types';
 
 import type { CreateStreamForm } from 'src/features/DataStream/Streams/StreamCreate/types';
 

--- a/packages/manager/src/features/DataStream/Shared/DataStreamTabHeader/DataStreamTabHeader.test.tsx
+++ b/packages/manager/src/features/DataStream/Shared/DataStreamTabHeader/DataStreamTabHeader.test.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+
+import { DataStreamTabHeader } from 'src/features/DataStream/Shared/DataStreamTabHeader/DataStreamTabHeader';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+describe('DataStreamTabHeader', () => {
+  it('should render a create button', () => {
+    const { getByText } = renderWithTheme(
+      <DataStreamTabHeader entity="Stream" onButtonClick={() => null} />
+    );
+    expect(getByText('Create Stream')).toBeInTheDocument();
+  });
+
+  it('should render a disabled create button', () => {
+    const { getByText } = renderWithTheme(
+      <DataStreamTabHeader
+        disabledCreateButton
+        entity="Stream"
+        onButtonClick={() => null}
+      />
+    );
+
+    expect(getByText('Create Stream').closest('button')).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+  });
+});

--- a/packages/manager/src/features/DataStream/Shared/DataStreamTabHeader/DataStreamTabHeader.tsx
+++ b/packages/manager/src/features/DataStream/Shared/DataStreamTabHeader/DataStreamTabHeader.tsx
@@ -1,0 +1,100 @@
+import { Button } from '@linode/ui';
+import Grid from '@mui/material/Grid';
+import { styled, useTheme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import * as React from 'react';
+
+import type { Theme } from '@mui/material/styles';
+
+export interface DataStreamTabHeaderProps {
+  buttonDataAttrs?: { [key: string]: boolean | string };
+  createButtonText?: string;
+  disabledCreateButton?: boolean;
+  entity?: string;
+  loading?: boolean;
+  onButtonClick?: () => void;
+  spacingBottom?: 0 | 4 | 16 | 24;
+}
+
+export const DataStreamTabHeader = ({
+  buttonDataAttrs,
+  createButtonText,
+  disabledCreateButton,
+  entity,
+  loading,
+  onButtonClick,
+  spacingBottom = 24,
+}: DataStreamTabHeaderProps) => {
+  const theme = useTheme();
+
+  const xsDown = useMediaQuery((theme: Theme) => theme.breakpoints.down('sm'));
+  const customBreakpoint = 636;
+  const customXsDownBreakpoint = useMediaQuery((theme: Theme) =>
+    theme.breakpoints.down(customBreakpoint)
+  );
+  const customSmMdBetweenBreakpoint = useMediaQuery((theme: Theme) =>
+    theme.breakpoints.between(customBreakpoint, 'md')
+  );
+
+  return (
+    <StyledLandingHeaderGrid
+      container
+      data-qa-entity-header
+      sx={{
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        marginBottom: spacingBottom !== undefined ? `${spacingBottom}px` : 0,
+        width: '100%',
+      }}
+    >
+      <Grid
+        sx={{
+          alignItems: 'center',
+          display: 'flex',
+          flexWrap: xsDown ? 'wrap' : 'nowrap',
+          gap: 3,
+          justifyContent: 'flex-end',
+          flex: '1 1 auto',
+
+          marginLeft: customSmMdBetweenBreakpoint
+            ? theme.spacingFunction(16)
+            : customXsDownBreakpoint
+              ? theme.spacingFunction(8)
+              : undefined,
+        }}
+      >
+        {
+          // @TODO (DPS-34192) Search input - both streams and destinations
+        }
+        <StyledActions>
+          {
+            // @TODO (DPS-34193) Select status - only streams
+          }
+          {onButtonClick && (
+            <Button
+              buttonType="primary"
+              disabled={disabledCreateButton}
+              loading={loading}
+              onClick={onButtonClick}
+              {...buttonDataAttrs}
+            >
+              {createButtonText ?? `Create ${entity}`}
+            </Button>
+          )}
+        </StyledActions>
+      </Grid>
+    </StyledLandingHeaderGrid>
+  );
+};
+
+const StyledActions = styled('div')(({ theme }) => ({
+  display: 'flex',
+  gap: theme.spacingFunction(24),
+  justifyContent: 'flex-end',
+}));
+
+const StyledLandingHeaderGrid = styled(Grid)(({ theme }) => ({
+  '&:not(:first-of-type)': {
+    marginTop: theme.spacingFunction(24),
+  },
+}));

--- a/packages/manager/src/features/DataStream/Shared/types.ts
+++ b/packages/manager/src/features/DataStream/Shared/types.ts
@@ -1,10 +1,8 @@
-export const destinationType = {
-  CustomHttps: 'custom_https',
-  LinodeObjectStorage: 'linode_object_storage',
-} as const;
-
-export type DestinationType =
-  (typeof destinationType)[keyof typeof destinationType];
+import {
+  type DestinationType,
+  destinationType,
+  type LinodeObjectStorageDetails,
+} from '@linode/api-v4';
 
 export interface DestinationTypeOption {
   label: string;
@@ -22,18 +20,7 @@ export const destinationTypeOptions: DestinationTypeOption[] = [
   },
 ];
 
-export interface LinodeObjectStorageDetails {
-  access_key_id: string;
-  access_key_secret: string;
-  bucket_name: string;
-  host: string;
-  path: string;
-  region: string;
-}
-
-export type DestinationDetails = LinodeObjectStorageDetails; // Later a CustomHTTPsDetails type will be added
-
-export interface CreateDestinationForm extends DestinationDetails {
+export interface CreateDestinationForm extends LinodeObjectStorageDetails {
   destination_label: string;
   destination_type: DestinationType;
 }

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/CheckoutBar/StreamCreateCheckoutBar.test.tsx
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/CheckoutBar/StreamCreateCheckoutBar.test.tsx
@@ -1,13 +1,12 @@
+import { destinationType, streamType } from '@linode/api-v4';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { describe, expect } from 'vitest';
 
-import { destinationType } from 'src/features/DataStream/Shared/types';
 import { StreamCreateCheckoutBar } from 'src/features/DataStream/Streams/StreamCreate/CheckoutBar/StreamCreateCheckoutBar';
 import { StreamCreateGeneralInfo } from 'src/features/DataStream/Streams/StreamCreate/StreamCreateGeneralInfo';
-import { streamType } from 'src/features/DataStream/Streams/StreamCreate/types';
 import {
   renderWithTheme,
   renderWithThemeAndHookFormContext,
@@ -15,10 +14,11 @@ import {
 
 describe('StreamCreateCheckoutBar', () => {
   const getDeliveryPriceContext = () => screen.getByText(/\/unit/i).textContent;
+  const createStream = () => {};
 
   const renderComponent = () => {
     renderWithThemeAndHookFormContext({
-      component: <StreamCreateCheckoutBar />,
+      component: <StreamCreateCheckoutBar createStream={createStream} />,
       useFormOptions: {
         defaultValues: {
           destination_type: destinationType.LinodeObjectStorage,
@@ -27,11 +27,11 @@ describe('StreamCreateCheckoutBar', () => {
     });
   };
 
-  it('should render checkout bar with disabled checkout button', async () => {
+  it('should render checkout bar with enabled checkout button', async () => {
     renderComponent();
     const submitButton = screen.getByText('Create Stream');
 
-    expect(submitButton).toBeDisabled();
+    expect(submitButton).toBeEnabled();
   });
 
   it('should render Delivery summary with destination type and price', () => {
@@ -56,7 +56,7 @@ describe('StreamCreateCheckoutBar', () => {
       <FormProvider {...methods}>
         <form>
           <StreamCreateGeneralInfo />
-          <StreamCreateCheckoutBar />
+          <StreamCreateCheckoutBar createStream={createStream} />
         </form>
       </FormProvider>
     );

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/CheckoutBar/StreamCreateCheckoutBar.tsx
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/CheckoutBar/StreamCreateCheckoutBar.tsx
@@ -9,7 +9,12 @@ import { StyledHeader } from 'src/features/DataStream/Streams/StreamCreate/Check
 
 import type { CreateStreamForm } from 'src/features/DataStream/Streams/StreamCreate/types';
 
-export const StreamCreateCheckoutBar = () => {
+export interface Props {
+  createStream: () => void;
+}
+
+export const StreamCreateCheckoutBar = (props: Props) => {
+  const { createStream } = props;
   const { control } = useFormContext<CreateStreamForm>();
   const destinationType = useWatch({ control, name: 'destination_type' });
   const formValues = useWatch({
@@ -22,14 +27,13 @@ export const StreamCreateCheckoutBar = () => {
     ],
   });
   const price = getPrice(formValues);
-  const onDeploy = () => {};
 
   return (
     <CheckoutBar
       calculatedPrice={price}
-      disabled={true}
+      disabled={false}
       heading="Stream Summary"
-      onDeploy={onDeploy}
+      onDeploy={createStream}
       priceSelectionText="Select Cluster and define a Destination to view pricing and create a stream."
       submitText="Create Stream"
     >

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreate.tsx
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreate.tsx
@@ -1,19 +1,27 @@
-import { Stack } from '@linode/ui';
+import { destinationType, streamType } from '@linode/api-v4';
+import { useCreateStreamMutation } from '@linode/queries';
+import { omitProps, Stack } from '@linode/ui';
 import Grid from '@mui/material/Grid';
+import { useNavigate } from '@tanstack/react-router';
 import * as React from 'react';
 import { FormProvider, useForm, useWatch } from 'react-hook-form';
 
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { LandingHeader } from 'src/components/LandingHeader';
-import { destinationType } from 'src/features/DataStream/Shared/types';
+import { sendCreateStreamEvent } from 'src/utilities/analytics/customEventAnalytics';
 
 import { StreamCreateCheckoutBar } from './CheckoutBar/StreamCreateCheckoutBar';
 import { StreamCreateClusters } from './StreamCreateClusters';
 import { StreamCreateDelivery } from './StreamCreateDelivery';
 import { StreamCreateGeneralInfo } from './StreamCreateGeneralInfo';
-import { type CreateStreamForm, streamType } from './types';
+
+import type { CreateStreamPayload } from '@linode/api-v4';
+import type { CreateStreamForm } from 'src/features/DataStream/Streams/StreamCreate/types';
 
 export const StreamCreate = () => {
+  const { mutateAsync: createStream } = useCreateStreamMutation();
+  const navigate = useNavigate();
+
   const form = useForm<CreateStreamForm>({
     defaultValues: {
       type: streamType.AuditLogs,
@@ -46,14 +54,35 @@ export const StreamCreate = () => {
     title: 'Create Stream',
   };
 
-  const onSubmit = () => {};
+  const onSubmit = () => {
+    const { label, type, destinations, details } = form.getValues();
+    const payload: CreateStreamPayload = {
+      label,
+      type,
+      destinations,
+    };
+    if (type === streamType.LKEAuditLogs && details) {
+      if (details.is_auto_add_all_clusters_enabled) {
+        payload['details'] = omitProps(details, ['cluster_ids']);
+      } else {
+        payload['details'] = omitProps(details, [
+          'is_auto_add_all_clusters_enabled',
+        ]);
+      }
+    }
+
+    createStream(payload).then(() => {
+      sendCreateStreamEvent('Stream Create Page');
+      navigate({ to: '/datastream/streams' });
+    });
+  };
 
   return (
     <>
       <DocumentTitleSegment segment="Create Stream" />
       <LandingHeader {...landingHeaderProps} />
       <FormProvider {...form}>
-        <form onSubmit={handleSubmit(onSubmit)}>
+        <form>
           <Grid container spacing={2}>
             <Grid size={{ lg: 9, md: 12, sm: 12, xs: 12 }}>
               <Stack spacing={2}>
@@ -65,7 +94,7 @@ export const StreamCreate = () => {
               </Stack>
             </Grid>
             <Grid size={{ lg: 3, md: 12, sm: 12, xs: 12 }}>
-              <StreamCreateCheckoutBar />
+              <StreamCreateCheckoutBar createStream={handleSubmit(onSubmit)} />
             </Grid>
           </Grid>
         </form>

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateDelivery.test.tsx
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateDelivery.test.tsx
@@ -1,8 +1,8 @@
+import { destinationType } from '@linode/api-v4';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
-import { destinationType } from 'src/features/DataStream/Shared/types';
 import { renderWithThemeAndHookFormContext } from 'src/utilities/testHelpers';
 
 import { StreamCreateDelivery } from './StreamCreateDelivery';

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateDelivery.tsx
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateDelivery.tsx
@@ -1,3 +1,4 @@
+import { destinationType } from '@linode/api-v4';
 import { Autocomplete, Box, Paper, Typography } from '@linode/ui';
 import { createFilterOptions } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
@@ -7,10 +8,7 @@ import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import { DocsLink } from 'src/components/DocsLink/DocsLink';
 import { getDestinationTypeOption } from 'src/features/DataStream/dataStreamUtils';
 import { DestinationLinodeObjectStorageDetailsForm } from 'src/features/DataStream/Shared/DestinationLinodeObjectStorageDetailsForm';
-import {
-  destinationType,
-  destinationTypeOptions,
-} from 'src/features/DataStream/Shared/types';
+import { destinationTypeOptions } from 'src/features/DataStream/Shared/types';
 
 import { type CreateStreamForm } from './types';
 
@@ -22,7 +20,7 @@ type DestinationName = {
 
 export const StreamCreateDelivery = () => {
   const theme = useTheme();
-  const { control } = useFormContext<CreateStreamForm>();
+  const { control, setValue } = useFormContext<CreateStreamForm>();
 
   const [showDestinationForm, setShowDestinationForm] =
     React.useState<boolean>(false);
@@ -100,6 +98,7 @@ export const StreamCreateDelivery = () => {
             label="Destination Name"
             onChange={(_, newValue) => {
               field.onChange(newValue?.label || newValue);
+              setValue('destinations', [newValue?.id as number]);
               setShowDestinationForm(!!newValue?.create);
             }}
             options={destinationNameOptions}

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateGeneralInfo.test.tsx
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateGeneralInfo.test.tsx
@@ -1,3 +1,4 @@
+import { streamType } from '@linode/api-v4';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
@@ -5,7 +6,6 @@ import React from 'react';
 import { renderWithThemeAndHookFormContext } from 'src/utilities/testHelpers';
 
 import { StreamCreateGeneralInfo } from './StreamCreateGeneralInfo';
-import { streamType } from './types';
 
 describe('StreamCreateGeneralInfo', () => {
   it('should render Name input and allow to type text', async () => {

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateGeneralInfo.tsx
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateGeneralInfo.tsx
@@ -1,8 +1,9 @@
+import { streamType } from '@linode/api-v4';
 import { Autocomplete, Paper, TextField, Typography } from '@linode/ui';
 import React from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 
-import { type CreateStreamForm, streamType } from './types';
+import { type CreateStreamForm } from './types';
 
 export const StreamCreateGeneralInfo = () => {
   const { control } = useFormContext<CreateStreamForm>();

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/types.ts
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/types.ts
@@ -1,28 +1,6 @@
+import type { CreateStreamPayload } from '@linode/api-v4';
 import type { CreateDestinationForm } from 'src/features/DataStream/Shared/types';
 
-export const streamType = {
-  AuditLogs: 'audit_logs',
-  LKEAuditLogs: 'lke_audit_logs',
-} as const;
-
-export type StreamType = (typeof streamType)[keyof typeof streamType];
-
-export const streamStatus = {
-  Active: 'active',
-  Inactive: 'inactive',
-} as const;
-
-export type StreamStatus = (typeof streamStatus)[keyof typeof streamStatus];
-
-export interface StreamDetails {
-  cluster_ids?: number[];
-  is_auto_add_all_clusters_enabled?: boolean;
-}
-
-export interface CreateStreamForm extends CreateDestinationForm {
-  destinations: number[];
-  details?: StreamDetails;
-  label: string;
-  status: StreamStatus;
-  type: StreamType;
-}
+export interface CreateStreamForm
+  extends CreateDestinationForm,
+    CreateStreamPayload {}

--- a/packages/manager/src/features/DataStream/Streams/StreamTableRow.tsx
+++ b/packages/manager/src/features/DataStream/Streams/StreamTableRow.tsx
@@ -1,0 +1,45 @@
+import { Hidden } from '@linode/ui';
+import * as React from 'react';
+
+import { DateTimeDisplay } from 'src/components/DateTimeDisplay';
+import { StatusIcon } from 'src/components/StatusIcon/StatusIcon';
+import { TableCell } from 'src/components/TableCell';
+import { TableRow } from 'src/components/TableRow';
+
+import type { Stream, StreamStatus } from '@linode/api-v4';
+
+interface StreamTableRowProps {
+  stream: Stream;
+}
+
+export const StreamTableRow = React.memo((props: StreamTableRowProps) => {
+  const { stream } = props;
+
+  return (
+    <TableRow key={stream.id}>
+      <TableCell>{stream.label}</TableCell>
+      <TableCell statusCell>
+        <StatusIcon status={stream.status} />
+        {humanizeStreamStatus(stream.status)}
+      </TableCell>
+      <TableCell>{stream.id}</TableCell>
+      <TableCell>{stream.destinations[0].label}</TableCell>
+      <Hidden smDown>
+        <TableCell>
+          <DateTimeDisplay value={stream.created} />
+        </TableCell>
+      </Hidden>
+    </TableRow>
+  );
+});
+
+const humanizeStreamStatus = (status: StreamStatus) => {
+  switch (status) {
+    case 'active':
+      return 'Active';
+    case 'inactive':
+      return 'Inactive';
+    default:
+      return 'Unknown';
+  }
+};

--- a/packages/manager/src/features/DataStream/Streams/StreamsLanding.test.tsx
+++ b/packages/manager/src/features/DataStream/Streams/StreamsLanding.test.tsx
@@ -1,0 +1,66 @@
+import { waitForElementToBeRemoved } from '@testing-library/react';
+import * as React from 'react';
+
+import { streamFactory } from 'src/factories/datastream';
+import { StreamsLanding } from 'src/features/DataStream/Streams/StreamsLanding';
+import { makeResourcePage } from 'src/mocks/serverHandlers';
+import { http, HttpResponse, server } from 'src/mocks/testServer';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+const loadingTestId = 'circle-progress';
+
+describe('Streams Landing Table', () => {
+  it('should render streams landing table with items PaginationFooter', async () => {
+    server.use(
+      http.get('*/monitor/streams', () => {
+        return HttpResponse.json(makeResourcePage(streamFactory.buildList(30)));
+      })
+    );
+
+    const { getByText, queryByTestId, getByTestId } = await renderWithTheme(
+      <StreamsLanding />
+    );
+
+    const loadingElement = queryByTestId(loadingTestId);
+    if (loadingElement) {
+      await waitForElementToBeRemoved(loadingElement);
+    }
+
+    // Table column headers
+    getByText('Name');
+    getByText('Status');
+    getByText('ID');
+    getByText('Destination Type');
+
+    // PaginationFooter
+    const paginationFooterSelectPageSizeInput = getByTestId(
+      'textfield-input'
+    ) as HTMLInputElement;
+    expect(paginationFooterSelectPageSizeInput.value).toBe('Show 25');
+  });
+
+  it('should render images landing empty state', async () => {
+    server.use(
+      http.get('*/monitor/streams', () => {
+        return HttpResponse.json(makeResourcePage([]));
+      })
+    );
+
+    const { getByText, queryByTestId } = await renderWithTheme(
+      <StreamsLanding />
+    );
+
+    const loadingElement = queryByTestId(loadingTestId);
+    if (loadingElement) {
+      await waitForElementToBeRemoved(loadingElement);
+    }
+
+    expect(
+      getByText((text) =>
+        text.includes(
+          'Create a data stream and configure delivery of cloud logs'
+        )
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/manager/src/features/DataStream/Streams/StreamsLanding.tsx
+++ b/packages/manager/src/features/DataStream/Streams/StreamsLanding.tsx
@@ -1,7 +1,138 @@
+import { useDataStreamsQuery } from '@linode/queries';
+import { CircleProgress, ErrorState, Hidden } from '@linode/ui';
+import { TableBody, TableCell, TableHead, TableRow } from '@mui/material';
+import Table from '@mui/material/Table';
+import { useNavigate } from '@tanstack/react-router';
 import * as React from 'react';
 
+import { PaginationFooter } from 'src/components/PaginationFooter/PaginationFooter';
+import { TableSortCell } from 'src/components/TableSortCell';
+import { DataStreamTabHeader } from 'src/features/DataStream/Shared/DataStreamTabHeader/DataStreamTabHeader';
+import {
+  STREAMS_TABLE_DEFAULT_ORDER,
+  STREAMS_TABLE_DEFAULT_ORDER_BY,
+  STREAMS_TABLE_PREFERENCE_KEY,
+} from 'src/features/DataStream/Streams/constants';
 import { StreamsLandingEmptyState } from 'src/features/DataStream/Streams/StreamsLandingEmptyState';
+import { StreamTableRow } from 'src/features/DataStream/Streams/StreamTableRow';
+import { useOrderV2 } from 'src/hooks/useOrderV2';
+import { usePaginationV2 } from 'src/hooks/usePaginationV2';
 
 export const StreamsLanding = () => {
-  return <StreamsLandingEmptyState />;
+  const navigate = useNavigate();
+
+  const pagination = usePaginationV2({
+    currentRoute: '/datastream/streams',
+    preferenceKey: STREAMS_TABLE_PREFERENCE_KEY,
+  });
+
+  const { handleOrderChange, order, orderBy } = useOrderV2({
+    initialRoute: {
+      defaultOrder: {
+        order: STREAMS_TABLE_DEFAULT_ORDER,
+        orderBy: STREAMS_TABLE_DEFAULT_ORDER_BY,
+      },
+      from: '/datastream/streams',
+    },
+    preferenceKey: `streams-order`,
+  });
+
+  const filter = {
+    ['+order']: order,
+    ['+order_by']: orderBy,
+  };
+
+  const {
+    data: streams,
+    isLoading,
+    error,
+  } = useDataStreamsQuery(
+    {
+      page: pagination.page,
+      page_size: pagination.pageSize,
+    },
+    filter
+  );
+
+  const navigateToCreate = () => {
+    navigate({ to: '/datastream/streams/create' });
+  };
+
+  if (isLoading) {
+    return <CircleProgress />;
+  }
+
+  if (error) {
+    return (
+      <ErrorState errorText="There was an error retrieving your streams. Please reload and try again." />
+    );
+  }
+
+  if (!streams?.data.length) {
+    return <StreamsLandingEmptyState navigateToCreate={navigateToCreate} />;
+  }
+
+  return (
+    <>
+      <DataStreamTabHeader
+        entity="Stream"
+        loading={isLoading}
+        onButtonClick={navigateToCreate}
+      />
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableSortCell
+              active={orderBy === 'label'}
+              direction={order}
+              handleClick={handleOrderChange}
+              label="label"
+            >
+              Name
+            </TableSortCell>
+            <TableSortCell
+              active={orderBy === 'status'}
+              direction={order}
+              handleClick={handleOrderChange}
+              label="status"
+            >
+              Status
+            </TableSortCell>
+            <TableSortCell
+              active={orderBy === 'id'}
+              direction={order}
+              handleClick={handleOrderChange}
+              label="id"
+            >
+              ID
+            </TableSortCell>
+            <TableCell>Destination Type</TableCell>
+            <Hidden smDown>
+              <TableSortCell
+                active={orderBy === 'created'}
+                direction={order}
+                handleClick={handleOrderChange}
+                label="created"
+              >
+                Creation Time
+              </TableSortCell>
+            </Hidden>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {streams?.data.map((stream) => (
+            <StreamTableRow key={stream.id} stream={stream} />
+          ))}
+        </TableBody>
+      </Table>
+      <PaginationFooter
+        count={streams?.results || 0}
+        eventCategory="Streams Table"
+        handlePageChange={pagination.handlePageChange}
+        handleSizeChange={pagination.handlePageSizeChange}
+        page={pagination.page}
+        pageSize={pagination.pageSize}
+      />
+    </>
+  );
 };

--- a/packages/manager/src/features/DataStream/Streams/StreamsLandingEmptyState.tsx
+++ b/packages/manager/src/features/DataStream/Streams/StreamsLandingEmptyState.tsx
@@ -1,4 +1,3 @@
-import { useNavigate } from '@tanstack/react-router';
 import * as React from 'react';
 
 import ComputeIcon from 'src/assets/icons/entityIcons/compute.svg';
@@ -12,8 +11,14 @@ import {
   linkAnalyticsEvent,
 } from './StreamsLandingEmptyStateData';
 
-export const StreamsLandingEmptyState = () => {
-  const navigate = useNavigate();
+interface StreamsEmptyLandingStateProps {
+  navigateToCreate: () => void;
+}
+
+export const StreamsLandingEmptyState = (
+  props: StreamsEmptyLandingStateProps
+) => {
+  const { navigateToCreate } = props;
 
   return (
     <>
@@ -28,7 +33,7 @@ export const StreamsLandingEmptyState = () => {
                 category: linkAnalyticsEvent.category,
                 label: 'Create Stream',
               });
-              navigate({ to: '/datastream/streams/create' });
+              navigateToCreate();
             },
           },
         ]}

--- a/packages/manager/src/features/DataStream/Streams/constants.ts
+++ b/packages/manager/src/features/DataStream/Streams/constants.ts
@@ -1,0 +1,3 @@
+export const STREAMS_TABLE_DEFAULT_ORDER = 'desc';
+export const STREAMS_TABLE_DEFAULT_ORDER_BY = 'created';
+export const STREAMS_TABLE_PREFERENCE_KEY = 'domains';

--- a/packages/manager/src/features/DataStream/dataStreamUtils.test.ts
+++ b/packages/manager/src/features/DataStream/dataStreamUtils.test.ts
@@ -1,10 +1,8 @@
+import { destinationType } from '@linode/api-v4';
 import { expect } from 'vitest';
 
 import { getDestinationTypeOption } from 'src/features/DataStream/dataStreamUtils';
-import {
-  destinationType,
-  destinationTypeOptions,
-} from 'src/features/DataStream/Shared/types';
+import { destinationTypeOptions } from 'src/features/DataStream/Shared/types';
 
 describe('dataStream utils functions', () => {
   describe('getDestinationTypeOption ', () => {

--- a/packages/manager/src/features/Events/factories/datastream.tsx
+++ b/packages/manager/src/features/Events/factories/datastream.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+
+import { EventLink } from '../EventLink';
+
+import type { PartialEventMap } from '../types';
+
+export const stream: PartialEventMap<'stream'> = {
+  stream_create: {
+    notification: (e) => (
+      <>
+        Stream <EventLink event={e} to="entity" /> has been{' '}
+        <strong>created</strong>.
+      </>
+    ),
+  },
+};

--- a/packages/manager/src/features/Events/factories/index.ts
+++ b/packages/manager/src/features/Events/factories/index.ts
@@ -3,6 +3,7 @@ export * from './backup';
 export * from './community';
 export * from './credit';
 export * from './database';
+export * from './datastream';
 export * from './disk';
 export * from './dns';
 export * from './domain';

--- a/packages/manager/src/mocks/mockState.ts
+++ b/packages/manager/src/mocks/mockState.ts
@@ -42,6 +42,7 @@ export const emptyStore: MockState = {
   placementGroups: [],
   regionAvailability: [],
   regions: [],
+  streams: [],
   subnets: [],
   supportReplies: [],
   supportTickets: [],

--- a/packages/manager/src/mocks/presets/baseline/crud.ts
+++ b/packages/manager/src/mocks/presets/baseline/crud.ts
@@ -1,3 +1,4 @@
+import { datastreamCrudPreset } from 'src/mocks/presets/crud/datastream';
 import {
   getEvents,
   updateEvents,
@@ -22,6 +23,7 @@ export const baselineCrudPreset: MockPresetBaseline = {
   handlers: [
     ...cloudNATCrudPreset.handlers,
     ...domainCrudPreset.handlers,
+    ...datastreamCrudPreset.handlers,
     ...firewallCrudPreset.handlers,
     ...kubernetesCrudPreset.handlers,
     ...linodeCrudPreset.handlers,

--- a/packages/manager/src/mocks/presets/crud/datastream.ts
+++ b/packages/manager/src/mocks/presets/crud/datastream.ts
@@ -1,0 +1,13 @@
+import {
+  createStreams,
+  getStreams,
+} from 'src/mocks/presets/crud/handlers/datastream';
+
+import type { MockPresetCrud } from 'src/mocks/types';
+
+export const datastreamCrudPreset: MockPresetCrud = {
+  group: { id: 'DataStream' },
+  handlers: [getStreams, createStreams],
+  id: 'datastream:crud',
+  label: 'Data Stream CRUD',
+};

--- a/packages/manager/src/mocks/presets/crud/handlers/datastream.ts
+++ b/packages/manager/src/mocks/presets/crud/handlers/datastream.ts
@@ -1,0 +1,94 @@
+import { DateTime } from 'luxon';
+import { http } from 'msw';
+
+import { destinationFactory, streamFactory } from 'src/factories/datastream';
+import { mswDB } from 'src/mocks/indexedDB';
+import { queueEvents } from 'src/mocks/utilities/events';
+import {
+  makeNotFoundResponse,
+  makePaginatedResponse,
+  makeResponse,
+} from 'src/mocks/utilities/response';
+
+import type { Stream } from '@linode/api-v4';
+import type { StrictResponse } from 'msw';
+import type { MockState } from 'src/mocks/types';
+import type {
+  APIErrorResponse,
+  APIPaginatedResponse,
+} from 'src/mocks/utilities/response';
+
+export const getStreams = () => [
+  http.get(
+    '*/v4beta/monitor/streams',
+    async ({
+      request,
+    }): Promise<
+      StrictResponse<APIErrorResponse | APIPaginatedResponse<Stream>>
+    > => {
+      const streams = await mswDB.getAll('streams');
+
+      if (!streams) {
+        return makeNotFoundResponse();
+      }
+
+      return makePaginatedResponse({
+        data: streams,
+        request,
+      });
+    }
+  ),
+  http.get(
+    '*/v4beta/monitor/streams/:id',
+    async ({ params }): Promise<StrictResponse<APIErrorResponse | Stream>> => {
+      const id = Number(params.id);
+      const stream = await mswDB.get('streams', id);
+
+      if (!stream) {
+        return makeNotFoundResponse();
+      }
+
+      return makeResponse(stream);
+    }
+  ),
+];
+
+export const createStreams = (mockState: MockState) => [
+  http.post(
+    '*/v4beta/monitor/streams',
+    async ({ request }): Promise<StrictResponse<APIErrorResponse | Stream>> => {
+      const payload = await request.clone().json();
+      const stream = streamFactory.build({
+        label: payload['label'],
+        type: payload['type'],
+        destinations: payload['destinations'].map((destinationId: number) =>
+          destinationFactory.build({
+            id: destinationId,
+            label: `Destination ${destinationId}`,
+          })
+        ),
+        details: payload['details'],
+        created: DateTime.now().toISO(),
+        updated: DateTime.now().toISO(),
+      });
+
+      await mswDB.add('streams', stream, mockState);
+
+      queueEvents({
+        event: {
+          action: 'stream_create',
+          entity: {
+            id: stream.id,
+            label: stream.label,
+            type: 'stream',
+            url: `/v4beta/datastream/streams`,
+          },
+        },
+        mockState,
+        sequence: [{ status: 'notification' }],
+      });
+
+      return makeResponse(stream);
+    }
+  ),
+];

--- a/packages/manager/src/mocks/types.ts
+++ b/packages/manager/src/mocks/types.ts
@@ -19,6 +19,7 @@ import type {
   PlacementGroup,
   Region,
   RegionAvailability,
+  Stream,
   Subnet,
   SupportReply,
   SupportTicket,
@@ -118,6 +119,7 @@ export interface MockPresetExtra extends MockPresetBase {
 export type MockPresetCrudGroup = {
   id:
     | 'CloudNATs'
+    | 'DataStream'
     | 'Domains'
     | 'Firewalls'
     | 'IP Addresses'
@@ -132,6 +134,7 @@ export type MockPresetCrudGroup = {
 };
 export type MockPresetCrudId =
   | 'cloudnats:crud'
+  | 'datastream:crud'
   | 'domains:crud'
   | 'firewalls:crud'
   | 'ip-addresses:crud'
@@ -175,6 +178,7 @@ export interface MockState {
   placementGroups: PlacementGroup[];
   regionAvailability: RegionAvailability[];
   regions: Region[];
+  streams: Stream[];
   subnets: [number, Subnet][]; // number is VPC ID
   supportReplies: SupportReply[];
   supportTickets: SupportTicket[];

--- a/packages/manager/src/utilities/analytics/customEventAnalytics.ts
+++ b/packages/manager/src/utilities/analytics/customEventAnalytics.ts
@@ -471,3 +471,16 @@ export const sendSupportTicketExitEvent = (label: 'Cancel' | 'Close') => {
     label: `Click:${label}`,
   });
 };
+
+// StreamCreate.tsx
+// @TODO (DPS-34191) add this event to Pendo
+export const sendCreateStreamEvent = (
+  eventLabel: string,
+  eventAction?: string
+): void => {
+  sendEvent({
+    action: eventAction || 'Create Stream',
+    category: 'Create Stream',
+    label: eventLabel,
+  });
+};

--- a/packages/queries/.changeset/pr-12524-upcoming-features-1753170309109.md
+++ b/packages/queries/.changeset/pr-12524-upcoming-features-1753170309109.md
@@ -1,0 +1,5 @@
+---
+"@linode/queries": Upcoming Features
+---
+
+Add queries for streams endpoints (GET, POST) ([#12524](https://github.com/linode/manager/pull/12524))

--- a/packages/queries/src/datastreams/datastream.ts
+++ b/packages/queries/src/datastreams/datastream.ts
@@ -1,0 +1,76 @@
+import {
+  type APIError,
+  createStream,
+  getStream,
+  getStreams,
+} from '@linode/api-v4';
+import { profileQueries } from '@linode/queries';
+import { getAll } from '@linode/utilities';
+import { createQueryKeys } from '@lukemorales/query-key-factory';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import type {
+  CreateStreamPayload,
+  Filter,
+  Params,
+  ResourcePage,
+  Stream,
+} from '@linode/api-v4';
+
+export const getAllDataStreams = (
+  passedParams: Params = {},
+  passedFilter: Filter = {},
+) =>
+  getAll<Stream>((params, filter) =>
+    getStreams({ ...params, ...passedParams }, { ...filter, ...passedFilter }),
+  )().then((data) => data.data);
+
+export const datastreamQueries = createQueryKeys('datastream', {
+  stream: (id: number) => ({
+    queryFn: () => getStream(id),
+    queryKey: [id],
+  }),
+  streams: {
+    contextQueries: {
+      all: (params: Params = {}, filter: Filter = {}) => ({
+        queryFn: () => getAllDataStreams(params, filter),
+        queryKey: [params, filter],
+      }),
+      paginated: (params: Params, filter: Filter) => ({
+        queryFn: () => getStreams(params, filter),
+        queryKey: [params, filter],
+      }),
+    },
+    queryKey: null,
+  },
+  // @TODO (DPS-34038) destinations
+});
+
+export const useDataStreamsQuery = (params: Params = {}, filter: Filter = {}) =>
+  useQuery<ResourcePage<Stream>, APIError[]>({
+    ...datastreamQueries.streams._ctx.paginated(params, filter),
+  });
+
+export const useCreateStreamMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation<Stream, APIError[], CreateStreamPayload>({
+    mutationFn: createStream,
+    onSuccess(stream) {
+      // Invalidate paginated lists
+      queryClient.invalidateQueries({
+        queryKey: datastreamQueries.streams._ctx.paginated._def,
+      });
+
+      // Set Stream in cache
+      queryClient.setQueryData(
+        datastreamQueries.stream(stream.id).queryKey,
+        stream,
+      );
+
+      // If a restricted user creates an entity, we must make sure grants are up to date.
+      queryClient.invalidateQueries({
+        queryKey: profileQueries.grants.queryKey,
+      });
+    },
+  });
+};

--- a/packages/queries/src/datastreams/index.ts
+++ b/packages/queries/src/datastreams/index.ts
@@ -1,0 +1,1 @@
+export * from './datastream';

--- a/packages/queries/src/index.ts
+++ b/packages/queries/src/index.ts
@@ -3,6 +3,7 @@ export * from './base';
 export * from './betas';
 export * from './cloudnats';
 export * from './databases';
+export * from './datastreams';
 export * from './domains';
 export * from './entitytransfers';
 export * from './eventHandlers';


### PR DESCRIPTION
## Description 📝

DataStream: Streams list

## Changes  🔄

- Streams tab view changed from Empty state to Streams list if any exist
- Streams mock API handlers for requests:
  - GET (`/monitor/streams`, `/monitor/streams/:id`)
  - POST (`/monitor/streams`) 

## Target release date 🗓️

August 2025

## Preview 📷

| Before  | After   |
| ------- | ------ |
|![before](https://github.com/user-attachments/assets/0a2bf9f5-fd78-4872-b383-52f62b9af222)|![after](https://github.com/user-attachments/assets/4969faca-17a0-4932-ae6e-c363d3ef9c8d)|

## How to test 🧪

### Prerequisites

- Open Local Dev Tools
- Enable MSW, set Base Preset to CRUD
- Apply

### Verification steps

- Navigate to datastream/streams
- Click on Create Stream button
- Fill Name filed and choose existing Destination Name
- Click on Create Stream button
- Page should redirect to datastream/streams and table view with created stream should be rendered

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
📱 Providing mobile support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>