### PR TITLE
[M3-10318] - Improve Tabs Lazy Loading - Profile + Account

### DIFF
--- a/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.tsx
+++ b/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.tsx
@@ -60,8 +60,12 @@ export const PaymentMethodRow = (props: Props) => {
       disabled: isRestrictedUser,
       onClick: () => {
         navigate({
-          to: '/account/billing/make-payment',
-          search: { paymentMethod },
+          to: '/account/billing',
+          search: (prev) => ({
+            ...prev,
+            action: 'make-payment',
+            paymentMethod,
+          }),
         });
       },
       title: 'Make a Payment',

--- a/packages/manager/src/features/Account/Maintenance/maintenanceLandingLazyRoute.ts
+++ b/packages/manager/src/features/Account/Maintenance/maintenanceLandingLazyRoute.ts
@@ -1,0 +1,9 @@
+import { createLazyRoute } from '@tanstack/react-router';
+
+import MaintenanceLanding from './MaintenanceLanding';
+
+export const maintenanceLandingLazyRoute = createLazyRoute(
+  '/account/maintenance'
+)({
+  component: MaintenanceLanding,
+});

--- a/packages/manager/src/features/Account/Quotas/quotasLazyRoute.tsx
+++ b/packages/manager/src/features/Account/Quotas/quotasLazyRoute.tsx
@@ -1,0 +1,21 @@
+import { createLazyRoute, Navigate } from '@tanstack/react-router';
+import * as React from 'react';
+
+import { useFlags } from 'src/hooks/useFlags';
+
+import { Quotas } from './Quotas';
+
+const QuotasComponent = () => {
+  const flags = useFlags();
+  const showQuotasTab = flags.limitsEvolution?.enabled ?? false;
+
+  if (!showQuotasTab) {
+    return <Navigate to="/account" />;
+  }
+
+  return <Quotas />;
+};
+
+export const quotasLazyRoute = createLazyRoute('/account/quotas')({
+  component: QuotasComponent,
+});

--- a/packages/manager/src/features/Account/accountLoginsLazyRoute.ts
+++ b/packages/manager/src/features/Account/accountLoginsLazyRoute.ts
@@ -1,0 +1,9 @@
+import { createLazyRoute } from '@tanstack/react-router';
+
+import AccountLogins from './AccountLogins';
+
+export const accountLoginsLazyRoute = createLazyRoute('/account/login-history')(
+  {
+    component: AccountLogins,
+  }
+);

--- a/packages/manager/src/features/Account/globalSettingsLazyRoute.ts
+++ b/packages/manager/src/features/Account/globalSettingsLazyRoute.ts
@@ -1,0 +1,7 @@
+import { createLazyRoute } from '@tanstack/react-router';
+
+import GlobalSettings from './GlobalSettings';
+
+export const globalSettingsLazyRoute = createLazyRoute('/account/settings')({
+  component: GlobalSettings,
+});

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
@@ -7,7 +7,7 @@ import {
 import { Box, Button, Divider, TooltipIcon, Typography } from '@linode/ui';
 import Grid from '@mui/material/Grid';
 import { useTheme } from '@mui/material/styles';
-import { useMatch, useNavigate, useSearch } from '@tanstack/react-router';
+import { useNavigate, useSearch } from '@tanstack/react-router';
 import * as React from 'react';
 
 import { Currency } from 'src/components/Currency';
@@ -54,13 +54,12 @@ export const BillingSummary = (props: BillingSummaryProps) => {
   const { balance, balanceUninvoiced, paymentMethods, promotions } = props;
 
   const navigate = useNavigate();
-  const match = useMatch({ strict: false });
-  const { paymentMethod } = useSearch({
-    strict: false,
+  const search = useSearch({
+    from: '/account/billing',
   });
+  const { paymentMethod } = search;
 
-  const routeForMakePayment = '/account/billing/make-payment';
-  const makePaymentRouteMatch = match?.routeId === routeForMakePayment;
+  const makePaymentRouteMatch = search.action === 'make-payment';
 
   const [paymentDrawerOpen, setPaymentDrawerOpen] =
     React.useState<boolean>(false);
@@ -131,7 +130,15 @@ export const BillingSummary = (props: BillingSummaryProps) => {
     balance > 0 ? (
       <Typography style={{ marginTop: 16 }}>
         <Button
-          onClick={() => navigate({ to: routeForMakePayment })}
+          onClick={() =>
+            navigate({
+              to: '/account/billing',
+              search: (prev) => ({
+                ...prev,
+                action: 'make-payment',
+              }),
+            })
+          }
           sx={{
             ...theme.applyLinkStyles,
             verticalAlign: 'initial',

--- a/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/ContactInformation.tsx
@@ -84,8 +84,13 @@ export const ContactInformation = React.memo((props: Props) => {
 
   const handleEditDrawerOpen = () => {
     navigate({
-      to: '/account/billing/edit',
-      search: { contactDrawerOpen: true, focusEmail: false },
+      to: '/account/billing',
+      search: (prev) => ({
+        ...prev,
+        action: 'edit',
+        contactDrawerOpen: true,
+        focusEmail: false,
+      }),
     });
   };
 

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.tsx
@@ -3,7 +3,7 @@ import { accountQueries } from '@linode/queries';
 import { Typography } from '@linode/ui';
 import Grid from '@mui/material/Grid';
 import { useQueryClient } from '@tanstack/react-query';
-import { useMatch, useNavigate } from '@tanstack/react-router';
+import { useNavigate, useSearch } from '@tanstack/react-router';
 import * as React from 'react';
 
 import { DeletePaymentMethodDialog } from 'src/components/PaymentMethodRow/DeletePaymentMethodDialog';
@@ -34,9 +34,9 @@ interface Props {
 
 const PaymentInformation = (props: Props) => {
   const { error, isAkamaiCustomer, loading, paymentMethods, profile } = props;
+  const search = useSearch({ from: '/account/billing' });
   const [addDrawerOpen, setAddDrawerOpen] = React.useState<boolean>(false);
   const navigate = useNavigate();
-  const match = useMatch({ strict: false });
   const [deleteDialogOpen, setDeleteDialogOpen] =
     React.useState<boolean>(false);
   const [deleteError, setDeleteError] = React.useState<string | undefined>();
@@ -44,8 +44,7 @@ const PaymentInformation = (props: Props) => {
   const [deletePaymentMethodSelection, setDeletePaymentMethodSelection] =
     React.useState<PaymentMethod | undefined>();
   const queryClient = useQueryClient();
-  const addPaymentMethodRouteMatch =
-    match.routeId === '/account/billing/add-payment-method';
+  const addPaymentMethodRouteMatch = search.action === 'add-payment-method';
 
   const isChildUser = profile?.user_type === 'child';
 
@@ -114,7 +113,13 @@ const PaymentInformation = (props: Props) => {
               disableRipple
               disableTouchRipple
               onClick={() =>
-                navigate({ to: '/account/billing/add-payment-method' })
+                navigate({
+                  to: '/account/billing',
+                  search: (prev) => ({
+                    ...prev,
+                    action: 'add-payment-method',
+                  }),
+                })
               }
               tooltipText={getRestrictedResourceText({
                 includeContactInfo: false,

--- a/packages/manager/src/features/Billing/billingDetailLazyRoute.ts
+++ b/packages/manager/src/features/Billing/billingDetailLazyRoute.ts
@@ -1,0 +1,7 @@
+import { createLazyRoute } from '@tanstack/react-router';
+
+import { BillingDetail } from './BillingDetail';
+
+export const billingDetailLazyRoute = createLazyRoute('/account/billing')({
+  component: BillingDetail,
+});

--- a/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/entityTransferLandingLazyRoute.ts
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/entityTransferLandingLazyRoute.ts
@@ -1,0 +1,9 @@
+import { createLazyRoute } from '@tanstack/react-router';
+
+import { EntityTransfersLanding } from './EntityTransfersLanding';
+
+export const entityTransferLandingLazyRoute = createLazyRoute(
+  '/account/service-transfers'
+)({
+  component: EntityTransfersLanding,
+});

--- a/packages/manager/src/features/Profile/APITokens/apiTokensLazyRoute.ts
+++ b/packages/manager/src/features/Profile/APITokens/apiTokensLazyRoute.ts
@@ -1,0 +1,7 @@
+import { createLazyRoute } from '@tanstack/react-router';
+
+import { APITokens } from './APITokens';
+
+export const apiTokensLazyRoute = createLazyRoute('/profile/tokens')({
+  component: APITokens,
+});

--- a/packages/manager/src/features/Profile/AuthenticationSettings/authenicationSettingsLazyRoute.ts
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/authenicationSettingsLazyRoute.ts
@@ -1,0 +1,9 @@
+import { createLazyRoute } from '@tanstack/react-router';
+
+import { AuthenticationSettings } from './AuthenticationSettings';
+
+export const authenticationSettingsLazyRoute = createLazyRoute('/profile/auth')(
+  {
+    component: AuthenticationSettings,
+  }
+);

--- a/packages/manager/src/features/Profile/DisplaySettings/displaySettingsLazyRoute.ts
+++ b/packages/manager/src/features/Profile/DisplaySettings/displaySettingsLazyRoute.ts
@@ -1,0 +1,7 @@
+import { createLazyRoute } from '@tanstack/react-router';
+
+import { DisplaySettings } from './DisplaySettings';
+
+export const displaySettingsLazyRoute = createLazyRoute('/profile/display')({
+  component: DisplaySettings,
+});

--- a/packages/manager/src/features/Profile/LishSettings/lishSettingsLazyRoute.ts
+++ b/packages/manager/src/features/Profile/LishSettings/lishSettingsLazyRoute.ts
@@ -1,0 +1,7 @@
+import { createLazyRoute } from '@tanstack/react-router';
+
+import { LishSettings } from './LishSettings';
+
+export const lishSettingsLazyRoute = createLazyRoute('/profile/lish')({
+  component: LishSettings,
+});

--- a/packages/manager/src/features/Profile/OAuthClients/oAuthClientsLazyRoute.ts
+++ b/packages/manager/src/features/Profile/OAuthClients/oAuthClientsLazyRoute.ts
@@ -1,0 +1,7 @@
+import { createLazyRoute } from '@tanstack/react-router';
+
+import OAuthClients from './OAuthClients';
+
+export const oAuthClientsLazyRoute = createLazyRoute('/profile/clients')({
+  component: OAuthClients,
+});

--- a/packages/manager/src/features/Profile/Profile.tsx
+++ b/packages/manager/src/features/Profile/Profile.tsx
@@ -1,50 +1,13 @@
+import { Outlet } from '@tanstack/react-router';
 import * as React from 'react';
 
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { LandingHeader } from 'src/components/LandingHeader';
 import { SuspenseLoader } from 'src/components/SuspenseLoader';
-import { SafeTabPanel } from 'src/components/Tabs/SafeTabPanel';
 import { TabPanels } from 'src/components/Tabs/TabPanels';
 import { Tabs } from 'src/components/Tabs/Tabs';
 import { TanStackTabLinkList } from 'src/components/Tabs/TanStackTabLinkList';
 import { useTabs } from 'src/hooks/useTabs';
-
-const SSHKeys = React.lazy(() =>
-  import('./SSHKeys/SSHKeys').then((module) => ({
-    default: module.SSHKeys,
-  }))
-);
-const Settings = React.lazy(() =>
-  import('./Settings/Settings').then((module) => ({
-    default: module.ProfileSettings,
-  }))
-);
-const Referrals = React.lazy(() =>
-  import('./Referrals/Referrals').then((module) => ({
-    default: module.Referrals,
-  }))
-);
-const OAuthClients = React.lazy(() => import('./OAuthClients/OAuthClients'));
-const LishSettings = React.lazy(() =>
-  import('./LishSettings/LishSettings').then((module) => ({
-    default: module.LishSettings,
-  }))
-);
-const DisplaySettings = React.lazy(() =>
-  import('./DisplaySettings/DisplaySettings').then((module) => ({
-    default: module.DisplaySettings,
-  }))
-);
-const AuthenticationSettings = React.lazy(() =>
-  import('./AuthenticationSettings/AuthenticationSettings').then((module) => ({
-    default: module.AuthenticationSettings,
-  }))
-);
-const APITokens = React.lazy(() =>
-  import('./APITokens/APITokens').then((module) => ({
-    default: module.APITokens,
-  }))
-);
 
 export const Profile = () => {
   const { tabs, handleTabChange, tabIndex } = useTabs([
@@ -90,30 +53,7 @@ export const Profile = () => {
         <TanStackTabLinkList tabs={tabs} />
         <React.Suspense fallback={<SuspenseLoader />}>
           <TabPanels>
-            <SafeTabPanel index={0}>
-              <DisplaySettings />
-            </SafeTabPanel>
-            <SafeTabPanel index={1}>
-              <AuthenticationSettings />
-            </SafeTabPanel>
-            <SafeTabPanel index={2}>
-              <SSHKeys />
-            </SafeTabPanel>
-            <SafeTabPanel index={3}>
-              <LishSettings />
-            </SafeTabPanel>
-            <SafeTabPanel index={4}>
-              <APITokens />
-            </SafeTabPanel>
-            <SafeTabPanel index={5}>
-              <OAuthClients />
-            </SafeTabPanel>
-            <SafeTabPanel index={6}>
-              <Referrals />
-            </SafeTabPanel>
-            <SafeTabPanel index={7}>
-              <Settings />
-            </SafeTabPanel>
+            <Outlet />
           </TabPanels>
         </React.Suspense>
       </Tabs>

--- a/packages/manager/src/features/Profile/Profile.tsx
+++ b/packages/manager/src/features/Profile/Profile.tsx
@@ -51,11 +51,11 @@ export const Profile = () => {
       <LandingHeader removeCrumbX={1} title="My Profile" />
       <Tabs index={tabIndex} onChange={handleTabChange}>
         <TanStackTabLinkList tabs={tabs} />
-        <React.Suspense fallback={<SuspenseLoader />}>
-          <TabPanels>
+        <TabPanels>
+          <React.Suspense fallback={<SuspenseLoader />}>
             <Outlet />
-          </TabPanels>
-        </React.Suspense>
+          </React.Suspense>
+        </TabPanels>
       </Tabs>
     </React.Fragment>
   );

--- a/packages/manager/src/features/Profile/Referrals/referralsLazyRoute.ts
+++ b/packages/manager/src/features/Profile/Referrals/referralsLazyRoute.ts
@@ -1,0 +1,7 @@
+import { createLazyRoute } from '@tanstack/react-router';
+
+import { Referrals } from './Referrals';
+
+export const referralsLazyRoute = createLazyRoute('/profile/referrals')({
+  component: Referrals,
+});

--- a/packages/manager/src/features/Profile/SSHKeys/sshKeysLazyRoute.ts
+++ b/packages/manager/src/features/Profile/SSHKeys/sshKeysLazyRoute.ts
@@ -1,0 +1,7 @@
+import { createLazyRoute } from '@tanstack/react-router';
+
+import { SSHKeys } from './SSHKeys';
+
+export const sshKeysLazyRoute = createLazyRoute('/profile/keys')({
+  component: SSHKeys,
+});

--- a/packages/manager/src/features/Profile/Settings/settingsLazyRoute.ts
+++ b/packages/manager/src/features/Profile/Settings/settingsLazyRoute.ts
@@ -1,0 +1,7 @@
+import { createLazyRoute } from '@tanstack/react-router';
+
+import { ProfileSettings } from './Settings';
+
+export const settingsLazyRoute = createLazyRoute('/profile/settings')({
+  component: ProfileSettings,
+});

--- a/packages/manager/src/features/Users/userDetailLazyRoute.ts
+++ b/packages/manager/src/features/Users/userDetailLazyRoute.ts
@@ -1,6 +1,6 @@
 import { createLazyRoute } from '@tanstack/react-router';
 
-import { UserDetail } from 'src/features/Users/UserDetail';
+import { UserDetail } from './UserDetail';
 
 export const userDetailLazyRoute = createLazyRoute('/account/users/$username')({
   component: UserDetail,

--- a/packages/manager/src/features/Users/usersLandingLazyRoute.ts
+++ b/packages/manager/src/features/Users/usersLandingLazyRoute.ts
@@ -1,0 +1,7 @@
+import { createLazyRoute } from '@tanstack/react-router';
+
+import { UsersLanding } from './UsersLanding';
+
+export const usersLandingLazyRoute = createLazyRoute('/account/users')({
+  component: UsersLanding,
+});

--- a/packages/manager/src/routes/account/index.ts
+++ b/packages/manager/src/routes/account/index.ts
@@ -1,16 +1,13 @@
-import { createRoute, redirect } from '@tanstack/react-router';
+import { createRoute } from '@tanstack/react-router';
 
 import { rootRoute } from '../root';
 import { AccountRoute } from './AccountRoute';
 
 import type { PaymentMethod } from '@linode/api-v4';
-
 interface AccountBillingSearch {
+  action?: 'add-payment-method' | 'edit' | 'make-payment';
   contactDrawerOpen?: boolean;
   focusEmail?: boolean;
-}
-
-interface AccountBillingMakePaymentSearch {
   paymentMethod?: PaymentMethod;
 }
 
@@ -18,16 +15,6 @@ const accountRoute = createRoute({
   component: AccountRoute,
   getParentRoute: () => rootRoute,
   path: 'account',
-});
-
-const accountIndexRoute = createRoute({
-  getParentRoute: () => accountRoute,
-  path: '/',
-  beforeLoad: () => {
-    throw redirect({
-      to: '/account/billing',
-    });
-  },
 }).lazy(() =>
   import('src/features/Account/accountLandingLazyRoute').then(
     (m) => m.accountLandingLazyRoute
@@ -39,8 +26,8 @@ const accountBillingRoute = createRoute({
   path: 'billing',
   validateSearch: (search: AccountBillingSearch) => search,
 }).lazy(() =>
-  import('src/features/Account/accountLandingLazyRoute').then(
-    (m) => m.accountLandingLazyRoute
+  import('src/features/Billing/billingDetailLazyRoute').then(
+    (m) => m.billingDetailLazyRoute
   )
 );
 
@@ -48,8 +35,8 @@ const accountUsersRoute = createRoute({
   getParentRoute: () => accountRoute,
   path: '/users',
 }).lazy(() =>
-  import('src/features/Account/accountLandingLazyRoute').then(
-    (m) => m.accountLandingLazyRoute
+  import('src/features/Users/usersLandingLazyRoute').then(
+    (m) => m.usersLandingLazyRoute
   )
 );
 
@@ -57,8 +44,8 @@ const accountQuotasRoute = createRoute({
   getParentRoute: () => accountRoute,
   path: '/quotas',
 }).lazy(() =>
-  import('src/features/Account/accountLandingLazyRoute').then(
-    (m) => m.accountLandingLazyRoute
+  import('src/features/Account/Quotas/quotasLazyRoute').then(
+    (m) => m.quotasLazyRoute
   )
 );
 
@@ -66,8 +53,8 @@ const accountLoginHistoryRoute = createRoute({
   getParentRoute: () => accountRoute,
   path: '/login-history',
 }).lazy(() =>
-  import('src/features/Account/accountLandingLazyRoute').then(
-    (m) => m.accountLandingLazyRoute
+  import('src/features/Account/accountLoginsLazyRoute').then(
+    (m) => m.accountLoginsLazyRoute
   )
 );
 
@@ -75,17 +62,17 @@ const accountServiceTransfersRoute = createRoute({
   getParentRoute: () => accountRoute,
   path: '/service-transfers',
 }).lazy(() =>
-  import('src/features/Account/accountLandingLazyRoute').then(
-    (m) => m.accountLandingLazyRoute
-  )
+  import(
+    'src/features/EntityTransfers/EntityTransfersLanding/entityTransferLandingLazyRoute'
+  ).then((m) => m.entityTransferLandingLazyRoute)
 );
 
 const accountMaintenanceRoute = createRoute({
   getParentRoute: () => accountRoute,
   path: '/maintenance',
 }).lazy(() =>
-  import('src/features/Account/accountLandingLazyRoute').then(
-    (m) => m.accountLandingLazyRoute
+  import('src/features/Account/Maintenance/maintenanceLandingLazyRoute').then(
+    (m) => m.maintenanceLandingLazyRoute
   )
 );
 
@@ -93,14 +80,14 @@ const accountSettingsRoute = createRoute({
   getParentRoute: () => accountRoute,
   path: '/settings',
 }).lazy(() =>
-  import('src/features/Account/accountLandingLazyRoute').then(
-    (m) => m.accountLandingLazyRoute
+  import('src/features/Account/globalSettingsLazyRoute').then(
+    (m) => m.globalSettingsLazyRoute
   )
 );
 
 const accountUsersUsernameRoute = createRoute({
-  getParentRoute: () => accountRoute,
-  path: 'users/$username',
+  getParentRoute: () => rootRoute,
+  path: 'account/users/$username',
 }).lazy(() =>
   import('src/features/Users/userDetailLazyRoute').then(
     (m) => m.userDetailLazyRoute
@@ -122,34 +109,6 @@ const accountUsersUsernamePermissionsRoute = createRoute({
 }).lazy(() =>
   import('src/features/Users/userDetailLazyRoute').then(
     (m) => m.userDetailLazyRoute
-  )
-);
-
-const accountBillingMakePaymentRoute = createRoute({
-  getParentRoute: () => accountRoute,
-  path: 'billing/make-payment',
-  validateSearch: (search: AccountBillingMakePaymentSearch) => search,
-}).lazy(() =>
-  import('src/features/Account/accountLandingLazyRoute').then(
-    (m) => m.accountLandingLazyRoute
-  )
-);
-
-const accountBillingPaymentMethodsRoute = createRoute({
-  getParentRoute: () => accountRoute,
-  path: 'billing/add-payment-method',
-}).lazy(() =>
-  import('src/features/Account/accountLandingLazyRoute').then(
-    (m) => m.accountLandingLazyRoute
-  )
-);
-
-const accountBillingEditRoute = createRoute({
-  getParentRoute: () => accountRoute,
-  path: 'billing/edit',
-}).lazy(() =>
-  import('src/features/Account/accountLandingLazyRoute').then(
-    (m) => m.accountLandingLazyRoute
   )
 );
 
@@ -175,7 +134,6 @@ const accountEntityTransfersCreateRoute = createRoute({
 );
 
 export const accountRouteTree = accountRoute.addChildren([
-  accountIndexRoute,
   accountUsersRoute,
   accountQuotasRoute,
   accountLoginHistoryRoute,
@@ -187,9 +145,6 @@ export const accountRouteTree = accountRoute.addChildren([
     accountUsersUsernamePermissionsRoute,
   ]),
   accountBillingRoute,
-  accountBillingMakePaymentRoute,
-  accountBillingPaymentMethodsRoute,
-  accountBillingEditRoute,
   accountInvoicesInvoiceIdRoute,
   accountEntityTransfersCreateRoute,
 ]);

--- a/packages/manager/src/routes/profile/index.ts
+++ b/packages/manager/src/routes/profile/index.ts
@@ -31,44 +31,76 @@ const profileDisplaySettingsRoute = createRoute({
   getParentRoute: () => profileRoute,
   path: 'display',
   validateSearch: (search: ProfileDisplaySettingsSearchParams) => search,
-});
+}).lazy(() =>
+  import('src/features/Profile/DisplaySettings/displaySettingsLazyRoute').then(
+    (m) => m.displaySettingsLazyRoute
+  )
+);
 
 const profileAuthenticationSettingsRoute = createRoute({
   getParentRoute: () => profileRoute,
   path: 'auth',
   validateSearch: (search: ProfileAuthenticationSettingsSearchParams) => search,
-});
+}).lazy(() =>
+  import(
+    'src/features/Profile/AuthenticationSettings/authenicationSettingsLazyRoute'
+  ).then((m) => m.authenticationSettingsLazyRoute)
+);
 
 const profileSSHKeysRoute = createRoute({
   getParentRoute: () => profileRoute,
   path: 'keys',
-});
+}).lazy(() =>
+  import('src/features/Profile/SSHKeys/sshKeysLazyRoute').then(
+    (m) => m.sshKeysLazyRoute
+  )
+);
 
 const profileLishSettingsRoute = createRoute({
   getParentRoute: () => profileRoute,
   path: 'lish',
-});
+}).lazy(() =>
+  import('src/features/Profile/LishSettings/lishSettingsLazyRoute').then(
+    (m) => m.lishSettingsLazyRoute
+  )
+);
 
 const profileAPITokensRoute = createRoute({
   getParentRoute: () => profileRoute,
   path: 'tokens',
-});
+}).lazy(() =>
+  import('src/features/Profile/APITokens/apiTokensLazyRoute').then(
+    (m) => m.apiTokensLazyRoute
+  )
+);
 
 const profileOAuthClientsRoute = createRoute({
   getParentRoute: () => profileRoute,
   path: 'clients',
-});
+}).lazy(() =>
+  import('src/features/Profile/OAuthClients/oAuthClientsLazyRoute').then(
+    (m) => m.oAuthClientsLazyRoute
+  )
+);
 
 const profileReferralsRoute = createRoute({
   getParentRoute: () => profileRoute,
   path: 'referrals',
-});
+}).lazy(() =>
+  import('src/features/Profile/Referrals/referralsLazyRoute').then(
+    (m) => m.referralsLazyRoute
+  )
+);
 
 const profileSettingsRoute = createRoute({
   getParentRoute: () => profileRoute,
   path: 'settings',
   validateSearch: (search: ProfileSettingsSearchParams) => search,
-});
+}).lazy(() =>
+  import('src/features/Profile/Settings/settingsLazyRoute').then(
+    (m) => m.settingsLazyRoute
+  )
+);
 
 export const profileRouteTree = profileRoute.addChildren([
   profileAuthenticationSettingsRoute,


### PR DESCRIPTION
## Description 📝
Following https://github.com/linode/manager/pull/12506, this is part 1 of several PRs ensuring our routed tabs lazy load bundles and prefetch them on hover.

We should see immediate performance improvements from this PR, as we will fetch much less bundles for landing pages with tabs 🎉 , and since other tabs bundles are prefetched and preloaded.

It will be done for every routed Tabs, but broken down to allow for quicker reviews.

This will prepare the routing refactor for its final stages and allow the complete removal of `react-router-dom`.

## Changes  🔄
- Route Tabs
- Improve routing to use search params for modals (only when implemented already)
- Fix tests as needed

## Preview 📷
There should be no visual or functional regression as a result of this PR.

## How to test 🧪

### Prerequisites
- use localhost to be able to see bundle names

### Reproduction steps
(this is one example of reproduction, which can be reproduced across 
- Navigate to http://localhost:3000/account/billing
- In your browser dev tools, open your Network tab and allow to see All requests (including JS bundles)
- Enter `UsersLanding.tsx` in your request filter
- Reload page
- Confirm it loaded on page load


### Verification steps
- Navigate to http://localhost:3000/account/billing
- In your browser dev tools, open your Network tab and allow to see All requests (including JS bundles)
- Enter `UsersLanding.tsx` in your request filter
- Reload page
- Confirm the bundle isn't loaded
- Hover "Users & Grants" tab
- Confirm it is prefetched on demand

⚠️ CONFIRM NO REGRESSION WITH THE FEATURE AS A WHOLE

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support
</details>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules
