### PR TITLE
feat: [UIE-8870] - IAM RBAC: add a permission check for firewalls rules

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRulesLanding.test.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRulesLanding.test.tsx
@@ -1,0 +1,191 @@
+import React from 'react';
+
+import { firewallRulesFactory } from 'src/factories/firewalls';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { FirewallRulesLanding } from './FirewallRulesLanding';
+
+const queryMocks = vi.hoisted(() => ({
+  userPermissions: vi.fn(() => ({
+    permissions: {
+      update_firewall_rules: false,
+    },
+  })),
+  useNavigate: vi.fn(),
+  useLocation: vi.fn(),
+  useBlocker: vi.fn(() => ({
+    proceed: vi.fn(),
+    reset: vi.fn(),
+    status: 'unblocked',
+  })),
+}));
+
+vi.mock('src/features/IAM/hooks/usePermissions', () => ({
+  usePermissions: queryMocks.userPermissions,
+}));
+
+vi.mock('@tanstack/react-router', async () => {
+  const actual = await vi.importActual('@tanstack/react-router');
+  return {
+    ...actual,
+    useNavigate: queryMocks.useNavigate,
+    useLocation: vi.fn(() => ({
+      pathname: '/firewalls/1/rules',
+    })),
+    useBlocker: queryMocks.useBlocker,
+  };
+});
+
+const firewallRules = firewallRulesFactory.build();
+const getDisabledState = () =>
+  !queryMocks.userPermissions().permissions.update_firewall_rules;
+
+describe('FirewallRuleTable', () => {
+  it('should disable "Add AN Inbound Rule" button if the user does not have update_firewall_rules permission', () => {
+    const { getByRole } = renderWithTheme(
+      <FirewallRulesLanding
+        disabled={getDisabledState()}
+        firewallID={1}
+        rules={firewallRules}
+      />
+    );
+
+    const addInboundBtn = getByRole('button', { name: 'Add an Inbound Rule' });
+
+    expect(addInboundBtn).toBeInTheDocument();
+    expect(addInboundBtn).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('should disable "Add AN Outbound Rule" button if the user does not have update_firewall_rules permission', () => {
+    const { getByRole } = renderWithTheme(
+      <FirewallRulesLanding
+        disabled={getDisabledState()}
+        firewallID={1}
+        rules={firewallRules}
+      />
+    );
+
+    const addOutboundBtn = getByRole('button', {
+      name: 'Add an Outbound Rule',
+    });
+    expect(addOutboundBtn).toBeInTheDocument();
+    expect(addOutboundBtn).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('should disable "Save Changes" button if the user does not have update_firewall_rules permission', () => {
+    const { getByRole } = renderWithTheme(
+      <FirewallRulesLanding
+        disabled={getDisabledState()}
+        firewallID={1}
+        rules={firewallRules}
+      />
+    );
+
+    const saveBtn = getByRole('button', { name: 'Save Changes' });
+
+    expect(saveBtn).toBeInTheDocument();
+    expect(saveBtn).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('should disable menu buttons if the user does not have update_firewall_rules permission', () => {
+    const { getAllByRole } = renderWithTheme(
+      <FirewallRulesLanding
+        disabled={getDisabledState()}
+        firewallID={1}
+        rules={firewallRules}
+      />
+    );
+
+    const editBtns = getAllByRole('button', {
+      name: 'Edit',
+    });
+    expect(editBtns[0]).toBeVisible();
+    expect(editBtns[0]).toHaveAttribute('aria-disabled', 'true');
+
+    const cloneBtns = getAllByRole('button', {
+      name: 'Clone',
+    });
+    expect(cloneBtns[0]).toBeVisible();
+    expect(cloneBtns[0]).toHaveAttribute('aria-disabled', 'true');
+
+    const deleteBtns = getAllByRole('button', {
+      name: 'Delete',
+    });
+    expect(deleteBtns[0]).toBeVisible();
+    expect(deleteBtns[0]).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('should enable menu buttons if the user has update_firewall_rules permission', () => {
+    queryMocks.userPermissions.mockReturnValue({
+      permissions: {
+        update_firewall_rules: true,
+      },
+    });
+    const { getAllByRole } = renderWithTheme(
+      <FirewallRulesLanding
+        disabled={getDisabledState()}
+        firewallID={1}
+        rules={firewallRules}
+      />
+    );
+
+    const editBtns = getAllByRole('button', {
+      name: 'Edit',
+    });
+    expect(editBtns[0]).toBeVisible();
+    expect(editBtns[0]).not.toHaveAttribute('aria-disabled', 'true');
+
+    const cloneBtns = getAllByRole('button', {
+      name: 'Clone',
+    });
+    expect(cloneBtns[0]).toBeVisible();
+    expect(cloneBtns[0]).not.toHaveAttribute('aria-disabled', 'true');
+
+    const deleteBtns = getAllByRole('button', {
+      name: 'Delete',
+    });
+    expect(deleteBtns[0]).toBeVisible();
+    expect(deleteBtns[0]).not.toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('should enable "Add AN Inbound Rule" button if the user has update_firewall_rules permission', () => {
+    queryMocks.userPermissions.mockReturnValue({
+      permissions: {
+        update_firewall_rules: true,
+      },
+    });
+    const { getByRole } = renderWithTheme(
+      <FirewallRulesLanding
+        disabled={getDisabledState()}
+        firewallID={1}
+        rules={firewallRules}
+      />
+    );
+
+    const addInboundBtn = getByRole('button', { name: 'Add an Inbound Rule' });
+
+    expect(addInboundBtn).toBeInTheDocument();
+    expect(addInboundBtn).not.toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('should enable "Add AN Outbound Rule" button if the user has update_firewall_rules permission', () => {
+    queryMocks.userPermissions.mockReturnValue({
+      permissions: {
+        update_firewall_rules: true,
+      },
+    });
+    const { getByRole } = renderWithTheme(
+      <FirewallRulesLanding
+        disabled={getDisabledState()}
+        firewallID={1}
+        rules={firewallRules}
+      />
+    );
+
+    const addOutboundBtn = getByRole('button', {
+      name: 'Add an Outbound Rule',
+    });
+    expect(addOutboundBtn).toBeInTheDocument();
+    expect(addOutboundBtn).not.toHaveAttribute('aria-disabled', 'true');
+  });
+});

--- a/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
@@ -27,6 +27,7 @@ import { SafeTabPanel } from 'src/components/Tabs/SafeTabPanel';
 import { TabPanels } from 'src/components/Tabs/TabPanels';
 import { Tabs } from 'src/components/Tabs/Tabs';
 import { TanStackTabLinkList } from 'src/components/Tabs/TanStackTabLinkList';
+import { usePermissions } from 'src/features/IAM/hooks/usePermissions';
 import { useFlags } from 'src/hooks/useFlags';
 import { useSecureVMNoticesEnabled } from 'src/hooks/useSecureVMNoticesEnabled';
 import { useTabs } from 'src/hooks/useTabs';
@@ -80,6 +81,12 @@ export const FirewallDetail = () => {
     firewallId,
     profile,
     grants
+  );
+
+  const { permissions } = usePermissions(
+    'firewall',
+    ['update_firewall_rules'],
+    firewallId
   );
 
   const { data: allDevices } = useAllFirewallDevicesQuery(firewallId);
@@ -230,7 +237,7 @@ export const FirewallDetail = () => {
           <TabPanels>
             <SafeTabPanel index={0}>
               <FirewallRulesLanding
-                disabled={!userCanModifyFirewall}
+                disabled={!permissions.update_firewall_rules}
                 firewallID={firewallId}
                 rules={firewall.rules}
               />


### PR DESCRIPTION
## Description 📝

Implement the new RBAC permission hook in Firewalls Rules flow

## Changes  🔄

1. Permissions Refactor
Replaced usage of checkIfUserCanModifyFirewall and related grant checks with a new usePermissions hook throughout Firewalls Rules flow.

2. Test Coverage
Added new tests for permission-based UI states.

3. Files Affected:
    FirewallRulesLanding.test.tsx
    index.tsx

## Target release date 🗓️

July 29th


## How to test 🧪

### Prerequisites

(How to setup test environment)

You can test using a DevCloud IAM account or local devenv setup or mock data (use the User Permissions presets);

_Note: The unrestricted account has full access — permission checks are skipped._

To test permissions using presets:

1. Enable MSW and use Legacy MSW Handlers.
2. Use the Custom Profile preset with the restricted option selected.
3. For account-related permissions (e.g. `const { permissions } = usePermissions('account', ['create_firewall'])` ), use the Custom User Account Permissions preset.
5. For entity-related permissions, use the Custom User Entity Permissions preset.
6. Click "Save" and "Apply".

Permissions to check:

`Custom User Entity Permissions` preset:
```
[
    "update_firewall_rules", 
]
```

### Verification steps

(How to verify changes)

- [ ]  Confirm the buttons/inputs are disabled according the grant model with IAM is off, and according to the RBAC model when IAM is on.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

