### PR TITLE
[M3-10341] - Improve Tabs Lazy Loading - Linodes

### DIFF
--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeActivity/linodeActivityLazyRoute.ts
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeActivity/linodeActivityLazyRoute.ts
@@ -1,0 +1,9 @@
+import { createLazyRoute } from '@tanstack/react-router';
+
+import LinodeActivity from './LinodeActivity';
+
+export const linodeActivityLazyRoute = createLazyRoute(
+  '/linodes/$linodeId/activity'
+)({
+  component: LinodeActivity,
+});

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeAlerts/LinodeAlerts.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeAlerts/LinodeAlerts.test.tsx
@@ -38,13 +38,7 @@ vi.mock('@tanstack/react-router', async () => {
 
 describe('LinodeAlerts', () => {
   it('should render component', async () => {
-    const { getByText } = renderWithTheme(
-      <LinodeAlerts
-        isAclpAlertsSupportedRegionLinode={true}
-        isAlertsBetaMode={false}
-        onAlertsModeChange={() => {}}
-      />
-    );
+    const { getByText } = renderWithTheme(<LinodeAlerts />);
 
     expect(getByText('Alerts')).toBeVisible();
     expect(getByText('CPU Usage')).toBeVisible();
@@ -53,13 +47,7 @@ describe('LinodeAlerts', () => {
   });
 
   it('should disable "Save" button if the user does not have update_linode permission', async () => {
-    const { getByTestId } = renderWithTheme(
-      <LinodeAlerts
-        isAclpAlertsSupportedRegionLinode={true}
-        isAlertsBetaMode={false}
-        onAlertsModeChange={() => {}}
-      />
-    );
+    const { getByTestId } = renderWithTheme(<LinodeAlerts />);
 
     const saveBtn = getByTestId('alerts-save');
     expect(saveBtn).toBeInTheDocument();
@@ -72,13 +60,7 @@ describe('LinodeAlerts', () => {
         update_linode: true,
       },
     });
-    const { getByTestId, getAllByTestId } = renderWithTheme(
-      <LinodeAlerts
-        isAclpAlertsSupportedRegionLinode={true}
-        isAlertsBetaMode={false}
-        onAlertsModeChange={() => {}}
-      />
-    );
+    const { getByTestId, getAllByTestId } = renderWithTheme(<LinodeAlerts />);
 
     const inputCPU = getAllByTestId('textfield-input')[0];
     expect(inputCPU).toBeInTheDocument();

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeAlerts/LinodeAlerts.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeAlerts/LinodeAlerts.tsx
@@ -35,13 +35,14 @@ const LinodeAlerts = () => {
 
   return (
     <Box>
-      {aclpBetaServices?.linode?.alerts && (
-        <AclpPreferenceToggle
-          isAlertsBetaMode={isAclpAlertsBetaEditFlow}
-          onAlertsModeChange={setIsAclpAlertsBetaEditFlow}
-          type="alerts"
-        />
-      )}
+      {aclpBetaServices?.linode?.alerts &&
+        isAclpAlertsSupportedRegionLinode && (
+          <AclpPreferenceToggle
+            isAlertsBetaMode={isAclpAlertsBetaEditFlow}
+            onAlertsModeChange={setIsAclpAlertsBetaEditFlow}
+            type="alerts"
+          />
+        )}
       {aclpBetaServices?.linode?.alerts &&
       isAclpAlertsSupportedRegionLinode &&
       isAclpAlertsBetaEditFlow ? (

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeAlerts/linodeAlertsLazyRoute.ts
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeAlerts/linodeAlertsLazyRoute.ts
@@ -1,0 +1,9 @@
+import { createLazyRoute } from '@tanstack/react-router';
+
+import LinodeAlerts from './LinodeAlerts';
+
+export const linodeAlertsLazyRoute = createLazyRoute(
+  '/linodes/$linodeId/alerts'
+)({
+  component: LinodeAlerts,
+});

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/linodeBackupsLazyRoute.ts
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/linodeBackupsLazyRoute.ts
@@ -1,0 +1,9 @@
+import { createLazyRoute } from '@tanstack/react-router';
+
+import { LinodeBackups } from './LinodeBackups';
+
+export const linodeBackupsLazyRoute = createLazyRoute(
+  '/linodes/$linodeId/backup'
+)({
+  component: LinodeBackups,
+});

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/linodeConfigsLazyRoute.ts
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/linodeConfigsLazyRoute.ts
@@ -1,0 +1,9 @@
+import { createLazyRoute } from '@tanstack/react-router';
+
+import LinodeConfigs from './LinodeConfigs';
+
+export const linodeConfigsLazyRoute = createLazyRoute(
+  '/linodes/$linodeId/configurations'
+)({
+  component: LinodeConfigs,
+});

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeMetrics/LinodeMetrics.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeMetrics/LinodeMetrics.tsx
@@ -1,6 +1,11 @@
-import { usePreferences } from '@linode/queries';
+import {
+  useLinodeQuery,
+  usePreferences,
+  useRegionsQuery,
+} from '@linode/queries';
 import { Box } from '@linode/ui';
-import { createLazyRoute } from '@tanstack/react-router';
+import { isAclpSupportedRegion } from '@linode/utilities';
+import { useParams } from '@tanstack/react-router';
 import * as React from 'react';
 
 import { CloudPulseDashboardWithFilters } from 'src/features/CloudPulse/Dashboard/CloudPulseDashboardWithFilters';
@@ -9,14 +14,17 @@ import { useFlags } from 'src/hooks/useFlags';
 import { AclpPreferenceToggle } from '../../AclpPreferenceToggle';
 import LinodeSummary from './LinodeSummary/LinodeSummary';
 
-interface Props {
-  isAclpMetricsSupportedRegionLinode: boolean;
-  linodeCreated: string;
-  linodeId: number;
-}
+const LinodeMetrics = () => {
+  const { linodeId } = useParams({ from: '/linodes/$linodeId' });
+  const { data: linode } = useLinodeQuery(linodeId);
+  const { data: regions } = useRegionsQuery();
 
-const LinodeMetrics = (props: Props) => {
-  const { linodeCreated, linodeId, isAclpMetricsSupportedRegionLinode } = props;
+  const isAclpMetricsSupportedRegionLinode = isAclpSupportedRegion({
+    capability: 'Linodes',
+    regionId: linode?.region,
+    regions,
+    type: 'metrics',
+  });
 
   const { aclpBetaServices } = useFlags();
   const { data: isAclpMetricsPreferenceBeta } = usePreferences(
@@ -30,7 +38,6 @@ const LinodeMetrics = (props: Props) => {
         isAclpMetricsSupportedRegionLinode && (
           <AclpPreferenceToggle type="metrics" />
         )}
-
       {aclpBetaServices?.linode?.metrics &&
       isAclpMetricsSupportedRegionLinode &&
       isAclpMetricsPreferenceBeta ? (
@@ -41,16 +48,10 @@ const LinodeMetrics = (props: Props) => {
         />
       ) : (
         // Legacy Metrics View
-        <LinodeSummary linodeCreated={linodeCreated} />
+        <LinodeSummary linodeCreated={linode?.created ?? ''} />
       )}
     </Box>
   );
 };
 
 export default LinodeMetrics;
-
-export const linodeMetricsLazyRoute = createLazyRoute(
-  '/linodes/$linodeId/metrics'
-)({
-  component: LinodeMetrics,
-});

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeMetrics/linodeMetricsLazyRoute.ts
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeMetrics/linodeMetricsLazyRoute.ts
@@ -1,0 +1,9 @@
+import { createLazyRoute } from '@tanstack/react-router';
+
+import LinodeMetrics from './LinodeMetrics';
+
+export const linodeMetricsLazyRoute = createLazyRoute(
+  '/linodes/$linodeId/metrics'
+)({
+  component: LinodeMetrics,
+});

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/liondeNetworkingLazyRoute.ts
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/liondeNetworkingLazyRoute.ts
@@ -1,0 +1,9 @@
+import { createLazyRoute } from '@tanstack/react-router';
+
+import { LinodeNetworking } from './LinodeNetworking';
+
+export const linodeNetworkingLazyRoute = createLazyRoute(
+  '/linodes/$linodeId/networking'
+)({
+  component: LinodeNetworking,
+});

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/linodeSettingsLazyRoute.ts
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/linodeSettingsLazyRoute.ts
@@ -1,0 +1,9 @@
+import { createLazyRoute } from '@tanstack/react-router';
+
+import LinodeSettings from './LinodeSettings';
+
+export const linodeSettingsLazyRoute = createLazyRoute(
+  '/linodes/$linodeId/settings'
+)({
+  component: LinodeSettings,
+});

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeStorage/linodeStorageLazyRoute.ts
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeStorage/linodeStorageLazyRoute.ts
@@ -1,0 +1,9 @@
+import { createLazyRoute } from '@tanstack/react-router';
+
+import { LinodeStorage } from './LinodeStorage';
+
+export const linodeStorageLazyRoute = createLazyRoute(
+  '/linodes/$linodeId/storage'
+)({
+  component: LinodeStorage,
+});

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailNavigation.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailNavigation.tsx
@@ -8,38 +8,18 @@ import { useIsLinodeAclpSubscribed } from '@linode/shared';
 import { BetaChip, CircleProgress, ErrorState } from '@linode/ui';
 import { isAclpSupportedRegion } from '@linode/utilities';
 import Grid from '@mui/material/Grid';
-import { useParams } from '@tanstack/react-router';
+import { Outlet, useParams } from '@tanstack/react-router';
 import * as React from 'react';
 
 import { DismissibleBanner } from 'src/components/DismissibleBanner/DismissibleBanner';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { SuspenseLoader } from 'src/components/SuspenseLoader';
-import { SafeTabPanel } from 'src/components/Tabs/SafeTabPanel';
 import { TabPanels } from 'src/components/Tabs/TabPanels';
 import { Tabs } from 'src/components/Tabs/Tabs';
 import { TanStackTabLinkList } from 'src/components/Tabs/TanStackTabLinkList';
 import { SMTPRestrictionText } from 'src/features/Linodes/SMTPRestrictionText';
 import { useFlags } from 'src/hooks/useFlags';
 import { useTabs } from 'src/hooks/useTabs';
-
-const LinodeMetrics = React.lazy(() => import('./LinodeMetrics/LinodeMetrics'));
-const LinodeNetworking = React.lazy(() =>
-  import('./LinodeNetworking/LinodeNetworking').then((module) => ({
-    default: module.LinodeNetworking,
-  }))
-);
-const LinodeStorage = React.lazy(() => import('./LinodeStorage/LinodeStorage'));
-const LinodeConfigurations = React.lazy(
-  () => import('./LinodeConfigs/LinodeConfigs')
-);
-const LinodeBackup = React.lazy(() => import('./LinodeBackup/LinodeBackups'));
-const LinodeActivity = React.lazy(
-  () => import('./LinodeActivity/LinodeActivity')
-);
-const LinodeAlerts = React.lazy(() => import('./LinodeAlerts/LinodeAlerts'));
-const LinodeSettings = React.lazy(
-  () => import('./LinodeSettings/LinodeSettings')
-);
 
 const LinodesDetailNavigation = () => {
   const { linodeId } = useParams({ from: '/linodes/$linodeId' });
@@ -76,10 +56,8 @@ const LinodesDetailNavigation = () => {
 
   // In Edit flow, default alert mode is based on Linode's ACLP subscription status
   const isLinodeAclpSubscribed = useIsLinodeAclpSubscribed(linode?.id, 'beta');
-  const [isAclpAlertsBetaEditFlow, setIsAclpAlertsBetaEditFlow] =
-    React.useState<boolean>(isLinodeAclpSubscribed);
 
-  const { tabs, handleTabChange, tabIndex, getTabIndex } = useTabs([
+  const { tabs, handleTabChange, tabIndex } = useTabs([
     {
       chip:
         aclpBetaServices?.linode?.metrics &&
@@ -117,7 +95,7 @@ const LinodesDetailNavigation = () => {
       chip:
         aclpBetaServices?.linode?.alerts &&
         isAclpAlertsSupportedRegionLinode &&
-        isAclpAlertsBetaEditFlow ? (
+        isLinodeAclpSubscribed ? (
           <BetaChip />
         ) : null,
       to: '/linodes/$linodeId/alerts',
@@ -163,21 +141,7 @@ const LinodesDetailNavigation = () => {
           <TanStackTabLinkList tabs={tabs} />
           <React.Suspense fallback={<SuspenseLoader />}>
             <TabPanels>
-              <SafeTabPanel index={getTabIndex('/linodes/$linodeId/metrics')}>
-                <LinodeMetrics
-                  isAclpMetricsSupportedRegionLinode={
-                    isAclpMetricsSupportedRegionLinode
-                  }
-                  linodeCreated={linode?.created}
-                  linodeId={id}
-                />
-              </SafeTabPanel>
-              <SafeTabPanel
-                index={getTabIndex('/linodes/$linodeId/networking')}
-              >
-                <LinodeNetworking />
-              </SafeTabPanel>
-              {isBareMetalInstance ? null : (
+              {/* {isBareMetalInstance ? null : (
                 <>
                   <SafeTabPanel
                     index={getTabIndex('/linodes/$linodeId/storage')}
@@ -196,22 +160,8 @@ const LinodesDetailNavigation = () => {
                     <LinodeBackup />
                   </SafeTabPanel>
                 </>
-              )}
-              <SafeTabPanel index={getTabIndex('/linodes/$linodeId/activity')}>
-                <LinodeActivity />
-              </SafeTabPanel>
-              <SafeTabPanel index={getTabIndex('/linodes/$linodeId/alerts')}>
-                <LinodeAlerts
-                  isAclpAlertsSupportedRegionLinode={
-                    isAclpAlertsSupportedRegionLinode
-                  }
-                  isAlertsBetaMode={isAclpAlertsBetaEditFlow}
-                  onAlertsModeChange={setIsAclpAlertsBetaEditFlow}
-                />
-              </SafeTabPanel>
-              <SafeTabPanel index={getTabIndex('/linodes/$linodeId/settings')}>
-                <LinodeSettings />
-              </SafeTabPanel>
+              )} */}
+              <Outlet />
             </TabPanels>
           </React.Suspense>
         </Tabs>

--- a/packages/manager/src/routes/linodes/index.ts
+++ b/packages/manager/src/routes/linodes/index.ts
@@ -111,7 +111,11 @@ const linodesDetailAnalyticsRoute = createRoute({
 const linodesDetailNetworkingRoute = createRoute({
   getParentRoute: () => linodesDetailRoute,
   path: 'networking',
-});
+}).lazy(() =>
+  import(
+    'src/features/Linodes/LinodesDetail/LinodeNetworking/liondeNetworkingLazyRoute'
+  ).then((m) => m.linodeNetworkingLazyRoute)
+);
 
 const linodesDetailNetworkingInterfacesRoute = createRoute({
   getParentRoute: () => linodesDetailNetworkingRoute,
@@ -129,37 +133,65 @@ const linodesDetailNetworkingInterfacesDetailRoute = createRoute({
 const linodesDetailStorageRoute = createRoute({
   getParentRoute: () => linodesDetailRoute,
   path: 'storage',
-});
+}).lazy(() =>
+  import(
+    'src/features/Linodes/LinodesDetail/LinodeStorage/linodeStorageLazyRoute'
+  ).then((m) => m.linodeStorageLazyRoute)
+);
 
 const linodesDetailConfigurationsRoute = createRoute({
   getParentRoute: () => linodesDetailRoute,
   path: 'configurations',
-});
+}).lazy(() =>
+  import(
+    'src/features/Linodes/LinodesDetail/LinodeConfigs/linodeConfigsLazyRoute'
+  ).then((m) => m.linodeConfigsLazyRoute)
+);
 
 const linodesDetailBackupsRoute = createRoute({
   getParentRoute: () => linodesDetailRoute,
   path: 'backup',
-});
+}).lazy(() =>
+  import(
+    'src/features/Linodes/LinodesDetail/LinodeBackup/linodeBackupsLazyRoute'
+  ).then((m) => m.linodeBackupsLazyRoute)
+);
 
 const linodesDetailActivityRoute = createRoute({
   getParentRoute: () => linodesDetailRoute,
   path: 'activity',
-});
+}).lazy(() =>
+  import(
+    'src/features/Linodes/LinodesDetail/LinodeActivity/linodeActivityLazyRoute'
+  ).then((m) => m.linodeActivityLazyRoute)
+);
 
 const linodesDetailSettingsRoute = createRoute({
   getParentRoute: () => linodesDetailRoute,
   path: 'settings',
-});
+}).lazy(() =>
+  import(
+    'src/features/Linodes/LinodesDetail/LinodeSettings/linodeSettingsLazyRoute'
+  ).then((m) => m.linodeSettingsLazyRoute)
+);
 
 const linodesDetailAlertsRoute = createRoute({
   getParentRoute: () => linodesDetailRoute,
   path: 'alerts',
-});
+}).lazy(() =>
+  import(
+    'src/features/Linodes/LinodesDetail/LinodeAlerts/linodeAlertsLazyRoute'
+  ).then((m) => m.linodeAlertsLazyRoute)
+);
 
 const linodesDetailMetricsRoute = createRoute({
   getParentRoute: () => linodesDetailRoute,
   path: 'metrics',
-});
+}).lazy(() =>
+  import(
+    'src/features/Linodes/LinodesDetail/LinodeMetrics/linodeMetricsLazyRoute'
+  ).then((m) => m.linodeMetricsLazyRoute)
+);
 
 const linodesDetailUpgradeInterfacesRoute = createRoute({
   getParentRoute: () => linodesDetailConfigurationsRoute,


### PR DESCRIPTION
## Description 📝
Following https://github.com/linode/manager/pull/12506, this is part 1 of several PRs ensuring our routed tabs lazy load bundles and prefetch them on hover.

We should see immediate performance improvements from this PR, as we will fetch much less bundles for landing pages with tabs 🎉 , and since other tabs bundles are prefetched and preloaded.

It will be done for every routed Tabs, but broken down to allow for quicker reviews.

This will prepare the routing refactor for its final stages and allow the complete removal of `react-router-dom`.

## Changes  🔄
- Route Tabs
- Improve routing to use search params for modals (only when implemented already)
- Fix tests as needed

## Preview 📷
There should be no visual or functional regression as a result of this PR.

## How to test 🧪

### Prerequisites
- use localhost to be able to see bundle names

### Reproduction steps
(this is one example of reproduction, which can be reproduced across 
- Navigate to http://localhost:3000/account/billing
- In your browser dev tools, open your Network tab and allow to see All requests (including JS bundles)
- Enter `UsersLanding.tsx` in your request filter
- Reload page
- Confirm it loaded on page load


### Verification steps
- Navigate to http://localhost:3000/account/billing
- In your browser dev tools, open your Network tab and allow to see All requests (including JS bundles)
- Enter `UsersLanding.tsx` in your request filter
- Reload page
- Confirm the bundle isn't loaded
- Hover "Users & Grants" tab
- Confirm it is prefetched on demand

⚠️ CONFIRM NO REGRESSION WITH THE FEATURE AS A WHOLE

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support
</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules
