### PR TITLE
poc: Investigate performance of a self-hosted Github Actions runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
       - run: cd test-sdk-cjs && node ./sdk-commonjs.cjs
 
   test-manager:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: build-sdk
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Description 📝

Trying a selfhoted Github Actions runner in DevCloud to see if our servers are faster than Github's

### Before
![Screenshot 2025-07-18 at 3 07 23 PM](https://github.com/user-attachments/assets/c1c21f55-dd3a-4007-9af3-b3aeeeb646a1)

### After
![Screenshot 2025-07-18 at 3 07 01 PM](https://github.com/user-attachments/assets/48288290-f6f0-426c-995a-c881d08032d9)
