### PR TITLE
fix: resort to payment id for edit billing flow

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2025-07-21] - v1.146.2
+
+### Fixed:
+
+- resort to payment id for edit billing flow ([#12525](https://github.com/linode/manager/pull/12525))
+
 ## [2025-07-16] - v1.146.1
 
 

--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed:
 
-- resort to payment id for edit billing flow ([#12525](https://github.com/linode/manager/pull/12525))
+- Resort to payment id for edit billing flow ([#12525](https://github.com/linode/manager/pull/12525))
 
 ## [2025-07-16] - v1.146.1
 

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.146.1",
+  "version": "1.146.2",
   "private": true,
   "type": "module",
   "bugs": {

--- a/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.test.tsx
+++ b/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.test.tsx
@@ -243,17 +243,7 @@ describe('Payment Method Row', () => {
 
     expect(navigate).toHaveBeenCalledWith({
       search: {
-        paymentMethod: {
-          created: '2021-05-21T14:27:51',
-          data: {
-            card_type: 'Visa',
-            expiry: '12/2022',
-            last_four: '1881',
-          },
-          id: 9,
-          is_default: false,
-          type: 'credit_card',
-        },
+        paymentMethodId: 9,
       },
       to: '/account/billing/make-payment',
     });

--- a/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.tsx
+++ b/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.tsx
@@ -61,7 +61,9 @@ export const PaymentMethodRow = (props: Props) => {
       onClick: () => {
         navigate({
           to: '/account/billing/make-payment',
-          search: { paymentMethod },
+          search: {
+            paymentMethodId: paymentMethod.id,
+          },
         });
       },
       title: 'Make a Payment',

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
@@ -55,9 +55,11 @@ export const BillingSummary = (props: BillingSummaryProps) => {
 
   const navigate = useNavigate();
   const match = useMatch({ strict: false });
-  const { paymentMethod } = useSearch({
+  const search = useSearch({
     strict: false,
   });
+
+  const { paymentMethodId } = search;
 
   const routeForMakePayment = '/account/billing/make-payment';
   const makePaymentRouteMatch = match?.routeId === routeForMakePayment;
@@ -91,13 +93,17 @@ export const BillingSummary = (props: BillingSummaryProps) => {
       return;
     }
 
-    const selectedPaymentMethod =
-      paymentMethod ??
-      paymentMethods?.find((payment) => payment.is_default) ??
-      undefined;
+    const selectedPaymentMethod = paymentMethodId
+      ? paymentMethods?.find((payment) => payment.id === paymentMethodId)
+      : (paymentMethods?.find((payment) => payment.is_default) ?? undefined);
 
     openPaymentDrawer(selectedPaymentMethod);
-  }, [paymentMethods, openPaymentDrawer, makePaymentRouteMatch, paymentMethod]);
+  }, [
+    paymentMethods,
+    openPaymentDrawer,
+    makePaymentRouteMatch,
+    paymentMethodId,
+  ]);
 
   //
   // Account Balance logic

--- a/packages/manager/src/routes/account/index.ts
+++ b/packages/manager/src/routes/account/index.ts
@@ -3,15 +3,13 @@ import { createRoute, redirect } from '@tanstack/react-router';
 import { rootRoute } from '../root';
 import { AccountRoute } from './AccountRoute';
 
-import type { PaymentMethod } from '@linode/api-v4';
-
 interface AccountBillingSearch {
   contactDrawerOpen?: boolean;
   focusEmail?: boolean;
 }
 
 interface AccountBillingMakePaymentSearch {
-  paymentMethod?: PaymentMethod;
+  paymentMethodId?: number;
 }
 
 const accountRoute = createRoute({


### PR DESCRIPTION
## Changes  🔄
- Update billing flow to use payment method id for editing payment
- Reduces parameter surface area in navigation.

## Target release date 🗓️
7/21

## Preview 📷
| Before  | After   |
| ------- | ------- |
| 📷 | <img width="463" height="33" alt="Screenshot 2025-07-21 at 12 10 57 PM" src="https://github.com/user-attachments/assets/f775eba4-dfcc-43e3-aec3-02bee6937672" /> |

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>