### PR TITLE
fix: [M3-10339] - Linode create page document title

### DIFF
--- a/packages/manager/src/features/PlacementGroups/PlacementGroupsCreateDrawer.tsx
+++ b/packages/manager/src/features/PlacementGroups/PlacementGroupsCreateDrawer.tsx
@@ -81,7 +81,7 @@ export const PlacementGroupsCreateDrawer = (
     useFormValidateOnChange();
 
   const location = useLocation();
-  const isFromLinodeCreate = location.pathname.includes('/linodes/create');
+  const isFromPlacementGroup = location.pathname.includes('/placement-groups');
   const queryParams = getQueryParamsFromQueryString(location.search);
 
   const handleRegionSelect = (region: Region['id']) => {
@@ -116,7 +116,7 @@ export const PlacementGroupsCreateDrawer = (
       if (onPlacementGroupCreate) {
         onPlacementGroupCreate(response);
         // Fire analytics form submit upon successful PG creation from Linode Create flow.
-        if (isFromLinodeCreate) {
+        if (!isFromPlacementGroup) {
           sendLinodeCreateFormStepEvent({
             createType: (queryParams.type as LinodeCreateType) ?? 'OS',
             headerName: 'Create Placement Group',
@@ -199,7 +199,7 @@ export const PlacementGroupsCreateDrawer = (
 
   return (
     <>
-      {!isFromLinodeCreate && (
+      {isFromPlacementGroup && (
         <DocumentTitleSegment
           segment={`${open ? 'Create a Placement Group' : 'Placement Groups'}`}
         />
@@ -236,7 +236,7 @@ export const PlacementGroupsCreateDrawer = (
                 </List>
               </Notice>
             )}
-            {selectedRegion && isFromLinodeCreate && (
+            {selectedRegion && !isFromPlacementGroup && (
               <DescriptionList
                 items={[
                   {


### PR DESCRIPTION
## Description

- This PR Fixes the document title for the `Linode create` page.

## Changes

- Fixed Document title for the `Linode create` page.

## Target Release

NA

## Preview

| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/963648e9-1d40-4375-80ad-eff56d3a3def) | ![After](https://github.com/user-attachments/assets/2b6698c2-bf00-45c1-8ed6-b6d5a6a84fda) |

## How to Test

1. Navigate to `/linodes/create`.
3. Verify document title is showing correct title `Create a Linode | Akamai Cloud Manager`.

<details>
<summary>Author Checklists</summary>

### As an Author, I considered:  
- [x] Self-review  
- [x] Contribution guidelines  
- [x] Small, focused PR  
- [x] Changeset added if needed  
- [x] Tests added or updated  
- [x] No sensitive info  
- [x] Feature flag if needed  
- [x] Reproduction steps  
- [x] Docs updated if needed  
- [x] Mobile and a11y support  

### Before moving from Draft to Open:  
- [x] All unit tests passing  
- [x] TypeScript compiles  
- [x] Linting passes  

</details>
