### PR TITLE
upcoming: [M3-10295] - Edit node pool configuration in LKE cluster create flow

### DIFF
--- a/packages/manager/.changeset/pr-12552-upcoming-features-1753194650146.md
+++ b/packages/manager/.changeset/pr-12552-upcoming-features-1753194650146.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Edit node pool configuration in LKE cluster create flow ([#12552](https://github.com/linode/manager/pull/12552))

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -658,6 +658,7 @@ export const CreateCluster = () => {
         open={isNodePoolConfigDrawerOpen}
         planId={selectedType}
         poolIndex={selectedPoolIndex}
+        selectedRegion={selectedRegion}
         selectedTier={selectedTier}
       />
     </FormProvider>

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -96,6 +96,7 @@ export interface NodePoolConfigDrawerHandlerParams {
   drawerMode: NodePoolConfigDrawerMode;
   isOpen: boolean;
   planLabel?: string;
+  poolIndex?: number;
 }
 
 export const CreateCluster = () => {
@@ -138,6 +139,7 @@ export const CreateCluster = () => {
   const [nodePoolConfigDrawerMode, setNodePoolConfigDrawerMode] =
     React.useState<NodePoolConfigDrawerMode>('add');
   const [selectedType, setSelectedType] = React.useState<string>();
+  const [selectedPoolIndex, setSelectedPoolIndex] = React.useState<number>();
 
   // Use React Hook Form for node pools to make updating pools and their configs easier.
   // TODO - Future: use RHF for the rest of the form and replace FormValues with CreateKubeClusterPayload.
@@ -249,10 +251,12 @@ export const CreateCluster = () => {
     drawerMode,
     isOpen,
     planLabel,
+    poolIndex,
   }: NodePoolConfigDrawerHandlerParams) => {
     setNodePoolConfigDrawerMode(drawerMode);
     setIsNodePoolConfigDrawerOpen(isOpen);
     setSelectedType(planLabel);
+    setSelectedPoolIndex(poolIndex);
   };
 
   const createCluster = async () => {
@@ -623,6 +627,7 @@ export const CreateCluster = () => {
                 ? lkeEnterpriseType?.price.monthly
                 : undefined
             }
+            handleConfigurePool={handleOpenNodePoolConfigDrawer}
             hasAgreed={hasAgreed}
             highAvailability={highAvailability}
             highAvailabilityPrice={
@@ -652,6 +657,7 @@ export const CreateCluster = () => {
         onClose={() => setIsNodePoolConfigDrawerOpen(false)}
         open={isNodePoolConfigDrawerOpen}
         planId={selectedType}
+        poolIndex={selectedPoolIndex}
         selectedTier={selectedTier}
       />
     </FormProvider>

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.test.tsx
@@ -2,7 +2,10 @@ import { regionFactory } from '@linode/utilities';
 import * as React from 'react';
 
 import { typeFactory } from 'src/factories';
-import { nodePoolFactory } from 'src/factories/kubernetesCluster';
+import {
+  nodePoolBetaFactory,
+  nodePoolFactory,
+} from 'src/factories/kubernetesCluster';
 import { UNKNOWN_PRICE } from 'src/utilities/pricing/constants';
 import { LKE_CREATE_CLUSTER_CHECKOUT_MESSAGE } from 'src/utilities/pricing/constants';
 import { renderWithThemeAndHookFormContext } from 'src/utilities/testHelpers';
@@ -41,6 +44,11 @@ describe('KubeCheckoutBar', () => {
   it('should render helper text and disable create button until a region has been selected', async () => {
     const { findByText, getByText } = renderWithThemeAndHookFormContext({
       component: <KubeCheckoutBar {...props} region={undefined} />,
+      useFormOptions: {
+        defaultValues: {
+          nodePools: [nodePoolBetaFactory.build()],
+        },
+      },
     });
 
     await findByText(LKE_CREATE_CLUSTER_CHECKOUT_MESSAGE);
@@ -53,6 +61,11 @@ describe('KubeCheckoutBar', () => {
   it('should render a section for each pool', async () => {
     const { queryAllByTestId } = renderWithThemeAndHookFormContext({
       component: <KubeCheckoutBar {...props} />,
+      useFormOptions: {
+        defaultValues: {
+          nodePools: [nodePoolBetaFactory.build()],
+        },
+      },
     });
 
     expect(queryAllByTestId('node-pool-summary')).toHaveLength(pools.length);
@@ -61,6 +74,11 @@ describe('KubeCheckoutBar', () => {
   it('should not show a warning if all pools have 3 nodes or more', () => {
     const { queryAllByText } = renderWithThemeAndHookFormContext({
       component: <KubeCheckoutBar {...props} />,
+      useFormOptions: {
+        defaultValues: {
+          nodePools: [nodePoolBetaFactory.build()],
+        },
+      },
     });
     expect(queryAllByText(/minimum of 3 nodes/i)).toHaveLength(0);
   });
@@ -68,6 +86,11 @@ describe('KubeCheckoutBar', () => {
   it('should render additional pricing text and link', async () => {
     const { findByText, getByRole } = renderWithThemeAndHookFormContext({
       component: <KubeCheckoutBar {...props} />,
+      useFormOptions: {
+        defaultValues: {
+          nodePools: [nodePoolBetaFactory.build()],
+        },
+      },
     });
     expect(
       await findByText(
@@ -87,6 +110,11 @@ describe('KubeCheckoutBar', () => {
     const poolsWithSmallNode = [...pools, nodePoolFactory.build({ count: 2 })];
     const { findByText } = renderWithThemeAndHookFormContext({
       component: <KubeCheckoutBar {...props} pools={poolsWithSmallNode} />,
+      useFormOptions: {
+        defaultValues: {
+          nodePools: [nodePoolBetaFactory.build()],
+        },
+      },
     });
 
     await findByText(/minimum of 3 nodes/i);
@@ -95,6 +123,11 @@ describe('KubeCheckoutBar', () => {
   it('should display the total price of the cluster without High Availability', async () => {
     const { findByText } = renderWithThemeAndHookFormContext({
       component: <KubeCheckoutBar {...props} />,
+      useFormOptions: {
+        defaultValues: {
+          nodePools: [nodePoolBetaFactory.build()],
+        },
+      },
     });
 
     // 5 node pools * 3 linodes per pool * 10 per linode
@@ -104,6 +137,11 @@ describe('KubeCheckoutBar', () => {
   it('should display the total price of the cluster with High Availability', async () => {
     const { findByText } = renderWithThemeAndHookFormContext({
       component: <KubeCheckoutBar {...props} highAvailability />,
+      useFormOptions: {
+        defaultValues: {
+          nodePools: [nodePoolBetaFactory.build()],
+        },
+      },
     });
 
     // 5 node pools * 3 linodes per pool * 10 per linode + 60 per month per cluster for HA
@@ -113,6 +151,11 @@ describe('KubeCheckoutBar', () => {
   it('should display the DC-Specific total price of the cluster for a region with a price increase without HA selection', async () => {
     const { findByText } = renderWithThemeAndHookFormContext({
       component: <KubeCheckoutBar {...props} region="id-cgk" />,
+      useFormOptions: {
+        defaultValues: {
+          nodePools: [nodePoolBetaFactory.build()],
+        },
+      },
     });
 
     // 5 node pools * 3 linodes per pool * 12 per linode * 20% increase for Jakarta + 72 per month per cluster for HA
@@ -129,6 +172,11 @@ describe('KubeCheckoutBar', () => {
           region="id-cgk"
         />
       ),
+      useFormOptions: {
+        defaultValues: {
+          nodePools: [nodePoolBetaFactory.build()],
+        },
+      },
     });
 
     // 5 node pools * 3 linodes per pool * 12 per linode * 20% increase for Jakarta + 72 per month per cluster for HA
@@ -145,6 +193,11 @@ describe('KubeCheckoutBar', () => {
           region="id-cgk"
         />
       ),
+      useFormOptions: {
+        defaultValues: {
+          nodePools: [nodePoolBetaFactory.build()],
+        },
+      },
     });
 
     // 5 node pools * 3 linodes per pool * 12 per linode * 20% increase for Jakarta + UNKNOWN_PRICE
@@ -155,6 +208,11 @@ describe('KubeCheckoutBar', () => {
   it('should display the total price of the cluster with LKE Enterprise', async () => {
     const { findByText } = renderWithThemeAndHookFormContext({
       component: <KubeCheckoutBar {...props} enterprisePrice={300} />,
+      useFormOptions: {
+        defaultValues: {
+          nodePools: [nodePoolBetaFactory.build()],
+        },
+      },
     });
 
     // 5 node pools * 3 linodes per pool * 10 per linode + 300 per month for enterprise (HA included)
@@ -171,6 +229,11 @@ describe('KubeCheckoutBar', () => {
           highAvailabilityPrice="60"
         />
       ),
+      useFormOptions: {
+        defaultValues: {
+          nodePools: [nodePoolBetaFactory.build()],
+        },
+      },
     });
 
     // 5 node pools * 3 linodes per pool * 10 per linode + 300 per month for enterprise (HA included)

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
@@ -33,11 +33,13 @@ import {
 import { nodeWarning } from '../constants';
 import { NodePoolSummaryItem } from './NodePoolSummaryItem';
 
+import type { NodePoolConfigDrawerHandlerParams } from '../CreateCluster/CreateCluster';
 import type { KubeNodePoolResponse, Region } from '@linode/api-v4';
 
 export interface Props {
   createCluster: () => void;
   enterprisePrice?: number;
+  handleConfigurePool?: (params: NodePoolConfigDrawerHandlerParams) => void;
   hasAgreed: boolean;
   highAvailability?: boolean;
   highAvailabilityPrice: string;
@@ -52,6 +54,7 @@ export const KubeCheckoutBar = (props: Props) => {
   const {
     createCluster,
     enterprisePrice,
+    handleConfigurePool,
     hasAgreed,
     highAvailability,
     highAvailabilityPrice,
@@ -153,9 +156,11 @@ export const KubeCheckoutBar = (props: Props) => {
         {pools.map((thisPool, idx) => (
           <NodePoolSummaryItem
             clusterTier={enterprisePrice ? 'enterprise' : 'standard'}
+            handleConfigurePool={handleConfigurePool}
             key={idx}
             nodeCount={thisPool.count}
             onRemove={() => remove(idx)}
+            poolIndex={idx}
             poolType={
               types?.find((thisType) => thisType.id === thisPool.type) || null
             }

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/NodePoolSummary.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/NodePoolSummary.test.tsx
@@ -2,7 +2,8 @@ import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
 import { extendedTypes } from 'src/__data__/ExtendedType';
-import { renderWithTheme } from 'src/utilities/testHelpers';
+import { nodePoolBetaFactory } from 'src/factories/kubernetesCluster';
+import { renderWithThemeAndHookFormContext } from 'src/utilities/testHelpers';
 
 import { NodePoolSummaryItem } from './NodePoolSummaryItem';
 
@@ -19,19 +20,40 @@ const props: Props = {
 
 describe('Node Pool Summary Item', () => {
   it("should render the label of its pool's plan", () => {
-    const { getByText } = renderWithTheme(<NodePoolSummaryItem {...props} />);
+    const { getByText } = renderWithThemeAndHookFormContext({
+      component: <NodePoolSummaryItem {...props} />,
+      useFormOptions: {
+        defaultValues: {
+          nodePools: [nodePoolBetaFactory.build()],
+        },
+      },
+    });
     getByText(/Linode 2 GB Plan/i);
     getByText(/1 CPU, 50 GB Storage/i);
   });
 
   it('should call its onRemove handler when the trash can is clicked', async () => {
-    const { getByTestId } = renderWithTheme(<NodePoolSummaryItem {...props} />);
+    const { getByTestId } = renderWithThemeAndHookFormContext({
+      component: <NodePoolSummaryItem {...props} />,
+      useFormOptions: {
+        defaultValues: {
+          nodePools: [nodePoolBetaFactory.build()],
+        },
+      },
+    });
     await userEvent.click(getByTestId('remove-pool-button'));
     expect(props.onRemove).toHaveBeenCalledTimes(1);
   });
 
   it("should display its pool's price", () => {
-    const { getByText } = renderWithTheme(<NodePoolSummaryItem {...props} />);
+    const { getByText } = renderWithThemeAndHookFormContext({
+      component: <NodePoolSummaryItem {...props} />,
+      useFormOptions: {
+        defaultValues: {
+          nodePools: [nodePoolBetaFactory.build()],
+        },
+      },
+    });
     getByText('$1,000.00');
   });
 });

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/NodePoolSummary.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/NodePoolSummary.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
 import { extendedTypes } from 'src/__data__/ExtendedType';
@@ -9,6 +9,7 @@ import { NodePoolSummaryItem } from './NodePoolSummaryItem';
 import type { Props } from './NodePoolSummaryItem';
 
 const props: Props = {
+  poolIndex: 0,
   nodeCount: 3,
   onRemove: vi.fn(),
   poolType: extendedTypes[1],
@@ -23,9 +24,9 @@ describe('Node Pool Summary Item', () => {
     getByText(/1 CPU, 50 GB Storage/i);
   });
 
-  it('should call its onRemove handler when the trash can is clicked', () => {
+  it('should call its onRemove handler when the trash can is clicked', async () => {
     const { getByTestId } = renderWithTheme(<NodePoolSummaryItem {...props} />);
-    fireEvent.click(getByTestId('remove-pool-button'));
+    await userEvent.click(getByTestId('remove-pool-button'));
     expect(props.onRemove).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/NodePoolSummaryItem.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/NodePoolSummaryItem.tsx
@@ -76,9 +76,11 @@ export const NodePoolSummaryItem = React.memo((props: Props) => {
             GB Storage
           </Typography>
           <Typography>
-            {UPDATE_STRATEGY_OPTIONS.find(
-              (option) => option.value === thisPool.update_strategy
-            )?.label ?? ''}
+            {isLkeEnterprisePostLAFeatureEnabled && thisPool
+              ? UPDATE_STRATEGY_OPTIONS.find(
+                  (option) => option.value === thisPool?.update_strategy
+                )?.label
+              : ''}
           </Typography>
         </Stack>
         <IconButton

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/NodePoolSummaryItem.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/NodePoolSummaryItem.tsx
@@ -90,7 +90,9 @@ export const NodePoolSummaryItem = React.memo((props: Props) => {
           <CloseIcon />
         </IconButton>
       </Stack>
-      {!isLkeEnterprisePostLAFeatureEnabled ? (
+      {isLkeEnterprisePostLAFeatureEnabled ? (
+        pluralize('Node', 'Nodes', nodeCount)
+      ) : (
         <EnhancedNumberInput
           max={
             clusterTier === 'enterprise'
@@ -101,8 +103,6 @@ export const NodePoolSummaryItem = React.memo((props: Props) => {
           setValue={updateNodeCount}
           value={nodeCount}
         />
-      ) : (
-        pluralize('Node', 'Nodes', nodeCount)
       )}
       <Box pt={0.5}>
         {price ? (

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/NodePoolConfigDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/NodePoolConfigDrawer.tsx
@@ -34,6 +34,7 @@ export interface Props {
   onClose: () => void;
   open: boolean;
   planId: string | undefined;
+  poolIndex?: number;
   selectedTier: KubernetesTier;
 }
 
@@ -43,7 +44,7 @@ interface VersionUpdateFormFields {
 }
 
 export const NodePoolConfigDrawer = (props: Props) => {
-  const { onClose, open, selectedTier, planId, mode } = props;
+  const { onClose, open, selectedTier, planId, poolIndex, mode } = props;
 
   // Use the node pool state from the main create flow from.
   const { control: parentFormControl, setValue: parentFormSetValue } =
@@ -79,9 +80,12 @@ export const NodePoolConfigDrawer = (props: Props) => {
       selectedTier === 'enterprise' ? 'on_recycle' : undefined
     );
 
-    // eslint-disable-next-line sonarjs/todo-tag
-    // TODO - M3-10295: If the plan has been added to the cluster, set the existing node count for editing.
-  }, [planId, open, selectedTier, setValue]);
+    // If we're in edit mode, set the existing config values on the pool.
+    if (!isAddMode && poolIndex !== undefined) {
+      setValue('nodeCount', _nodePools[poolIndex].count);
+      setValue('updateStrategy', _nodePools[poolIndex].update_strategy);
+    }
+  }, [planId, open, selectedTier, setValue, isAddMode, poolIndex, _nodePools]);
 
   const onSubmit = async (values: VersionUpdateFormFields) => {
     try {

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/NodePoolConfigDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/NodePoolConfigDrawer.tsx
@@ -88,7 +88,8 @@ export const NodePoolConfigDrawer = (props: Props) => {
 
   // Keep track of the node count to display an accurate price.
   const nodeCountWatcher = useWatch({ control, name: 'nodeCount' });
-  const updatedCount = nodeCountWatcher ?? form.getValues('nodeCount');
+  const updatedCount =
+    nodeCountWatcher ?? form.getValues('nodeCount') ?? DEFAULT_PLAN_COUNT;
   const pricePerNode = getLinodeRegionPrice(
     planType,
     selectedRegion?.toString()

--- a/packages/manager/src/features/Kubernetes/NodePoolUpdateStrategySelect.tsx
+++ b/packages/manager/src/features/Kubernetes/NodePoolUpdateStrategySelect.tsx
@@ -1,10 +1,7 @@
 import { Autocomplete } from '@linode/ui';
 import React from 'react';
 
-const updateStrategyOptions = [
-  { label: 'On Recycle Updates', value: 'on_recycle' },
-  { label: 'Rolling Updates', value: 'rolling_update' },
-];
+import { UPDATE_STRATEGY_OPTIONS } from './constants';
 
 interface Props {
   onChange: (value: string | undefined) => void;
@@ -18,9 +15,9 @@ export const NodePoolUpdateStrategySelect = (props: Props) => {
       disableClearable
       label="Node Pool Update Strategy"
       onChange={(e, updateStrategy) => onChange(updateStrategy?.value)}
-      options={updateStrategyOptions}
+      options={UPDATE_STRATEGY_OPTIONS}
       placeholder="Select an Update Strategy"
-      value={updateStrategyOptions.find((option) => option.value === value)}
+      value={UPDATE_STRATEGY_OPTIONS.find((option) => option.value === value)}
     />
   );
 };

--- a/packages/manager/src/features/Kubernetes/constants.ts
+++ b/packages/manager/src/features/Kubernetes/constants.ts
@@ -44,3 +44,8 @@ export const ADD_NODE_POOLS_DESCRIPTION = `Add groups of Linodes to your cluster
 export const ADD_NODE_POOLS_ENTERPRISE_DESCRIPTION = `Add groups of Linodes to your cluster. You can have a maximum of ${MAX_NODES_PER_POOL_ENTERPRISE_TIER} Linodes per node pool.`;
 
 export const DEFAULT_PLAN_COUNT = 3;
+
+export const UPDATE_STRATEGY_OPTIONS = [
+  { label: 'On Recycle Updates', value: 'on_recycle' },
+  { label: 'Rolling Updates', value: 'rolling_update' },
+];


### PR DESCRIPTION
## Description 📝

This PR builds off of #12449 by providing a way for the user to edit their node pool's configuration via the cluster summary/checkout bar. 

## Changes  🔄
- This work is feature-flagged as `postLa` under the LKE-Enterprise flag.
- Adds `poolIndex` and `selectedRegion` props to the NodePoolConfigDrawer
   - Adds ability to update the node pool config with drawer edit mode
   - Adds the pricing in the drawer
   - Adds a warning for low node count in the drawer
- Updates the NodePoolSummaryItem (in the checkout bar)
   - Adds link button to the NodePoolConfigDrawer
   - Removes the number input from the Node
   - Updates a unit test impacted by the addition of the `poolIndex` prop

## Target release date 🗓️

8/12 (dev)

## Preview 📷

| Flag State | Before  | After   |
| ------- | ----------- |  -- |
| Node Pool Config Drawer - Edit mode |  N/A |  Standard cluster (+ warning): ![Screenshot 2025-07-21 at 6 40 08 PM](https://github.com/user-attachments/assets/79f5a27e-5e29-446f-a5a5-d920672d1704) Enterprise cluster: ![Screenshot 2025-07-21 at 6 41 25 PM](https://github.com/user-attachments/assets/21ddbcff-b201-45c8-939b-436dbac7ce70) |
| Kube Checkout Bar |  <details><summary>Screenshots</summary> ![Screenshot 2025-07-21 at 6 36 33 PM](https://github.com/user-attachments/assets/af407363-5de1-4bf2-94c3-89a77bf39036) ![Screenshot 2025-07-21 at 6 34 44 PM](https://github.com/user-attachments/assets/8b6242ec-5ee7-4b54-8b20-cd971940276e) </details> | <details><summary>Screenshots</summary> ![Screenshot 2025-07-21 at 6 40 23 PM](https://github.com/user-attachments/assets/d54070a9-0bb1-45ad-b71b-6622f4daf6da)![Screenshot 2025-07-21 at 6 41 17 PM](https://github.com/user-attachments/assets/71a4922b-c7df-49f0-8459-5b053b498531) </details>  |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Check out this PR/use preview link.
- Ensure the `LKE-Enterprise > postLa` flag is enabled locally in dev tools.
- Open your chrome dev tools > Network tab to be ready to confirm the POST request.

### Verification steps

(How to verify changes)

With the flag on:
   - [ ] The user can update their configuration via a button in the kube checkout bar with the node pool line item. 
   - [ ] EnhancedNumberInput is no longer shown in the checkout bar, since it is shown and is editable in the Configure Node Pool drawer.
   - [ ] The warning notice for <3 pools is also displayed in the drawer when count is adjusted
   - [ ] Pricing is shown in the drawer (having pricing in drawer is consistent with add/resize NP drawers)
   - [ ] The node count and the update strategy are displayed as  text in checkout bar
   - [ ] The submitted request includes the edited `count` and `update_strategy` values the user set for a cluster

With the flag off:
   - [ ] There should be parity with prod -  no changes to the checkout bar.

Tests:
- [ ] Existing test coverage should pass to ensure there are no regressions. Test coverage for the new functionality is forthcoming.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [X] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [X] All tests and CI checks are passing
- [X] TypeScript compilation succeeded without errors
- [X] Code passes all linting rules

</details>