### PR TITLE
feat: [UIE-8881] - IAM RBAC: fix the error message

### DIFF
--- a/packages/manager/.changeset/pr-12556-upcoming-features-1753265232709.md
+++ b/packages/manager/.changeset/pr-12556-upcoming-features-1753265232709.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+IAM RBAC: fix error message for the one account_admin in the account ([#12556](https://github.com/linode/manager/pull/12556))

--- a/packages/manager/src/features/IAM/Shared/utilities.test.ts
+++ b/packages/manager/src/features/IAM/Shared/utilities.test.ts
@@ -836,12 +836,9 @@ describe('getErrorMessage', () => {
     const errors = [
       {
         reason: 'Request made to janus is invalid',
-        field: 'Bad janus request',
       },
       {
-        reason:
-          'Can not remove account admin access from the last account admin on the account',
-        field: 'Removing last account admin',
+        reason: 'Must have at least one user with account_admin role',
       },
     ];
     const result = getErrorMessage(errors);

--- a/packages/manager/src/features/IAM/Shared/utilities.ts
+++ b/packages/manager/src/features/IAM/Shared/utilities.ts
@@ -523,7 +523,8 @@ export const mergeAssignedRolesIntoExistingRoles = (
 
 export const getErrorMessage = (error: APIError[] | null) => {
   const isLastAccountAdmin = error?.some(
-    (err) => err.field === 'Removing last account admin'
+    (err) =>
+      err.reason === 'Must have at least one user with account_admin role'
   );
 
   const errorMessage = isLastAccountAdmin


### PR DESCRIPTION
## Description 📝

IAM RBAC: fix error message for the one account_admin in the account


## Changes  🔄

List any change(s) relevant to the reviewer.

- fix error message for the one account_admin in the account


## Target release date 🗓️

8/12

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <img width="2746" height="1448" alt="image" src="https://github.com/user-attachments/assets/7546dedd-1ddb-402b-8776-fac5ab4c47ce" /> | <img width="2836" height="1492" alt="image" src="https://github.com/user-attachments/assets/da06bbff-32ee-438e-80eb-8ed48dd10afe" /> |
| <img width="968" height="1276" alt="image" src="https://github.com/user-attachments/assets/5eb6a467-696f-42ef-9446-dc6f721183ed" /> | <img width="966" height="1178" alt="image" src="https://github.com/user-attachments/assets/454690db-e711-495b-9428-c54d12edb913" /> |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- You can test using a DevCloud IAM account or local devenv setup
- You need to have an account with one account_admin

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] Go to the Assigned Roles tab.
- [ ] Try to remove the account_admin role

### Verification steps

(How to verify changes)

- [ ] Confirm there is a correct error message for removing/changing role for the last account admin

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
