### PR TITLE
upcoming: [DPS-34044] - Validate streams and destinations

### DIFF
--- a/packages/api-v4/.changeset/pr-12557-upcoming-features-1753340103984.md
+++ b/packages/api-v4/.changeset/pr-12557-upcoming-features-1753340103984.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Upcoming Features
+---
+
+Add validation to Create Stream POST request ([#12557](https://github.com/linode/manager/pull/12557))

--- a/packages/api-v4/src/datastream/streams.ts
+++ b/packages/api-v4/src/datastream/streams.ts
@@ -1,3 +1,5 @@
+import { createStreamSchema } from '@linode/validation';
+
 import { BETA_API_ROOT } from '../constants';
 import Request, {
   setData,
@@ -41,7 +43,7 @@ export const getStreams = (params?: Params, filter?: Filter) =>
  */
 export const createStream = (data: CreateStreamPayload) =>
   Request<Stream>(
-    setData(data), // @TODO (DPS-34044) add validation schema
+    setData(data, createStreamSchema),
     setURL(`${BETA_API_ROOT}/monitor/streams`),
     setMethod('POST'),
   );

--- a/packages/api-v4/src/datastream/types.ts
+++ b/packages/api-v4/src/datastream/types.ts
@@ -86,7 +86,7 @@ interface ClientCertificateDetails {
 type AuthenticationType = 'basic' | 'none';
 
 interface Authentication {
-  details: AuthenticationDetails;
+  details?: AuthenticationDetails;
   type: AuthenticationType;
 }
 

--- a/packages/manager/.changeset/pr-12557-upcoming-features-1753340182313.md
+++ b/packages/manager/.changeset/pr-12557-upcoming-features-1753340182313.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Datastream form validation on create stream and destination ([#12557](https://github.com/linode/manager/pull/12557))

--- a/packages/manager/src/features/DataStream/Destinations/DestinationCreate/DestinationCreate.test.tsx
+++ b/packages/manager/src/features/DataStream/Destinations/DestinationCreate/DestinationCreate.test.tsx
@@ -13,7 +13,7 @@ describe('DestinationCreate', () => {
       component: <DestinationCreate />,
       useFormOptions: {
         defaultValues: {
-          destination_type: destinationType.LinodeObjectStorage,
+          destination: { type: destinationType.LinodeObjectStorage },
         },
       },
     });
@@ -30,7 +30,7 @@ describe('DestinationCreate', () => {
       component: <DestinationCreate />,
       useFormOptions: {
         defaultValues: {
-          destination_label: '',
+          destination: { label: '' },
         },
       },
     });
@@ -47,7 +47,7 @@ describe('DestinationCreate', () => {
       component: <DestinationCreate />,
       useFormOptions: {
         defaultValues: {
-          destination_type: destinationType.LinodeObjectStorage,
+          destination: { type: destinationType.LinodeObjectStorage },
         },
       },
     });
@@ -64,7 +64,7 @@ describe('DestinationCreate', () => {
       component: <DestinationCreate />,
       useFormOptions: {
         defaultValues: {
-          destination_type: destinationType.LinodeObjectStorage,
+          destination: { type: destinationType.LinodeObjectStorage },
         },
       },
     });
@@ -81,7 +81,7 @@ describe('DestinationCreate', () => {
       component: <DestinationCreate />,
       useFormOptions: {
         defaultValues: {
-          destination_type: destinationType.LinodeObjectStorage,
+          destination: { type: destinationType.LinodeObjectStorage },
         },
       },
     });
@@ -104,7 +104,7 @@ describe('DestinationCreate', () => {
       component: <DestinationCreate />,
       useFormOptions: {
         defaultValues: {
-          destination_type: destinationType.LinodeObjectStorage,
+          destination: { type: destinationType.LinodeObjectStorage },
         },
       },
     });
@@ -121,7 +121,7 @@ describe('DestinationCreate', () => {
       component: <DestinationCreate />,
       useFormOptions: {
         defaultValues: {
-          destination_type: destinationType.LinodeObjectStorage,
+          destination: { type: destinationType.LinodeObjectStorage },
         },
       },
     });
@@ -138,7 +138,7 @@ describe('DestinationCreate', () => {
       component: <DestinationCreate />,
       useFormOptions: {
         defaultValues: {
-          destination_type: destinationType.LinodeObjectStorage,
+          destination: { type: destinationType.LinodeObjectStorage },
         },
       },
     });

--- a/packages/manager/src/features/DataStream/Destinations/DestinationCreate/DestinationCreate.tsx
+++ b/packages/manager/src/features/DataStream/Destinations/DestinationCreate/DestinationCreate.tsx
@@ -1,5 +1,7 @@
+import { yupResolver } from '@hookform/resolvers/yup';
 import { destinationType } from '@linode/api-v4';
 import { Autocomplete, Box, Button, Paper, TextField } from '@linode/ui';
+import { createDestinationSchema } from '@linode/validation';
 import { useTheme } from '@mui/material/styles';
 import * as React from 'react';
 import { Controller, FormProvider, useForm, useWatch } from 'react-hook-form';
@@ -10,7 +12,7 @@ import { getDestinationTypeOption } from 'src/features/DataStream/dataStreamUtil
 import { DestinationLinodeObjectStorageDetailsForm } from 'src/features/DataStream/Shared/DestinationLinodeObjectStorageDetailsForm';
 import { destinationTypeOptions } from 'src/features/DataStream/Shared/types';
 
-import type { CreateStreamForm } from 'src/features/DataStream/Streams/StreamCreate/types';
+import type { CreateDestinationForm } from 'src/features/DataStream/Shared/types';
 
 export const DestinationCreate = () => {
   const theme = useTheme();
@@ -30,17 +32,21 @@ export const DestinationCreate = () => {
     title: 'Create Destination',
   };
 
-  const form = useForm<CreateStreamForm>({
+  const form = useForm<CreateDestinationForm>({
     defaultValues: {
-      destination_type: destinationType.LinodeObjectStorage,
-      region: '',
+      type: destinationType.LinodeObjectStorage,
+      details: {
+        region: '',
+      },
     },
+    mode: 'onBlur',
+    resolver: yupResolver(createDestinationSchema),
   });
   const { control, handleSubmit } = form;
 
   const selectedDestinationType = useWatch({
     control,
-    name: 'destination_type',
+    name: 'type',
   });
 
   const onSubmit = handleSubmit(async () => {});
@@ -51,15 +57,16 @@ export const DestinationCreate = () => {
       <LandingHeader {...landingHeaderProps} />
       <Paper>
         <FormProvider {...form}>
-          <form onSubmit={onSubmit}>
+          <form id="createDestinationForm" onSubmit={onSubmit}>
             <Controller
               control={control}
-              name="destination_type"
+              name="type"
               render={({ field }) => (
                 <Autocomplete
                   disableClearable
                   disabled={true}
                   label="Destination Type"
+                  onBlur={field.onBlur}
                   onChange={(_, { value }) => {
                     field.onChange(value);
                   }}
@@ -71,11 +78,13 @@ export const DestinationCreate = () => {
             />
             <Controller
               control={control}
-              name="destination_label"
-              render={({ field }) => (
+              name="label"
+              render={({ field, fieldState }) => (
                 <TextField
                   aria-required
+                  errorText={fieldState.error?.message}
                   label="Destination Name"
+                  onBlur={field.onBlur}
                   onChange={(value) => {
                     field.onChange(value);
                   }}
@@ -100,6 +109,7 @@ export const DestinationCreate = () => {
       >
         <Button
           buttonType="primary"
+          form="createDestinationForm"
           sx={{ mt: theme.spacingFunction(16) }}
           type="submit"
         >

--- a/packages/manager/src/features/DataStream/Shared/DestinationLinodeObjectStorageDetailsForm.tsx
+++ b/packages/manager/src/features/DataStream/Shared/DestinationLinodeObjectStorageDetailsForm.tsx
@@ -9,7 +9,29 @@ import { RegionSelect } from 'src/components/RegionSelect/RegionSelect';
 import { PathSample } from 'src/features/DataStream/Shared/PathSample';
 import { useFlags } from 'src/hooks/useFlags';
 
-export const DestinationLinodeObjectStorageDetailsForm = () => {
+interface DestinationLinodeObjectStorageDetailsFormProps {
+  controlPaths?: {
+    accessKeyId: string;
+    accessKeySecret: string;
+    bucketName: string;
+    host: string;
+    path: string;
+    region: string;
+  };
+}
+
+const defaultPaths = {
+  accessKeyId: 'details.access_key_id',
+  accessKeySecret: 'details.access_key_secret',
+  bucketName: 'details.bucket_name',
+  host: 'details.host',
+  path: 'details.path',
+  region: 'details.region',
+};
+
+export const DestinationLinodeObjectStorageDetailsForm = ({
+  controlPaths = defaultPaths,
+}: DestinationLinodeObjectStorageDetailsFormProps) => {
   const { gecko2 } = useFlags();
   const { isGeckoLAEnabled } = useIsGeckoEnabled(gecko2?.enabled, gecko2?.la);
   const { data: regions } = useRegionsQuery();
@@ -19,11 +41,13 @@ export const DestinationLinodeObjectStorageDetailsForm = () => {
     <>
       <Controller
         control={control}
-        name="host"
-        render={({ field }) => (
+        name={controlPaths.host}
+        render={({ field, fieldState }) => (
           <TextField
             aria-required
+            errorText={fieldState.error?.message}
             label="Host"
+            onBlur={field.onBlur}
             onChange={(value) => {
               field.onChange(value);
             }}
@@ -35,11 +59,13 @@ export const DestinationLinodeObjectStorageDetailsForm = () => {
       />
       <Controller
         control={control}
-        name="bucket_name"
-        render={({ field }) => (
+        name={controlPaths.bucketName}
+        render={({ field, fieldState }) => (
           <TextField
             aria-required
+            errorText={fieldState.error?.message}
             label="Bucket"
+            onBlur={field.onBlur}
             onChange={(value) => {
               field.onChange(value);
             }}
@@ -51,13 +77,15 @@ export const DestinationLinodeObjectStorageDetailsForm = () => {
       />
       <Controller
         control={control}
-        name="region"
-        render={({ field }) => (
+        name={controlPaths.region}
+        render={({ field, fieldState }) => (
           <RegionSelect
             currentCapability="Object Storage"
             disableClearable
+            errorText={fieldState.error?.message}
             isGeckoLAEnabled={isGeckoLAEnabled}
             label="Region"
+            onBlur={field.onBlur}
             onChange={(_, region) => field.onChange(region.id)}
             regionFilter="core"
             regions={regions ?? []}
@@ -67,11 +95,13 @@ export const DestinationLinodeObjectStorageDetailsForm = () => {
       />
       <Controller
         control={control}
-        name="access_key_id"
-        render={({ field }) => (
+        name={controlPaths.accessKeyId}
+        render={({ field, fieldState }) => (
           <HideShowText
             aria-required
+            errorText={fieldState.error?.message}
             label="Access Key ID"
+            onBlur={field.onBlur}
             onChange={(value) => field.onChange(value)}
             placeholder="Access Key ID..."
             value={field.value}
@@ -80,11 +110,13 @@ export const DestinationLinodeObjectStorageDetailsForm = () => {
       />
       <Controller
         control={control}
-        name="access_key_secret"
-        render={({ field }) => (
+        name={controlPaths.accessKeySecret}
+        render={({ field, fieldState }) => (
           <HideShowText
             aria-required
+            errorText={fieldState.error?.message}
             label="Secret Access Key"
+            onBlur={field.onBlur}
             onChange={(value) => field.onChange(value)}
             placeholder="Secret Access Key..."
             value={field.value}
@@ -96,11 +128,13 @@ export const DestinationLinodeObjectStorageDetailsForm = () => {
       <Box alignItems="end" display="flex" flexWrap="wrap" gap="16px">
         <Controller
           control={control}
-          name="path"
-          render={({ field }) => (
+          name={controlPaths.path}
+          render={({ field, fieldState }) => (
             <TextField
               aria-required
+              errorText={fieldState.error?.message}
               label="Log Path Prefix"
+              onBlur={field.onBlur}
               onChange={(value) => field.onChange(value)}
               placeholder="Log Path Prefix..."
               sx={{ width: 416 }}

--- a/packages/manager/src/features/DataStream/Shared/types.ts
+++ b/packages/manager/src/features/DataStream/Shared/types.ts
@@ -4,6 +4,8 @@ import {
   type LinodeObjectStorageDetails,
 } from '@linode/api-v4';
 
+import type { CustomHTTPsDetails } from '@linode/api-v4';
+
 export interface DestinationTypeOption {
   label: string;
   value: string;
@@ -20,7 +22,8 @@ export const destinationTypeOptions: DestinationTypeOption[] = [
   },
 ];
 
-export interface CreateDestinationForm extends LinodeObjectStorageDetails {
-  destination_label: string;
-  destination_type: DestinationType;
+export interface CreateDestinationForm {
+  details: CustomHTTPsDetails | LinodeObjectStorageDetails;
+  label: string;
+  type: DestinationType;
 }

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/CheckoutBar/StreamCreateCheckoutBar.test.tsx
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/CheckoutBar/StreamCreateCheckoutBar.test.tsx
@@ -21,7 +21,9 @@ describe('StreamCreateCheckoutBar', () => {
       component: <StreamCreateCheckoutBar createStream={createStream} />,
       useFormOptions: {
         defaultValues: {
-          destination_type: destinationType.LinodeObjectStorage,
+          destination: {
+            type: destinationType.LinodeObjectStorage,
+          },
         },
       },
     });
@@ -46,9 +48,13 @@ describe('StreamCreateCheckoutBar', () => {
   const TestFormComponent = () => {
     const methods = useForm({
       defaultValues: {
-        type: streamType.AuditLogs,
-        destination_type: destinationType.LinodeObjectStorage,
-        label: '',
+        stream: {
+          label: '',
+          type: streamType.AuditLogs,
+        },
+        destination: {
+          type: destinationType.LinodeObjectStorage,
+        },
       },
     });
 

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/CheckoutBar/StreamCreateCheckoutBar.tsx
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/CheckoutBar/StreamCreateCheckoutBar.tsx
@@ -7,7 +7,7 @@ import { displayPrice } from 'src/components/DisplayPrice';
 import { getDestinationTypeOption } from 'src/features/DataStream/dataStreamUtils';
 import { StyledHeader } from 'src/features/DataStream/Streams/StreamCreate/CheckoutBar/StreamCreateCheckoutBar.styles';
 
-import type { CreateStreamForm } from 'src/features/DataStream/Streams/StreamCreate/types';
+import type { CreateStreamAndDestinationForm } from 'src/features/DataStream/Streams/StreamCreate/types';
 
 export interface Props {
   createStream: () => void;
@@ -15,15 +15,15 @@ export interface Props {
 
 export const StreamCreateCheckoutBar = (props: Props) => {
   const { createStream } = props;
-  const { control } = useFormContext<CreateStreamForm>();
-  const destinationType = useWatch({ control, name: 'destination_type' });
+  const { control } = useFormContext<CreateStreamAndDestinationForm>();
+  const destinationType = useWatch({ control, name: 'destination.type' });
   const formValues = useWatch({
     control,
     name: [
-      'status',
-      'type',
-      'details.cluster_ids',
-      'details.is_auto_add_all_clusters_enabled',
+      'stream.status',
+      'stream.type',
+      'stream.details.cluster_ids',
+      'stream.details.is_auto_add_all_clusters_enabled',
     ],
   });
   const price = getPrice(formValues);

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/CheckoutBar/StreamCreateSubmitBar.test.tsx
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/CheckoutBar/StreamCreateSubmitBar.test.tsx
@@ -14,7 +14,7 @@ describe('StreamCreateSubmitBar', () => {
       component: <StreamCreateSubmitBar createStream={createStream} />,
       useFormOptions: {
         defaultValues: {
-          destination_type: destinationType.LinodeObjectStorage,
+          destination: { type: destinationType.LinodeObjectStorage },
         },
       },
     });

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/CheckoutBar/StreamCreateSubmitBar.tsx
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/CheckoutBar/StreamCreateSubmitBar.tsx
@@ -5,7 +5,7 @@ import { useFormContext, useWatch } from 'react-hook-form';
 import { getDestinationTypeOption } from 'src/features/DataStream/dataStreamUtils';
 import { StyledHeader } from 'src/features/DataStream/Streams/StreamCreate/CheckoutBar/StreamCreateCheckoutBar.styles';
 
-import type { CreateStreamForm } from 'src/features/DataStream/Streams/StreamCreate/types';
+import type { CreateStreamAndDestinationForm } from 'src/features/DataStream/Streams/StreamCreate/types';
 
 type StreamCreateSidebarProps = {
   createStream: () => void;
@@ -14,8 +14,8 @@ type StreamCreateSidebarProps = {
 export const StreamCreateSubmitBar = (props: StreamCreateSidebarProps) => {
   const { createStream } = props;
 
-  const { control } = useFormContext<CreateStreamForm>();
-  const destinationType = useWatch({ control, name: 'destination_type' });
+  const { control } = useFormContext<CreateStreamAndDestinationForm>();
+  const destinationType = useWatch({ control, name: 'destination.type' });
 
   return (
     <Paper sx={{ position: 'sticky', top: 0 }}>

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreate.tsx
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreate.tsx
@@ -1,6 +1,8 @@
+import { yupResolver } from '@hookform/resolvers/yup';
 import { destinationType, streamType } from '@linode/api-v4';
 import { useCreateStreamMutation } from '@linode/queries';
 import { omitProps, Stack } from '@linode/ui';
+import { createStreamAndDestinationFormSchema } from '@linode/validation';
 import Grid from '@mui/material/Grid';
 import { useNavigate } from '@tanstack/react-router';
 import * as React from 'react';
@@ -16,27 +18,36 @@ import { StreamCreateDelivery } from './StreamCreateDelivery';
 import { StreamCreateGeneralInfo } from './StreamCreateGeneralInfo';
 
 import type { CreateStreamPayload } from '@linode/api-v4';
-import type { CreateStreamForm } from 'src/features/DataStream/Streams/StreamCreate/types';
+import type {
+  CreateStreamAndDestinationForm,
+  CreateStreamForm,
+} from 'src/features/DataStream/Streams/StreamCreate/types';
 
 export const StreamCreate = () => {
   const { mutateAsync: createStream } = useCreateStreamMutation();
   const navigate = useNavigate();
 
-  const form = useForm<CreateStreamForm>({
+  const form = useForm<CreateStreamAndDestinationForm>({
     defaultValues: {
-      type: streamType.AuditLogs,
-      destination_type: destinationType.LinodeObjectStorage,
-      region: '',
-      details: {
-        is_auto_add_all_clusters_enabled: false,
+      stream: {
+        type: streamType.AuditLogs,
+        details: {},
+      },
+      destination: {
+        type: destinationType.LinodeObjectStorage,
+        details: {
+          region: '',
+        },
       },
     },
+    mode: 'onBlur',
+    resolver: yupResolver(createStreamAndDestinationFormSchema),
   });
 
   const { control, handleSubmit } = form;
   const selectedStreamType = useWatch({
     control,
-    name: 'type',
+    name: 'stream.type',
   });
 
   const landingHeaderProps = {
@@ -55,23 +66,27 @@ export const StreamCreate = () => {
   };
 
   const onSubmit = () => {
-    const { label, type, destinations, details } = form.getValues();
-    const payload: CreateStreamPayload = {
+    const {
+      stream: { label, type, destinations, details },
+    } = form.getValues();
+    const payload: CreateStreamForm = {
       label,
       type,
       destinations,
+      details,
     };
+
     if (type === streamType.LKEAuditLogs && details) {
       if (details.is_auto_add_all_clusters_enabled) {
-        payload['details'] = omitProps(details, ['cluster_ids']);
+        payload.details = omitProps(details, ['cluster_ids']);
       } else {
-        payload['details'] = omitProps(details, [
+        payload.details = omitProps(details, [
           'is_auto_add_all_clusters_enabled',
         ]);
       }
     }
 
-    createStream(payload).then(() => {
+    createStream(payload as CreateStreamPayload).then(() => {
       sendCreateStreamEvent('Stream Create Page');
       navigate({ to: '/datastream/streams' });
     });

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateClusters.test.tsx
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateClusters.test.tsx
@@ -12,9 +12,8 @@ const renderComponentWithoutSelectedClusters = () => {
     component: <StreamCreateClusters />,
     useFormOptions: {
       defaultValues: {
-        details: {
-          cluster_ids: [],
-          is_auto_add_all_clusters_enabled: false,
+        stream: {
+          details: {},
         },
       },
     },
@@ -163,8 +162,10 @@ describe('StreamCreateClusters', () => {
         component: <StreamCreateClusters />,
         useFormOptions: {
           defaultValues: {
-            details: {
-              cluster_ids: [3],
+            stream: {
+              details: {
+                cluster_ids: [3],
+              },
             },
           },
         },

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateClusters.tsx
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateClusters.tsx
@@ -16,7 +16,7 @@ import { TableRowEmpty } from 'src/components/TableRowEmpty/TableRowEmpty';
 import { TableSortCell } from 'src/components/TableSortCell';
 import { clusters } from 'src/features/DataStream/Streams/StreamCreate/StreamCreateClustersData';
 
-import type { CreateStreamForm } from 'src/features/DataStream/Streams/StreamCreate/types';
+import type { CreateStreamAndDestinationForm } from 'src/features/DataStream/Streams/StreamCreate/types';
 
 // TODO: remove type after fetching the clusters will be done
 export type Cluster = {
@@ -29,7 +29,8 @@ export type Cluster = {
 type OrderByKeys = 'label' | 'logGeneration' | 'region';
 
 export const StreamCreateClusters = () => {
-  const { control, setValue } = useFormContext<CreateStreamForm>();
+  const { control, setValue, formState } =
+    useFormContext<CreateStreamAndDestinationForm>();
 
   const [order, setOrder] = useState<'asc' | 'desc'>('asc');
   const [orderBy, setOrderBy] = useState<OrderByKeys>('label');
@@ -41,7 +42,7 @@ export const StreamCreateClusters = () => {
 
   const isAutoAddAllClustersEnabled = useWatch({
     control,
-    name: 'details.is_auto_add_all_clusters_enabled',
+    name: 'stream.details.is_auto_add_all_clusters_enabled',
   });
   const previousIsAutoAddAllClustersEnabled = usePrevious(
     isAutoAddAllClustersEnabled
@@ -50,7 +51,7 @@ export const StreamCreateClusters = () => {
   useEffect(() => {
     if (isAutoAddAllClustersEnabled !== previousIsAutoAddAllClustersEnabled) {
       setValue(
-        'details.cluster_ids',
+        'stream.details.cluster_ids',
         isAutoAddAllClustersEnabled ? idsWithLogGenerationEnabled : []
       );
     }
@@ -71,7 +72,10 @@ export const StreamCreateClusters = () => {
   };
 
   const getTableContent = (
-    field: ControllerRenderProps<CreateStreamForm, 'details.cluster_ids'>
+    field: ControllerRenderProps<
+      CreateStreamAndDestinationForm,
+      'stream.details.cluster_ids'
+    >
   ) => {
     const selectedIds = field.value || [];
 
@@ -177,6 +181,7 @@ export const StreamCreateClusters = () => {
                       aria-label={`Toggle ${label} cluster`}
                       checked={selectedIds.includes(id)}
                       disabled={isAutoAddAllClustersEnabled || !logGeneration}
+                      onBlur={field.onBlur}
                       onChange={() => toggleCluster(id)}
                     />
                   </TableCell>
@@ -208,10 +213,11 @@ export const StreamCreateClusters = () => {
         newly configured clusters.
       </Notice>
       <Controller
-        name={'details.is_auto_add_all_clusters_enabled'}
+        name={'stream.details.is_auto_add_all_clusters_enabled'}
         render={({ field }) => (
           <Checkbox
             checked={field.value}
+            onBlur={field.onBlur}
             onChange={(_, checked) => field.onChange(checked)}
             sxFormLabel={{ ml: -1 }}
             text="Automatically include all existing and recently configured clusters."
@@ -237,10 +243,17 @@ export const StreamCreateClusters = () => {
         <Table data-testid="clusters-table">
           <Controller
             control={control}
-            name="details.cluster_ids"
+            name="stream.details.cluster_ids"
             render={({ field }) => getTableContent(field)}
           />
         </Table>
+        {!isAutoAddAllClustersEnabled &&
+          formState.errors.stream?.details?.cluster_ids?.message && (
+            <Notice
+              text={formState.errors.stream?.details?.cluster_ids?.message}
+              variant="error"
+            />
+          )}
       </Box>
     </Paper>
   );

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateDelivery.test.tsx
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateDelivery.test.tsx
@@ -13,7 +13,9 @@ describe('StreamCreateDelivery', () => {
       component: <StreamCreateDelivery />,
       useFormOptions: {
         defaultValues: {
-          destination_type: destinationType.LinodeObjectStorage,
+          destination: {
+            type: destinationType.LinodeObjectStorage,
+          },
         },
       },
     });
@@ -30,7 +32,9 @@ describe('StreamCreateDelivery', () => {
       component: <StreamCreateDelivery />,
       useFormOptions: {
         defaultValues: {
-          destination_label: '',
+          destination: {
+            label: '',
+          },
         },
       },
     });
@@ -53,8 +57,10 @@ describe('StreamCreateDelivery', () => {
       component: <StreamCreateDelivery />,
       useFormOptions: {
         defaultValues: {
-          destination_label: '',
-          destination_type: destinationType.LinodeObjectStorage,
+          destination: {
+            label: '',
+            type: destinationType.LinodeObjectStorage,
+          },
         },
       },
     });

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateDelivery.tsx
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateDelivery.tsx
@@ -9,7 +9,7 @@ import { getDestinationTypeOption } from 'src/features/DataStream/dataStreamUtil
 import { DestinationLinodeObjectStorageDetailsForm } from 'src/features/DataStream/Shared/DestinationLinodeObjectStorageDetailsForm';
 import { destinationTypeOptions } from 'src/features/DataStream/Shared/types';
 
-import { type CreateStreamForm } from './types';
+import { type CreateStreamAndDestinationForm } from './types';
 
 type DestinationName = {
   create?: boolean;
@@ -17,9 +17,19 @@ type DestinationName = {
   label: string;
 };
 
+const controlPaths = {
+  accessKeyId: 'destination.details.access_key_id',
+  accessKeySecret: 'destination.details.access_key_secret',
+  bucketName: 'destination.details.bucket_name',
+  host: 'destination.details.host',
+  path: 'destination.details.path',
+  region: 'destination.details.region',
+};
+
 export const StreamCreateDelivery = () => {
   const theme = useTheme();
-  const { control, setValue } = useFormContext<CreateStreamForm>();
+  const { control, setValue } =
+    useFormContext<CreateStreamAndDestinationForm>();
 
   const [showDestinationForm, setShowDestinationForm] =
     React.useState<boolean>(false);
@@ -37,7 +47,7 @@ export const StreamCreateDelivery = () => {
 
   const selectedDestinationType = useWatch({
     control,
-    name: 'destination_type',
+    name: 'destination.type',
   });
 
   const destinationNameFilterOptions = createFilterOptions<DestinationName>();
@@ -50,12 +60,14 @@ export const StreamCreateDelivery = () => {
       </Typography>
       <Controller
         control={control}
-        name="destination_type"
-        render={({ field }) => (
+        name="destination.type"
+        render={({ field, fieldState }) => (
           <Autocomplete
             disableClearable
             disabled={true}
+            errorText={fieldState.error?.message}
             label="Destination Type"
+            onBlur={field.onBlur}
             onChange={(_, { value }) => {
               field.onChange(value);
             }}
@@ -63,13 +75,13 @@ export const StreamCreateDelivery = () => {
             value={getDestinationTypeOption(field.value)}
           />
         )}
-        rules={{ required: true }}
       />
       <Controller
         control={control}
-        name="destination_label"
-        render={({ field }) => (
+        name="destination.label"
+        render={({ field, fieldState }) => (
           <Autocomplete
+            errorText={fieldState.error?.message}
             filterOptions={(options, params) => {
               const filtered = destinationNameFilterOptions(options, params);
               const { inputValue } = params;
@@ -88,9 +100,10 @@ export const StreamCreateDelivery = () => {
             }}
             getOptionLabel={(option) => option.label}
             label="Destination Name"
+            onBlur={field.onBlur}
             onChange={(_, newValue) => {
               field.onChange(newValue?.label || newValue);
-              setValue('destinations', [newValue?.id as number]);
+              setValue('stream.destinations', [newValue?.id as number]);
               setShowDestinationForm(!!newValue?.create);
             }}
             options={destinationNameOptions}
@@ -112,11 +125,12 @@ export const StreamCreateDelivery = () => {
             value={field.value ? { label: field.value } : null}
           />
         )}
-        rules={{ required: true }}
       />
       {showDestinationForm &&
         selectedDestinationType === destinationType.LinodeObjectStorage && (
-          <DestinationLinodeObjectStorageDetailsForm />
+          <DestinationLinodeObjectStorageDetailsForm
+            controlPaths={controlPaths}
+          />
         )}
     </Paper>
   );

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateGeneralInfo.test.tsx
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateGeneralInfo.test.tsx
@@ -27,7 +27,9 @@ describe('StreamCreateGeneralInfo', () => {
       component: <StreamCreateGeneralInfo />,
       useFormOptions: {
         defaultValues: {
-          type: streamType.AuditLogs,
+          stream: {
+            type: streamType.AuditLogs,
+          },
         },
       },
     });

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateGeneralInfo.tsx
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateGeneralInfo.tsx
@@ -3,10 +3,11 @@ import { Autocomplete, Paper, TextField, Typography } from '@linode/ui';
 import React from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 
-import { type CreateStreamForm } from './types';
+import { type CreateStreamAndDestinationForm } from './types';
 
 export const StreamCreateGeneralInfo = () => {
-  const { control } = useFormContext<CreateStreamForm>();
+  const { control, setValue } =
+    useFormContext<CreateStreamAndDestinationForm>();
 
   const streamTypeOptions = [
     {
@@ -19,16 +20,26 @@ export const StreamCreateGeneralInfo = () => {
     },
   ];
 
+  const updateStreamDetails = (value: string) => {
+    if (value === streamType.LKEAuditLogs) {
+      setValue('stream.details.is_auto_add_all_clusters_enabled', false);
+    } else {
+      setValue('stream.details', {});
+    }
+  };
+
   return (
     <Paper>
       <Typography variant="h2">General Information</Typography>
       <Controller
         control={control}
-        name="label"
-        render={({ field }) => (
+        name="stream.label"
+        render={({ field, fieldState }) => (
           <TextField
             aria-required
+            errorText={fieldState.error?.message}
             label="Name"
+            onBlur={field.onBlur}
             onChange={(value) => {
               field.onChange(value);
             }}
@@ -40,13 +51,16 @@ export const StreamCreateGeneralInfo = () => {
       />
       <Controller
         control={control}
-        name="type"
-        render={({ field }) => (
+        name="stream.type"
+        render={({ field, fieldState }) => (
           <Autocomplete
             disableClearable
+            errorText={fieldState.error?.message}
             label="Stream Type"
+            onBlur={field.onBlur}
             onChange={(_, { value }) => {
               field.onChange(value);
+              updateStreamDetails(value);
             }}
             options={streamTypeOptions}
             value={streamTypeOptions.find(({ value }) => value === field.value)}

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/types.ts
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/types.ts
@@ -2,5 +2,11 @@ import type { CreateStreamPayload } from '@linode/api-v4';
 import type { CreateDestinationForm } from 'src/features/DataStream/Shared/types';
 
 export interface CreateStreamForm
-  extends CreateDestinationForm,
-    CreateStreamPayload {}
+  extends Omit<CreateStreamPayload, 'destinations'> {
+  destinations: (number | undefined)[];
+}
+
+export interface CreateStreamAndDestinationForm {
+  destination: CreateDestinationForm;
+  stream: CreateStreamForm;
+}

--- a/packages/validation/.changeset/pr-12557-upcoming-features-1753339964453.md
+++ b/packages/validation/.changeset/pr-12557-upcoming-features-1753339964453.md
@@ -1,0 +1,5 @@
+---
+"@linode/validation": Upcoming Features
+---
+
+Validation for datastream forms: create stream and destination. Validation for datastream create POST request ([#12557](https://github.com/linode/manager/pull/12557))

--- a/packages/validation/src/datastream.schema.ts
+++ b/packages/validation/src/datastream.schema.ts
@@ -1,0 +1,165 @@
+import { array, boolean, mixed, number, object, string } from 'yup';
+
+import type { InferType, MixedSchema, Schema } from 'yup';
+
+const maxLength = 255;
+const maxLengthMessage = 'Length must be 255 characters or less.';
+
+// DataSteam Destination
+
+const authenticationDetailsSchema = object({
+  basic_authentication_user: string()
+    .max(maxLength, maxLengthMessage)
+    .required(),
+  basic_authentication_password: string()
+    .max(maxLength, maxLengthMessage)
+    .required(),
+});
+
+const authenticationSchema = object({
+  type: string().oneOf(['basic', 'none']).required(),
+  details: mixed()
+    .defined()
+    .when('type', {
+      is: 'basic',
+      then: () => authenticationDetailsSchema.required(),
+      otherwise: () =>
+        mixed()
+          .nullable()
+          .test(
+            'null-or-undefined',
+            'For type `none` details should be `null` or `undefined`.',
+            (value) => !value,
+          ),
+    }) as Schema<InferType<typeof authenticationDetailsSchema> | undefined>,
+});
+
+const clientCertificateDetailsSchema = object({
+  tls_hostname: string().max(maxLength, maxLengthMessage).required(),
+  client_ca_certificate: string().required(),
+  client_certificate: string().required(),
+  client_private_key: string().required(),
+});
+
+const customHeaderSchema = object({
+  name: string().max(maxLength, maxLengthMessage).required(),
+  value: string().max(maxLength, maxLengthMessage).required(),
+});
+
+const customHTTPsDetailsSchema = object({
+  authentication: authenticationSchema.required(),
+  client_certificate_details: clientCertificateDetailsSchema.optional(),
+  content_type: string()
+    .oneOf(['application/json', 'application/json; charset=utf-8'])
+    .required(),
+  custom_headers: array().of(customHeaderSchema).min(1).optional(),
+  data_compression: string().oneOf(['gzip', 'None']).required(),
+  endpoint_url: string().max(maxLength, maxLengthMessage).required(),
+});
+
+const linodeObjectStorageDetailsSchema = object({
+  host: string().max(maxLength, maxLengthMessage).required('Host is required.'),
+  bucket_name: string()
+    .max(maxLength, maxLengthMessage)
+    .required('Bucket name is required.'),
+  region: string()
+    .max(maxLength, maxLengthMessage)
+    .required('Region is required.'),
+  path: string().max(maxLength, maxLengthMessage).required('Path is required.'),
+  access_key_id: string()
+    .max(maxLength, maxLengthMessage)
+    .required('Access Key ID is required.'),
+  access_key_secret: string()
+    .max(maxLength, maxLengthMessage)
+    .required('Access Key Secret is required.'),
+});
+
+export const createDestinationSchema = object().shape({
+  label: string()
+    .max(maxLength, maxLengthMessage)
+    .required('Destination name is required.'),
+  type: string().oneOf(['linode_object_storage', 'custom_https']).required(),
+  details: mixed<
+    | InferType<typeof customHTTPsDetailsSchema>
+    | InferType<typeof linodeObjectStorageDetailsSchema>
+  >()
+    .defined()
+    .required()
+    .when('type', {
+      is: 'linode_object_storage',
+      then: () => linodeObjectStorageDetailsSchema,
+      otherwise: () => customHTTPsDetailsSchema,
+    }),
+});
+
+// DataSteam Stream
+
+const streamDetailsBase = object({
+  cluster_ids: array()
+    .of(number().defined())
+    .min(1, 'At least one cluster must be selected.'),
+  is_auto_add_all_clusters_enabled: boolean(),
+});
+
+const streamDetailsSchema = streamDetailsBase.test(
+  'cluster_ids-or-all_clusters_enabled',
+  'Either cluster_ids or is_auto_add_all_clusters_enabled should be set.',
+  (value) => {
+    const HasClusterIds = 'cluster_ids' in value;
+    const HasAllClustersEnabled = 'is_auto_add_all_clusters_enabled' in value;
+    return HasClusterIds !== HasAllClustersEnabled;
+  },
+);
+
+const detailsShouldBeEmpty = (schema: MixedSchema) =>
+  schema
+    .defined()
+    .test(
+      'details-should-be-empty',
+      'Empty details for type `audit_logs`',
+      (value) => Object.keys(value).length === 0,
+    );
+
+const streamSchemaBase = object({
+  label: string()
+    .max(maxLength, maxLengthMessage)
+    .required('Stream name is required.'),
+  status: mixed<'active' | 'inactive'>().oneOf(['active', 'inactive']),
+  destinations: array().of(number().defined()).ensure().min(1).required(),
+  details: mixed<InferType<typeof streamDetailsSchema> | object>().when(
+    'type',
+    {
+      is: 'lke_audit_logs',
+      then: () => streamDetailsSchema.required(),
+      otherwise: detailsShouldBeEmpty,
+    },
+  ),
+});
+
+export const createStreamSchema = streamSchemaBase.shape({
+  type: string()
+    .oneOf(['audit_logs', 'lke_audit_logs'])
+    .required('Stream type is required.'),
+});
+
+export const createStreamAndDestinationFormSchema = object({
+  stream: createStreamSchema.shape({
+    destinations: array().of(number()).ensure().min(1).required(),
+    details: mixed<InferType<typeof streamDetailsSchema> | object>().when(
+      'type',
+      {
+        is: 'lke_audit_logs',
+        then: () => streamDetailsBase.required(),
+        otherwise: detailsShouldBeEmpty,
+      },
+    ),
+  }),
+  destination: createDestinationSchema.defined().when('stream.destinations', {
+    is: (value: never[]) => value?.length === 1 && value[0] === undefined,
+    then: (schema) => schema,
+    otherwise: (schema) =>
+      schema.shape({
+        details: mixed().strip(),
+      }),
+  }),
+});

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -3,6 +3,7 @@ export * from './buckets.schema';
 export * from './cloudnats.schema';
 export * from './cloudpulse.schema';
 export * from './databases.schema';
+export * from './datastream.schema';
 export * from './domains.schema';
 export * from './firewalls.schema';
 export * from './images.schema';


### PR DESCRIPTION
## Description 📝

DataStream: Stream and Destination validation.

## Changes  🔄

- Stream form validation.
- Destination form validation.
- Create Stream request payload validation.

## Target release date 🗓️

August 2025

## Preview 📷

| Before  | After   |
| ------- | ------- |
|![Screenshot 2025-07-23 at 12 36 17](https://github.com/user-attachments/assets/8a5be63c-96e3-4c09-a933-78a528c6864b)|![Screenshot 2025-07-23 at 12 34 27](https://github.com/user-attachments/assets/36e205bf-bb4f-4997-8bfb-d0e3d65aa7fa)|
|![Screenshot 2025-07-23 at 13 14 50](https://github.com/user-attachments/assets/e78d17e0-ff66-4610-9b7f-4d88367a063b)|![Screenshot 2025-07-23 at 13 15 05](https://github.com/user-attachments/assets/4a6e215d-2144-4472-9709-37d25759342f)|

## How to test 🧪

### Prerequisites

- Open Local Dev Tools
- Enable MSW, set Base Preset to CRUD
- Apply

### Verification steps

Stream form:
- Navigate to datastream/streams
- Click on Create Stream button
- Click on submit button (Create Stream) to see form fields being validated (fields also validate on blur)
- Fill the name field and choose destination to see validation state change
- Submit to create stream 
(creating stream with new destination is not yet supported, payload validation will throw error in console)

Destination form:
- Navigate to datastream/destinations
- Click on Create Destination button
- Click on submit button (Create Destination) to see form fields being validated  (fields also validate on blur)
(Submitting the form is not yet implemented)

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
📱 Providing mobile support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>