### PR TITLE
fix: [M3-10376] - Invoice details page UI issue and routing regression

### DIFF
--- a/packages/manager/.changeset/pr-12565-fixed-1753299138477.md
+++ b/packages/manager/.changeset/pr-12565-fixed-1753299138477.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Header alignment on invoice details page ([#12565](https://github.com/linode/manager/pull/12565))

--- a/packages/manager/src/components/DownloadCSV/DownloadCSV.tsx
+++ b/packages/manager/src/components/DownloadCSV/DownloadCSV.tsx
@@ -63,6 +63,7 @@ export const DownloadCSV = ({
         filename={filename}
         headers={headers}
         ref={csvRef}
+        style={{ display: 'none' }}
         tabIndex={-1}
       />
       {renderButton}

--- a/packages/manager/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
+++ b/packages/manager/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
@@ -1,9 +1,16 @@
 import { getInvoice, getInvoiceItems } from '@linode/api-v4/lib/account';
 import { useAccount, useRegionsQuery } from '@linode/queries';
-import { Box, Button, IconButton, Notice, Paper, Typography } from '@linode/ui';
+import {
+  Box,
+  Button,
+  IconButton,
+  Notice,
+  Paper,
+  Stack,
+  Typography,
+} from '@linode/ui';
 import { getAll } from '@linode/utilities';
 import KeyboardArrowLeft from '@mui/icons-material/KeyboardArrowLeft';
-import Grid from '@mui/material/Grid';
 import { useTheme } from '@mui/material/styles';
 import { createLazyRoute } from '@tanstack/react-router';
 import { useParams } from '@tanstack/react-router';
@@ -108,11 +115,6 @@ export const InvoiceDetail = () => {
     { key: 'total', label: 'Total (USD)' },
   ];
 
-  const sxGrid = {
-    alignItems: 'center',
-    display: 'flex',
-  };
-
   const sxDownloadButton = {
     whiteSpace: 'nowrap',
   };
@@ -120,169 +122,140 @@ export const InvoiceDetail = () => {
   return (
     <>
       <DocumentTitleSegment segment="Invoice | Account & Billing" />
-      <Paper
-        sx={{
-          padding: `${theme.spacing(2)} ${theme.spacing(3)}`,
-        }}
-      >
-        <Grid
-          container
-          sx={{
-            rowGap: 2,
-          }}
-        >
-          <Grid size={12}>
-            <Grid container data-qa-invoice-header spacing={2} sx={sxGrid}>
-              <Grid
-                size={{
-                  sm: 4,
-                  xs: 12,
-                }}
-                sx={sxGrid}
-              >
-                <Link
-                  accessibleAriaLabel="Back to Billing"
-                  data-qa-back-to-billing
-                  to={`/account/billing`}
-                >
-                  <IconButton
-                    component="span"
-                    disableFocusRipple
-                    role="none"
-                    size="large"
-                    sx={{
-                      padding: 0,
-                    }}
-                    tabIndex={-1}
-                  >
-                    <KeyboardArrowLeft
-                      sx={{
-                        height: 34,
-                        width: 34,
-                      }}
-                    />
-                  </IconButton>
-                </Link>
-                {invoice && (
-                  <LandingHeader
-                    breadcrumbProps={{
-                      crumbOverrides: [{ label: 'Billing Info', position: 1 }],
-                      firstAndLastOnly: true,
-                      labelTitle: `Invoice #${invoice.id}`,
-                      pathname: location.pathname,
-                    }}
-                  />
-                )}
-              </Grid>
-              <Grid
-                data-qa-printable-invoice
-                size={{
-                  sm: 'grow',
-                }}
-                sx={{ ...sxGrid, justifyContent: 'flex-end' }}
-              >
-                {account && invoice && items && (
-                  <>
-                    <DownloadCSV
-                      csvRef={csvRef}
-                      data={items}
-                      filename={`invoice-${invoice.date}.csv`}
-                      headers={csvHeaders}
-                      onClick={() => csvRef.current.link.click()}
-                      sx={{ ...sxDownloadButton, marginRight: '8px' }}
-                    />
-                    <Button
-                      buttonType="secondary"
-                      onClick={() => printInvoicePDF(account, invoice, items)}
-                      sx={sxDownloadButton}
-                    >
-                      Download PDF
-                    </Button>
-                  </>
-                )}
-              </Grid>
-              <Grid
-                size={{
-                  sm: 'auto',
-                }}
-              >
-                {invoice && (
-                  <Typography data-qa-total={invoice.total} variant="h2">
-                    Total:{' '}
-                    <Currency
-                      quantity={invoice.total}
-                      wrapInParentheses={invoice.total < 0}
-                    />
-                  </Typography>
-                )}
-              </Grid>
-            </Grid>
-          </Grid>
-          <Grid size={12}>
-            {pdfGenerationError && (
-              <Notice variant="error">Failed generating PDF.</Notice>
-            )}
-            <InvoiceTable
-              errors={errors}
-              items={items}
-              loading={loading}
-              shouldShowRegion={shouldShowRegion}
-            />
-          </Grid>
-          <Grid size={12}>
-            {invoice && (
-              <Box
-                data-qa-invoice-summary
+      <Paper>
+        <Stack spacing={2}>
+          <Stack
+            alignItems="center"
+            data-qa-invoice-header
+            direction="row"
+            spacing={2}
+          >
+            <Link
+              accessibleAriaLabel="Back to Billing"
+              data-qa-back-to-billing
+              to={`/account/billing`}
+            >
+              <IconButton
+                component="span"
+                disableFocusRipple
+                role="none"
+                size="large"
                 sx={{
-                  alignItems: 'flex-end',
-                  display: 'flex',
-                  flexDirection: 'column',
-                  gap: theme.spacing(2),
-                  padding: theme.spacing(1),
+                  padding: 0,
                 }}
+                tabIndex={-1}
               >
-                <Typography variant="h2">
-                  Subtotal:{' '}
-                  <Currency
-                    quantity={invoice.subtotal}
-                    wrapInParentheses={invoice.subtotal < 0}
-                  />
-                </Typography>
-                {invoice.tax_summary.map((summary) => {
-                  return (
-                    <Typography key={summary.name} variant="h2">
-                      {summary.name === 'Standard'
-                        ? 'Standard Tax: '
-                        : `${summary.name}: `}
-                      <Currency quantity={summary.tax} />
-                    </Typography>
-                  );
-                })}
-                <Typography variant="h2">
-                  Tax Subtotal: <Currency quantity={invoice.tax} />
-                </Typography>
-                <Typography variant="h2">
-                  Total:{' '}
-                  <Currency
-                    quantity={invoice.total}
-                    wrapInParentheses={invoice.total < 0}
-                  />
-                </Typography>
-                <Typography>
-                  This invoice may include Linode Compute Instances that have
-                  been powered off as the data is maintained and resources are
-                  still reserved. If you no longer need powered-down Linodes,
-                  you can{' '}
-                  <Link to="https://techdocs.akamai.com/cloud-computing/docs/stop-further-billing">
-                    {' '}
-                    remove the service
-                  </Link>{' '}
-                  from your account.
-                </Typography>
-              </Box>
+                <KeyboardArrowLeft
+                  sx={{
+                    height: 34,
+                    width: 34,
+                  }}
+                />
+              </IconButton>
+            </Link>
+            {invoice && (
+              <LandingHeader
+                breadcrumbProps={{
+                  crumbOverrides: [{ label: 'Billing Info', position: 1 }],
+                  firstAndLastOnly: true,
+                  labelTitle: `Invoice #${invoice.id}`,
+                  pathname: location.pathname,
+                }}
+              />
             )}
-          </Grid>
-        </Grid>
+            {account && invoice && items && (
+              <>
+                <DownloadCSV
+                  csvRef={csvRef}
+                  data={items}
+                  filename={`invoice-${invoice.date}.csv`}
+                  headers={csvHeaders}
+                  onClick={() => csvRef.current.link.click()}
+                  sx={{ ...sxDownloadButton, marginRight: '8px' }}
+                />
+                <Button
+                  buttonType="secondary"
+                  onClick={() => printInvoicePDF(account, invoice, items)}
+                  sx={sxDownloadButton}
+                >
+                  Download PDF
+                </Button>
+              </>
+            )}
+            {invoice && (
+              <Typography
+                data-qa-total={invoice.total}
+                sx={{ whiteSpace: 'nowrap' }}
+                variant="h2"
+              >
+                Total:{' '}
+                <Currency
+                  quantity={invoice.total}
+                  wrapInParentheses={invoice.total < 0}
+                />
+              </Typography>
+            )}
+          </Stack>
+          {pdfGenerationError && (
+            <Notice variant="error">Failed generating PDF.</Notice>
+          )}
+          <InvoiceTable
+            errors={errors}
+            items={items}
+            loading={loading}
+            shouldShowRegion={shouldShowRegion}
+          />
+          {invoice && (
+            <Box
+              data-qa-invoice-summary
+              sx={{
+                alignItems: 'flex-end',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: theme.spacing(2),
+                padding: theme.spacing(1),
+              }}
+            >
+              <Typography variant="h2">
+                Subtotal:{' '}
+                <Currency
+                  quantity={invoice.subtotal}
+                  wrapInParentheses={invoice.subtotal < 0}
+                />
+              </Typography>
+              {invoice.tax_summary.map((summary) => {
+                return (
+                  <Typography key={summary.name} variant="h2">
+                    {summary.name === 'Standard'
+                      ? 'Standard Tax: '
+                      : `${summary.name}: `}
+                    <Currency quantity={summary.tax} />
+                  </Typography>
+                );
+              })}
+              <Typography variant="h2">
+                Tax Subtotal: <Currency quantity={invoice.tax} />
+              </Typography>
+              <Typography variant="h2">
+                Total:{' '}
+                <Currency
+                  quantity={invoice.total}
+                  wrapInParentheses={invoice.total < 0}
+                />
+              </Typography>
+              <Typography>
+                This invoice may include Linode Compute Instances that have been
+                powered off as the data is maintained and resources are still
+                reserved. If you no longer need powered-down Linodes, you can{' '}
+                <Link to="https://techdocs.akamai.com/cloud-computing/docs/stop-further-billing">
+                  {' '}
+                  remove the service
+                </Link>{' '}
+                from your account.
+              </Typography>
+            </Box>
+          )}
+        </Stack>
       </Paper>
     </>
   );

--- a/packages/manager/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
+++ b/packages/manager/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
@@ -128,43 +128,53 @@ export const InvoiceDetail = () => {
             alignItems="center"
             data-qa-invoice-header
             direction="row"
-            spacing={2}
+            flexWrap="wrap"
+            justifyContent="space-between"
+            spacing={1}
           >
-            <Link
-              accessibleAriaLabel="Back to Billing"
-              data-qa-back-to-billing
-              to={`/account/billing`}
-            >
-              <IconButton
-                component="span"
-                disableFocusRipple
-                role="none"
-                size="large"
-                sx={{
-                  padding: 0,
-                }}
-                tabIndex={-1}
+            <Stack direction="row" flexWrap="nowrap" spacing={1}>
+              <Link
+                accessibleAriaLabel="Back to Billing"
+                data-qa-back-to-billing
+                to={`/account/billing`}
               >
-                <KeyboardArrowLeft
+                <IconButton
+                  component="span"
+                  disableFocusRipple
+                  role="none"
+                  size="large"
                   sx={{
-                    height: 34,
-                    width: 34,
+                    padding: 0,
                   }}
+                  tabIndex={-1}
+                >
+                  <KeyboardArrowLeft
+                    sx={{
+                      height: 34,
+                      width: 34,
+                    }}
+                  />
+                </IconButton>
+              </Link>
+              <Box>
+                <LandingHeader
+                  breadcrumbProps={{
+                    crumbOverrides: [{ label: 'Billing Info', position: 1 }],
+                    firstAndLastOnly: true,
+                    labelTitle: `Invoice #${invoiceId}`,
+                    pathname: location.pathname,
+                  }}
+                  spacingBottom={0}
                 />
-              </IconButton>
-            </Link>
-            {invoice && (
-              <LandingHeader
-                breadcrumbProps={{
-                  crumbOverrides: [{ label: 'Billing Info', position: 1 }],
-                  firstAndLastOnly: true,
-                  labelTitle: `Invoice #${invoice.id}`,
-                  pathname: location.pathname,
-                }}
-              />
-            )}
+              </Box>
+            </Stack>
             {account && invoice && items && (
-              <>
+              <Stack
+                alignItems="center"
+                direction="row"
+                flexWrap="wrap"
+                spacing={1}
+              >
                 <DownloadCSV
                   csvRef={csvRef}
                   data={items}
@@ -180,20 +190,20 @@ export const InvoiceDetail = () => {
                 >
                   Download PDF
                 </Button>
-              </>
-            )}
-            {invoice && (
-              <Typography
-                data-qa-total={invoice.total}
-                sx={{ whiteSpace: 'nowrap' }}
-                variant="h2"
-              >
-                Total:{' '}
-                <Currency
-                  quantity={invoice.total}
-                  wrapInParentheses={invoice.total < 0}
-                />
-              </Typography>
+                {invoice && (
+                  <Typography
+                    data-qa-total={invoice.total}
+                    sx={{ whiteSpace: 'nowrap' }}
+                    variant="h2"
+                  >
+                    Total:{' '}
+                    <Currency
+                      quantity={invoice.total}
+                      wrapInParentheses={invoice.total < 0}
+                    />
+                  </Typography>
+                )}
+              </Stack>
             )}
           </Stack>
           {pdfGenerationError && (

--- a/packages/manager/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
+++ b/packages/manager/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
@@ -115,10 +115,6 @@ export const InvoiceDetail = () => {
     { key: 'total', label: 'Total (USD)' },
   ];
 
-  const sxDownloadButton = {
-    whiteSpace: 'nowrap',
-  };
-
   return (
     <>
       <DocumentTitleSegment segment="Invoice | Account & Billing" />
@@ -129,14 +125,14 @@ export const InvoiceDetail = () => {
             data-qa-invoice-header
             direction="row"
             flexWrap="wrap"
+            gap={1}
             justifyContent="space-between"
-            spacing={1}
           >
             <Stack direction="row" flexWrap="nowrap" spacing={1}>
               <Link
                 accessibleAriaLabel="Back to Billing"
                 data-qa-back-to-billing
-                to={`/account/billing`}
+                to="/account/billing"
               >
                 <IconButton
                   component="span"
@@ -173,7 +169,7 @@ export const InvoiceDetail = () => {
                 alignItems="center"
                 direction="row"
                 flexWrap="wrap"
-                spacing={1}
+                gap={1}
               >
                 <DownloadCSV
                   csvRef={csvRef}
@@ -181,12 +177,10 @@ export const InvoiceDetail = () => {
                   filename={`invoice-${invoice.date}.csv`}
                   headers={csvHeaders}
                   onClick={() => csvRef.current.link.click()}
-                  sx={{ ...sxDownloadButton, marginRight: '8px' }}
                 />
                 <Button
                   buttonType="secondary"
                   onClick={() => printInvoicePDF(account, invoice, items)}
-                  sx={sxDownloadButton}
                 >
                   Download PDF
                 </Button>

--- a/packages/manager/src/routes/account/index.ts
+++ b/packages/manager/src/routes/account/index.ts
@@ -14,6 +14,11 @@ const accountRoute = createRoute({
   component: AccountRoute,
   getParentRoute: () => rootRoute,
   path: 'account',
+});
+
+const accountTabsRoute = createRoute({
+  getParentRoute: () => accountRoute,
+  path: '/',
 }).lazy(() =>
   import('src/features/Account/accountLandingLazyRoute').then(
     (m) => m.accountLandingLazyRoute
@@ -21,8 +26,8 @@ const accountRoute = createRoute({
 );
 
 const accountBillingRoute = createRoute({
-  getParentRoute: () => accountRoute,
-  path: 'billing',
+  getParentRoute: () => accountTabsRoute,
+  path: '/billing',
   validateSearch: (search: AccountBillingSearch) => search,
 }).lazy(() =>
   import('src/features/Billing/billingDetailLazyRoute').then(
@@ -31,7 +36,7 @@ const accountBillingRoute = createRoute({
 );
 
 const accountUsersRoute = createRoute({
-  getParentRoute: () => accountRoute,
+  getParentRoute: () => accountTabsRoute,
   path: '/users',
 }).lazy(() =>
   import('src/features/Users/usersLandingLazyRoute').then(
@@ -40,7 +45,7 @@ const accountUsersRoute = createRoute({
 );
 
 const accountQuotasRoute = createRoute({
-  getParentRoute: () => accountRoute,
+  getParentRoute: () => accountTabsRoute,
   path: '/quotas',
 }).lazy(() =>
   import('src/features/Account/Quotas/quotasLazyRoute').then(
@@ -49,7 +54,7 @@ const accountQuotasRoute = createRoute({
 );
 
 const accountLoginHistoryRoute = createRoute({
-  getParentRoute: () => accountRoute,
+  getParentRoute: () => accountTabsRoute,
   path: '/login-history',
 }).lazy(() =>
   import('src/features/Account/accountLoginsLazyRoute').then(
@@ -58,7 +63,7 @@ const accountLoginHistoryRoute = createRoute({
 );
 
 const accountServiceTransfersRoute = createRoute({
-  getParentRoute: () => accountRoute,
+  getParentRoute: () => accountTabsRoute,
   path: '/service-transfers',
 }).lazy(() =>
   import(
@@ -67,7 +72,7 @@ const accountServiceTransfersRoute = createRoute({
 );
 
 const accountMaintenanceRoute = createRoute({
-  getParentRoute: () => accountRoute,
+  getParentRoute: () => accountTabsRoute,
   path: '/maintenance',
 }).lazy(() =>
   import('src/features/Account/Maintenance/maintenanceLandingLazyRoute').then(
@@ -76,7 +81,7 @@ const accountMaintenanceRoute = createRoute({
 );
 
 const accountSettingsRoute = createRoute({
-  getParentRoute: () => accountRoute,
+  getParentRoute: () => accountTabsRoute,
   path: '/settings',
 }).lazy(() =>
   import('src/features/Account/globalSettingsLazyRoute').then(
@@ -85,8 +90,8 @@ const accountSettingsRoute = createRoute({
 );
 
 const accountUsersUsernameRoute = createRoute({
-  getParentRoute: () => rootRoute,
-  path: 'account/users/$username',
+  getParentRoute: () => accountRoute,
+  path: '/users/$username',
 }).lazy(() =>
   import('src/features/Users/userDetailLazyRoute').then(
     (m) => m.userDetailLazyRoute
@@ -111,7 +116,7 @@ const accountUsersUsernamePermissionsRoute = createRoute({
   )
 );
 
-const accountInvoicesInvoiceIdRoute = createRoute({
+const accountInvoiceDetailsRoute = createRoute({
   getParentRoute: () => accountRoute,
   parseParams: (params) => ({
     invoiceId: Number(params.invoiceId),
@@ -133,17 +138,19 @@ const accountEntityTransfersCreateRoute = createRoute({
 );
 
 export const accountRouteTree = accountRoute.addChildren([
-  accountUsersRoute,
-  accountQuotasRoute,
-  accountLoginHistoryRoute,
-  accountServiceTransfersRoute,
-  accountMaintenanceRoute,
-  accountSettingsRoute,
+  accountTabsRoute.addChildren([
+    accountBillingRoute,
+    accountUsersRoute,
+    accountQuotasRoute,
+    accountLoginHistoryRoute,
+    accountServiceTransfersRoute,
+    accountMaintenanceRoute,
+    accountSettingsRoute,
+  ]),
+  accountInvoiceDetailsRoute,
+  accountEntityTransfersCreateRoute,
   accountUsersUsernameRoute.addChildren([
     accountUsersUsernameProfileRoute,
     accountUsersUsernamePermissionsRoute,
   ]),
-  accountBillingRoute,
-  accountInvoicesInvoiceIdRoute,
-  accountEntityTransfersCreateRoute,
 ]);


### PR DESCRIPTION
## Description 📝

- Fixes a UI alignment issue in the Invoice details page header (bug in production)
- Fixes a routing regressions with the Invoice details page
  - I think it may have been introduced in https://github.com/linode/manager/pull/12532  (not in production yet)

## Preview 📷

| `develop`  | This PR   |
| ------- | ------- |
| ![Screenshot 2025-07-23 at 1 07 34 PM](https://github.com/user-attachments/assets/d3835d23-5a2c-4cdf-b20a-2073aec9829a) | ![Screenshot 2025-07-23 at 1 06 14 PM](https://github.com/user-attachments/assets/8c35d916-9498-4c9b-9999-c5886279b44e)  |
| The invoice details page is incorrectly rendered under the tabs and the header alignment is messed up | The invoice details is back to being a dedicated page and the header looks good 🎉  | 


## How to test 🧪

### Prerequisites

- Have an account with an invoice on it

### Reproduction steps

- Use dev or the latest develop code locally
- Go to `/account/billing/invoices/<id>` in Cloud Manager
- You should see a misaligned header 
- You should also see that the invoice details route is shown under the tabs

### Verification steps

- Go to `/account/billing/invoices/<id>` in Cloud Manager
- Verify the invoice details page is its own route (not nested under the account tabs)
- Verify the header on the invoice details page is properly aligned and works well on mobile viewports

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>