### PR TITLE
upcoming: [DPS-34204] DataStream - cleanup docs and costs

### DIFF
--- a/packages/api-v4/.changeset/pr-12572-upcoming-features-1753360891663.md
+++ b/packages/api-v4/.changeset/pr-12572-upcoming-features-1753360891663.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Upcoming Features
+---
+
+Remove the docs and costs from streams and destinations landing pages and stream create form ([#12572](https://github.com/linode/manager/pull/12572))

--- a/packages/manager/src/features/DataStream/Destinations/DestinationsLandingEmptyStateData.ts
+++ b/packages/manager/src/features/DataStream/Destinations/DestinationsLandingEmptyStateData.ts
@@ -1,8 +1,3 @@
-import {
-  docsLink,
-  guidesMoreLinkText,
-} from 'src/utilities/emptyStateLandingUtils';
-
 import type {
   ResourcesHeaders,
   ResourcesLinks,
@@ -21,16 +16,10 @@ export const linkAnalyticsEvent: ResourcesLinks['linkAnalyticsEvent'] = {
 };
 
 export const gettingStartedGuides: ResourcesLinkSection = {
-  links: [
-    {
-      // TODO: Change the link and text when proper documentation is ready
-      text: 'Getting started guide',
-      to: 'https://techdocs.akamai.com/cloud-computing/docs',
-    },
-  ],
+  links: [],
   moreInfo: {
-    text: guidesMoreLinkText,
-    to: docsLink,
+    text: '',
+    to: '',
   },
-  title: 'Getting Started Guides',
+  title: '',
 };

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/CheckoutBar/StreamCreateSubmitBar.test.tsx
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/CheckoutBar/StreamCreateSubmitBar.test.tsx
@@ -1,0 +1,38 @@
+import { destinationType } from '@linode/api-v4';
+import { screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect } from 'vitest';
+
+import { StreamCreateSubmitBar } from 'src/features/DataStream/Streams/StreamCreate/CheckoutBar/StreamCreateSubmitBar';
+import { renderWithThemeAndHookFormContext } from 'src/utilities/testHelpers';
+
+describe('StreamCreateSubmitBar', () => {
+  const createStream = () => {};
+
+  const renderComponent = () => {
+    renderWithThemeAndHookFormContext({
+      component: <StreamCreateSubmitBar createStream={createStream} />,
+      useFormOptions: {
+        defaultValues: {
+          destination_type: destinationType.LinodeObjectStorage,
+        },
+      },
+    });
+  };
+
+  it('should render checkout bar with enabled checkout button', async () => {
+    renderComponent();
+    const submitButton = screen.getByText('Create Stream');
+
+    expect(submitButton).toBeEnabled();
+  });
+
+  it('should render Delivery summary with destination type', () => {
+    renderComponent();
+    const deliveryTitle = screen.getByText('Delivery');
+    const deliveryType = screen.getByText('Linode Object Storage');
+
+    expect(deliveryTitle).toBeInTheDocument();
+    expect(deliveryType).toBeInTheDocument();
+  });
+});

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/CheckoutBar/StreamCreateSubmitBar.tsx
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/CheckoutBar/StreamCreateSubmitBar.tsx
@@ -1,0 +1,48 @@
+import { Box, Button, Divider, Paper, Stack, Typography } from '@linode/ui';
+import * as React from 'react';
+import { useFormContext, useWatch } from 'react-hook-form';
+
+import { getDestinationTypeOption } from 'src/features/DataStream/dataStreamUtils';
+import { StyledHeader } from 'src/features/DataStream/Streams/StreamCreate/CheckoutBar/StreamCreateCheckoutBar.styles';
+
+import type { CreateStreamForm } from 'src/features/DataStream/Streams/StreamCreate/types';
+
+type StreamCreateSidebarProps = {
+  createStream: () => void;
+};
+
+export const StreamCreateSubmitBar = (props: StreamCreateSidebarProps) => {
+  const { createStream } = props;
+
+  const { control } = useFormContext<CreateStreamForm>();
+  const destinationType = useWatch({ control, name: 'destination_type' });
+
+  return (
+    <Paper sx={{ position: 'sticky', top: 0 }}>
+      <Stack spacing={2}>
+        <Typography variant="h2">Stream Summary</Typography>
+        <Divider dark spacingBottom={16} spacingTop={16} />
+        <Box>
+          <StyledHeader mb={1}>Delivery</StyledHeader>
+          <Typography mb={1}>
+            {getDestinationTypeOption(destinationType)?.label ?? ''}
+          </Typography>
+        </Box>
+        <Divider dark spacingBottom={0} spacingTop={16} />
+        <Button
+          buttonType="primary"
+          data-qa-deploy-linode
+          onClick={createStream}
+          sx={(theme) => ({
+            mt: `${theme.spacingFunction(24)} !important`,
+            [theme.breakpoints.down('lg')]: {
+              alignSelf: 'flex-end',
+            },
+          })}
+        >
+          Create Stream
+        </Button>
+      </Stack>
+    </Paper>
+  );
+};

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreate.tsx
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreate.tsx
@@ -8,9 +8,9 @@ import { FormProvider, useForm, useWatch } from 'react-hook-form';
 
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { LandingHeader } from 'src/components/LandingHeader';
+import { StreamCreateSubmitBar } from 'src/features/DataStream/Streams/StreamCreate/CheckoutBar/StreamCreateSubmitBar';
 import { sendCreateStreamEvent } from 'src/utilities/analytics/customEventAnalytics';
 
-import { StreamCreateCheckoutBar } from './CheckoutBar/StreamCreateCheckoutBar';
 import { StreamCreateClusters } from './StreamCreateClusters';
 import { StreamCreateDelivery } from './StreamCreateDelivery';
 import { StreamCreateGeneralInfo } from './StreamCreateGeneralInfo';
@@ -94,7 +94,7 @@ export const StreamCreate = () => {
               </Stack>
             </Grid>
             <Grid size={{ lg: 3, md: 12, sm: 12, xs: 12 }}>
-              <StreamCreateCheckoutBar createStream={handleSubmit(onSubmit)} />
+              <StreamCreateSubmitBar createStream={handleSubmit(onSubmit)} />
             </Grid>
           </Grid>
         </form>

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateClusters.tsx
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateClusters.tsx
@@ -6,7 +6,6 @@ import { useWatch } from 'react-hook-form';
 import { Controller, useFormContext } from 'react-hook-form';
 
 import { DebouncedSearchTextField } from 'src/components/DebouncedSearchTextField';
-import { DocsLink } from 'src/components/DocsLink/DocsLink';
 import { StatusIcon } from 'src/components/StatusIcon/StatusIcon';
 import { Table } from 'src/components/Table';
 import { TableBody } from 'src/components/TableBody';
@@ -202,14 +201,7 @@ export const StreamCreateClusters = () => {
 
   return (
     <Paper>
-      <Box display="flex" justifyContent="space-between">
-        <Typography variant="h2">Clusters</Typography>
-        <DocsLink
-          // TODO: Change the link when proper documentation is ready
-          href="https://techdocs.akamai.com/cloud-computing/docs"
-          label="Docs"
-        />
-      </Box>
+      <Typography variant="h2">Clusters</Typography>
       <Notice sx={{ mt: 2 }} variant="info">
         Disabling this option allows you to manually define which clusters will
         be included in the stream. Stream will not be updated automatically with

--- a/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateDelivery.tsx
+++ b/packages/manager/src/features/DataStream/Streams/StreamCreate/StreamCreateDelivery.tsx
@@ -1,11 +1,10 @@
 import { destinationType } from '@linode/api-v4';
-import { Autocomplete, Box, Paper, Typography } from '@linode/ui';
+import { Autocomplete, Paper, Typography } from '@linode/ui';
 import { createFilterOptions } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import React from 'react';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 
-import { DocsLink } from 'src/components/DocsLink/DocsLink';
 import { getDestinationTypeOption } from 'src/features/DataStream/dataStreamUtils';
 import { DestinationLinodeObjectStorageDetailsForm } from 'src/features/DataStream/Shared/DestinationLinodeObjectStorageDetailsForm';
 import { destinationTypeOptions } from 'src/features/DataStream/Shared/types';
@@ -45,14 +44,7 @@ export const StreamCreateDelivery = () => {
 
   return (
     <Paper>
-      <Box display="flex" justifyContent="space-between">
-        <Typography variant="h2">Delivery</Typography>
-        <DocsLink
-          // TODO: Change the link when proper documentation is ready
-          href="https://techdocs.akamai.com/cloud-computing/docs"
-          label="Docs"
-        />
-      </Box>
+      <Typography variant="h2">Delivery</Typography>
       <Typography sx={{ mt: theme.spacingFunction(12) }}>
         Define a destination where you want this stream to send logs.
       </Typography>

--- a/packages/manager/src/features/DataStream/Streams/StreamsLandingEmptyStateData.ts
+++ b/packages/manager/src/features/DataStream/Streams/StreamsLandingEmptyStateData.ts
@@ -1,8 +1,3 @@
-import {
-  docsLink,
-  guidesMoreLinkText,
-} from 'src/utilities/emptyStateLandingUtils';
-
 import type {
   ResourcesHeaders,
   ResourcesLinks,
@@ -21,16 +16,10 @@ export const linkAnalyticsEvent: ResourcesLinks['linkAnalyticsEvent'] = {
 };
 
 export const gettingStartedGuides: ResourcesLinkSection = {
-  links: [
-    {
-      // TODO: Change the link and text when proper documentation is ready
-      text: 'Getting started guide',
-      to: 'https://techdocs.akamai.com/cloud-computing/docs',
-    },
-  ],
+  links: [],
   moreInfo: {
-    text: guidesMoreLinkText,
-    to: docsLink,
+    text: '',
+    to: '',
   },
-  title: 'Getting Started Guides',
+  title: '',
 };


### PR DESCRIPTION
## Description 📝

Cleanup docs and costs - they won't be ready for the beta release.

## Changes  🔄

- Remove Getting started guides
- Remove all Docs links from Stream Create form
- Replace the StreamCreateCheckoutBar with a new StreamCreateSubmitBar which doesn't have the price section

## Target release date 🗓️

August 2025

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![before 1](https://github.com/user-attachments/assets/69e9e936-b320-413e-972d-fbbe46a2e8c1) |  ![after 1](https://github.com/user-attachments/assets/bddbe804-757d-4e5f-855e-83a7e6751ee8)|
| ![before 2](https://github.com/user-attachments/assets/83233005-07a2-4fdb-82f6-e378565778f0) |![after 2](https://github.com/user-attachments/assets/18ed3f3d-6eb7-4559-8976-c94d27e7254b)|

## How to test 🧪

### Verification steps

-  in `datastream/streams/create` 
    - check if the right submit section behaves correctly
    - check if Docs link is visible in Cllusters and Delivery sections
- check if Getting started guides are not visible in `datastream/streams` and `datastream/destinations`

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
📱 Providing mobile support


<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
