### PR TITLE
test: [M3-8559] - Increase `Security.test.tsx` `waitFor` timeout from 1s to 5s

### DIFF
--- a/packages/manager/.changeset/pr-12576-tests-1753390501259.md
+++ b/packages/manager/.changeset/pr-12576-tests-1753390501259.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Improve stability of Linode create password field tests ([#12576](https://github.com/linode/manager/pull/12576))

--- a/packages/manager/src/features/Linodes/LinodeCreate/Security.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Security.test.tsx
@@ -52,12 +52,15 @@ describe('Security', () => {
       component: <Security />,
     });
 
-    await waitFor(() => {
-      const rootPasswordInput = getByLabelText('Root Password');
+    await waitFor(
+      () => {
+        const rootPasswordInput = getByLabelText('Root Password');
 
-      expect(rootPasswordInput).toBeVisible();
-      expect(rootPasswordInput).toBeDisabled();
-    });
+        expect(rootPasswordInput).toBeVisible();
+        expect(rootPasswordInput).toBeDisabled();
+      },
+      { timeout: 5_000 }
+    );
   });
 
   it('should enable the root password input if the user does has create_linode permission', async () => {


### PR DESCRIPTION
## Description 📝

Experimenting to see if increasing the `waitFor` timeout resolves the flake in the `Security.test.tsx` spec. If CI passes, I'll kick it off a few more times to confirm it's passing reliably. If not, I'll try increasing the timeout and/or applying the timeout to the entire test.

## Changes  🔄

- Increase `waitFor` timeout from 1s to 5s

## Target release date 🗓️

N/A.

## How to test 🧪

It seems like this test is passing locally for most users. Intel Mac users may be able to observe the failure by running the following against `develop`:

```
pnpm test Linodes/LinodeCreate
```

It seems like this test fails most often in CI, so I've run the tests against the PR 5 times and it's passed each time.

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
