### PR TITLE
change: [M3-10348, M3-10013] - Add/update inline docs for ACLP Alerts logic and fix Longview UI alignment issue

### DIFF
--- a/packages/manager/.changeset/pr-12578-fixed-1753437741673.md
+++ b/packages/manager/.changeset/pr-12578-fixed-1753437741673.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Longview UI alignment issue ([#12578](https://github.com/linode/manager/pull/12578))

--- a/packages/manager/.changeset/pr-12578-upcoming-features-1753437780675.md
+++ b/packages/manager/.changeset/pr-12578-upcoming-features-1753437780675.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add/update inline docs for ACLP Alerts logic ([#12578](https://github.com/linode/manager/pull/12578))

--- a/packages/manager/src/features/Linodes/AclpPreferenceToggle.tsx
+++ b/packages/manager/src/features/Linodes/AclpPreferenceToggle.tsx
@@ -67,6 +67,13 @@ const preferenceConfig: Record<
   },
 };
 
+/**
+ * - For Alerts, the toggle uses local state, not preferences. We do this because each Linode should manage its own alert mode individually.
+ *   - Create Linode: Toggle defaults to false (legacy mode). It's a simple UI toggle with no persistence.
+ *   - Edit Linode: Toggle defaults based on useIsLinodeAclpSubscribed (true if the Linode is already subscribed to ACLP). Still local state - not saved to preferences.
+ *
+ * - For Metrics, we use account-level preferences, since it's a global setting shared across all Linodes.
+ */
 export const AclpPreferenceToggle = (props: AclpPreferenceToggleType) => {
   const { isAlertsBetaMode, onAlertsModeChange, type } = props;
 

--- a/packages/manager/src/features/Longview/shared/InstallationInstructions.styles.ts
+++ b/packages/manager/src/features/Longview/shared/InstallationInstructions.styles.ts
@@ -16,7 +16,7 @@ export const StyledInstructionGrid = styled(Grid, {
         content: "'|'",
         left: `calc(-${theme.spacing(1)} + 2px)`,
         position: 'absolute',
-        top: `calc(${theme.spacing(1)} - 3px)`,
+        top: `calc(${theme.spacing(1)} - 8px)`,
       },
       marginLeft: theme.spacing(2),
       paddingLeft: theme.spacing(2),

--- a/packages/shared/src/hooks/useIsLinodeAclpSubscribed.ts
+++ b/packages/shared/src/hooks/useIsLinodeAclpSubscribed.ts
@@ -7,14 +7,12 @@ type AclpStage = 'beta' | 'ga';
  *
  * ### Cases:
  * - Legacy alerts = 0, Beta alerts = []
- *   - Show default Legacy UI (disabled) for Beta
- *   - Show default Beta UI (disabled) for GA
+ *   - Show default Legacy UI (disabled) for Beta stage
+ *   - Show default Beta UI (disabled) for GA stage
  * - Legacy alerts > 0, Beta alerts = []
  *   - Show default Legacy UI (enabled)
  * - Legacy alerts = 0, Beta alerts has values (either system, user, or both)
- *   - Show default Beta UI
- * - Legacy alerts > 0, Beta alerts has values (either system, user, or both)
- *   - Show default Beta UI
+ *   - Show default Beta UI (enabled)
  *
  * @param linodeId - The ID of the Linode
  * @param stage - The current ACLP stage: 'beta' or 'ga'


### PR DESCRIPTION
## Description 📝
This PR Add/updates inline docs for ACLP Alerts logic and fixes some dividers (In Longview) that are not aligned nicely.

## Changes  🔄
- Add documentation to the `AclpPreferenceToggle` component to explain its purpose and behavior. The component currently lacks context, making it hard to understand
- Remove the 4th case comment from the `useIsLinodeAclpSubscribed` hook, as this case is not expected to occur (or may never occur)
- Fix Longview UI alignment issue

## Target release date 🗓️
N/A

## Preview 📷
- No visual changes related to ACLP alerts
-  | Before  | After   |
   | ------- | ------- |
   | ![Screenshot 2025-07-25 at 3 22 01 PM](https://github.com/user-attachments/assets/01758a03-84b8-47ed-abdb-97ca490d18d0) | ![Screenshot 2025-07-25 at 3 21 30 PM](https://github.com/user-attachments/assets/35aae215-1bec-4ffa-bac4-076816131c69) |


## How to test 🧪
### Verification steps
- Ensure there are no typos in the added inline doc/comments
- Ensure that dividers in Longview are properly aligned

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules