### PR TITLE
fix: [M3-10316] - Disabled state styling for zebra stripped table rows

### DIFF
--- a/packages/manager/.changeset/pr-12579-fixed-1753443210506.md
+++ b/packages/manager/.changeset/pr-12579-fixed-1753443210506.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Hover styling of disabled state for zebra stripped table rows ([#12579](https://github.com/linode/manager/pull/12579))

--- a/packages/manager/.changeset/pr-12579-fixed-1753443210506.md
+++ b/packages/manager/.changeset/pr-12579-fixed-1753443210506.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-Hover styling of disabled state for zebra stripped table rows ([#12579](https://github.com/linode/manager/pull/12579))
+Hover styling of disabled state for zebra striped table rows ([#12579](https://github.com/linode/manager/pull/12579))

--- a/packages/ui/src/foundations/themes/dark.ts
+++ b/packages/ui/src/foundations/themes/dark.ts
@@ -205,11 +205,11 @@ const MuiTableHeadSvgStyles = {
 };
 
 const MuiTableZebraHoverStyles = {
-  // In dark theme, we exclude disabled rows from hover styling to maintain accessibility
-  '&.MuiTableRow-hover:not(.disabled-row):hover, &.Mui-selected:not(.disabled-row), &.Mui-selected:not(.disabled-row):hover':
-    {
+  '&:not(.disabled-row)': {
+    '&.MuiTableRow-hover:hover, &.Mui-selected, &.Mui-selected:hover': {
       background: Table.Row.Background.Hover,
     },
+  },
 };
 
 const MuiTableZebraStyles = {

--- a/packages/ui/src/foundations/themes/light.ts
+++ b/packages/ui/src/foundations/themes/light.ts
@@ -245,8 +245,10 @@ const MuiTableHeadSvgStyles = {
 };
 
 const MuiTableZebraHoverStyles = {
-  '&.MuiTableRow-hover:hover, &.Mui-selected, &.Mui-selected:hover': {
-    background: Table.Row.Background.Hover,
+  '&:not(.disabled-row)': {
+    '&.MuiTableRow-hover:hover, &.Mui-selected, &.Mui-selected:hover': {
+      background: Table.Row.Background.Hover,
+    },
   },
 };
 


### PR DESCRIPTION
## 📝 Description

Fixes hover styling for **disabled zebra-striped table rows**.

## 🔄 Changes

- Updated hover style for disabled rows.
- Ensured consistency across Light and Dark themes.

## 📷 Preview

| Theme       | Before | After  |
|-------------|--------|--------|
| **Dark**    | ![Before - Dark](https://github.com/user-attachments/assets/f1e576fa-8ed0-4493-9f38-94f8c3548722) | ![After - Dark](https://github.com/user-attachments/assets/cbce547c-e02e-4324-9b21-3019bf707197) |
| **Light**   | ![Before - Light](https://github.com/user-attachments/assets/be84eb18-3b64-4f6a-9995-c719f1611440) | ![After - Light](https://github.com/user-attachments/assets/18fd8465-8c45-4d4a-ad9d-e0e61e9063b1) |

## How to test

1. Go to `/linodes/create`.
2. Select a region and choose a **GPU** plan.
3. Verify hover styling on disabled zebra-striped rows.


<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
