### PR TITLE
M3 10202 add dual stack support to create flow

### DIFF
--- a/packages/api-v4/src/kubernetes/types.ts
+++ b/packages/api-v4/src/kubernetes/types.ts
@@ -13,6 +13,8 @@ export type Label = {
 
 export type NodePoolUpdateStrategy = 'on_recycle' | 'rolling_update';
 
+export type KubernetesStackType = 'ipv4' | 'ipv4-ipv6';
+
 export interface Taint {
   effect: KubernetesTaintEffect;
   key: string;
@@ -27,6 +29,11 @@ export interface KubernetesCluster {
   k8s_version: string;
   label: string;
   region: string;
+  /**
+   * Upcoming Feature Notice - LKE-E:** this property may not be available to all customers
+   * and may change in subsequent releases.
+   */
+  stack_type?: KubernetesStackType;
   status: string; // @todo enum this
   /**
    * Upcoming Feature Notice - LKE-E:** this property may not be available to all customers
@@ -147,5 +154,6 @@ export interface CreateKubeClusterPayload {
   label?: string; // Label will be assigned by the API if not provided
   node_pools: CreateNodePoolDataBeta[];
   region?: string; // Will be caught by Yup if undefined
+  stack_type?: KubernetesStackType; // For LKE-E; will default to 'ipv4'
   tier?: KubernetesTier; // For LKE-E: Will be assigned 'standard' by the API if not provided
 }

--- a/packages/manager/src/features/Kubernetes/CreateCluster/ClusterNetworkingPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/ClusterNetworkingPanel.tsx
@@ -1,8 +1,73 @@
-import { Stack, Typography } from '@linode/ui';
+import {
+  Divider,
+  FormControlLabel,
+  Radio,
+  RadioGroup,
+  Stack,
+  Typography,
+} from '@linode/ui';
 import React from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
+
+import { FormLabel } from 'src/components/FormLabel';
+
+import { useIsLkeEnterpriseEnabled } from '../kubeUtils';
+
+import type { KubernetesStackType } from '@linode/api-v4';
 
 export const ClusterNetworkingPanel = () => {
-  return (
+  const { isLkeEnterprisePhase2FeatureEnabled } = useIsLkeEnterpriseEnabled();
+
+  const { control } = useFormContext();
+
+  const [selectedStackType, setSelectedStackType] =
+    React.useState<KubernetesStackType>();
+
+  return isLkeEnterprisePhase2FeatureEnabled ? (
+    <>
+      <Stack divider={<Divider />} spacing={4}>
+        <Controller
+          control={control}
+          name="stack_type"
+          render={() => (
+            <RadioGroup
+              onChange={(e, value: KubernetesStackType) => {
+                setSelectedStackType(value);
+              }}
+              value={selectedStackType}
+            >
+              <FormLabel>IP Version</FormLabel>
+              <>
+                <FormControlLabel
+                  control={<Radio />}
+                  label="IPv4"
+                  value="ipv4"
+                />
+                <FormControlLabel
+                  control={<Radio />}
+                  label="IPv4 + IPv6"
+                  value="ipv4-ipv6"
+                />
+              </>
+            </RadioGroup>
+          )}
+        />
+      </Stack>
+      <Stack marginTop={3}>
+        <Typography
+          sx={(theme) => ({
+            font: theme.tokens.alias.Typography.Label.Bold.S,
+          })}
+        >
+          VPC
+        </Typography>
+        <Typography marginTop={1}>
+          Allow for private communications within and across clusters in the
+          same data center.
+        </Typography>
+      </Stack>
+    </>
+  ) : (
     <Stack>
       <Typography variant="h3">VPC & Firewall</Typography>
       <Typography marginTop={1}>

--- a/packages/manager/src/features/Kubernetes/CreateCluster/ClusterNetworkingPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/ClusterNetworkingPanel.tsx
@@ -13,15 +13,10 @@ import { FormLabel } from 'src/components/FormLabel';
 
 import { useIsLkeEnterpriseEnabled } from '../kubeUtils';
 
-import type { KubernetesStackType } from '@linode/api-v4';
-
 export const ClusterNetworkingPanel = () => {
   const { isLkeEnterprisePhase2FeatureEnabled } = useIsLkeEnterpriseEnabled();
 
   const { control } = useFormContext();
-
-  const [selectedStackType, setSelectedStackType] =
-    React.useState<KubernetesStackType>();
 
   return isLkeEnterprisePhase2FeatureEnabled ? (
     <>
@@ -29,26 +24,19 @@ export const ClusterNetworkingPanel = () => {
         <Controller
           control={control}
           name="stack_type"
-          render={() => (
+          render={({ field }) => (
             <RadioGroup
-              onChange={(e, value: KubernetesStackType) => {
-                setSelectedStackType(value);
-              }}
-              value={selectedStackType}
+              {...field}
+              onChange={(e) => field.onChange(e.target.value)}
+              value={field.value ?? null}
             >
               <FormLabel>IP Version</FormLabel>
-              <>
-                <FormControlLabel
-                  control={<Radio />}
-                  label="IPv4"
-                  value="ipv4"
-                />
-                <FormControlLabel
-                  control={<Radio />}
-                  label="IPv4 + IPv6"
-                  value="ipv4-ipv6"
-                />
-              </>
+              <FormControlLabel control={<Radio />} label="IPv4" value="ipv4" />
+              <FormControlLabel
+                control={<Radio />}
+                label="IPv4 + IPv6"
+                value="ipv4-ipv6"
+              />
             </RadioGroup>
           )}
         />

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -91,7 +91,7 @@ import type { ExtendedIP } from 'src/utilities/ipUtils';
 
 type FormValues = {
   nodePools: KubeNodePoolResponseBeta[];
-  stackType: KubernetesStackType | null;
+  stack_type: KubernetesStackType | null;
 };
 
 export interface NodePoolConfigDrawerHandlerParams {
@@ -154,7 +154,7 @@ export const CreateCluster = () => {
   const { control, ...form } = useForm<FormValues>({
     defaultValues: {
       nodePools: [],
-      stackType: isLkeEnterprisePhase2FeatureEnabled ? 'ipv4' : null,
+      stack_type: isLkeEnterprisePhase2FeatureEnabled ? 'ipv4' : null,
     },
     shouldUnregister: true,
   });
@@ -279,7 +279,7 @@ export const CreateCluster = () => {
       pick(['type', 'count', 'update_strategy'])
     ) as CreateNodePoolDataBeta[];
 
-    const stack_type = form.getValues('stackType');
+    const stackType = form.getValues('stack_type');
 
     const _ipv4 = ipV4Addr
       .map((ip) => {
@@ -329,8 +329,8 @@ export const CreateCluster = () => {
       payload = { ...payload, tier: selectedTier };
     }
 
-    if (isLkeEnterprisePhase2FeatureEnabled && stack_type) {
-      payload = { ...payload, stack_type };
+    if (isLkeEnterprisePhase2FeatureEnabled && stackType) {
+      payload = { ...payload, stack_type: stackType };
     }
 
     const createClusterFn = isUsingBetaEndpoint

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -82,6 +82,7 @@ import type {
   CreateKubeClusterPayload,
   CreateNodePoolDataBeta,
   KubeNodePoolResponseBeta,
+  KubernetesStackType,
   KubernetesTier,
 } from '@linode/api-v4/lib/kubernetes';
 import type { Region } from '@linode/api-v4/lib/regions';
@@ -90,6 +91,7 @@ import type { ExtendedIP } from 'src/utilities/ipUtils';
 
 type FormValues = {
   nodePools: KubeNodePoolResponseBeta[];
+  stackType: KubernetesStackType | null;
 };
 
 export interface NodePoolConfigDrawerHandlerParams {
@@ -141,12 +143,20 @@ export const CreateCluster = () => {
   const [selectedType, setSelectedType] = React.useState<string>();
   const [selectedPoolIndex, setSelectedPoolIndex] = React.useState<number>();
 
+  const {
+    isLkeEnterpriseLAFeatureEnabled,
+    isLkeEnterpriseLAFlagEnabled,
+    isLkeEnterprisePhase2FeatureEnabled,
+  } = useIsLkeEnterpriseEnabled();
+
   // Use React Hook Form for node pools to make updating pools and their configs easier.
   // TODO - Future: use RHF for the rest of the form and replace FormValues with CreateKubeClusterPayload.
   const { control, ...form } = useForm<FormValues>({
     defaultValues: {
       nodePools: [],
+      stackType: isLkeEnterprisePhase2FeatureEnabled ? 'ipv4' : null,
     },
+    shouldUnregister: true,
   });
   const nodePools = useWatch({ control, name: 'nodePools' });
   const { update } = useFieldArray({
@@ -227,9 +237,6 @@ export const CreateCluster = () => {
   const { mutateAsync: createKubernetesClusterBeta } =
     useCreateKubernetesClusterBetaMutation();
 
-  const { isLkeEnterpriseLAFeatureEnabled, isLkeEnterpriseLAFlagEnabled } =
-    useIsLkeEnterpriseEnabled();
-
   const {
     isLoadingVersions,
     versions: versionData,
@@ -271,6 +278,8 @@ export const CreateCluster = () => {
     const node_pools = nodePools.map(
       pick(['type', 'count', 'update_strategy'])
     ) as CreateNodePoolDataBeta[];
+
+    const stack_type = form.getValues('stackType');
 
     const _ipv4 = ipV4Addr
       .map((ip) => {
@@ -318,6 +327,10 @@ export const CreateCluster = () => {
 
     if (isLkeEnterpriseLAFeatureEnabled) {
       payload = { ...payload, tier: selectedTier };
+    }
+
+    if (isLkeEnterprisePhase2FeatureEnabled && stack_type) {
+      payload = { ...payload, stack_type };
     }
 
     const createClusterFn = isUsingBetaEndpoint

--- a/packages/manager/src/mocks/presets/crud/handlers/kubernetes.ts
+++ b/packages/manager/src/mocks/presets/crud/handlers/kubernetes.ts
@@ -223,6 +223,7 @@ export const createKubernetesCluster = (mockState: MockState) => [
         created: DateTime.now().toISO(),
         updated: DateTime.now().toISO(),
         tier: payload.tier,
+        stack_type: payload.stack_type,
       });
 
       const createNodePoolPromises = (payload.node_pools || []).map(


### PR DESCRIPTION
## Description 📝

This PR provides support for a new IP Version (Stack Type) selection in the LKE-E create flow.

## Changes  🔄

- During cluster creation, a stack type selection field is shown for IPv4/IPv6 selection. Once the cluster is created, the stack type cannot be changed.
- Updates to mocks and types are make to support the MSW POST /v4beta/clusters request

## Target release date 🗓️

8/7 devcloud

## Preview 📷

| Before  | After   |
| ------- | ------- |
| 📷 | 📷 |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Have the LKE-Enterprise `phase2Mtc` flag on locally
- Turn on the MSW in CRUD mode
- Have the LKE-E customer tag on your account (see project trackers)
- Have browser dev tools > Network tab open to confirm POST request

### Verification steps

(How to verify changes)
- [ ] On this branch, go to the cluster create flow
- [ ] Select the "enterprise" cluster tier
- [ ] Scroll down and observe a new "IP Version" section with IPv4 and IPv4 + IPv6 selections
- [ ] Observe that IPv4 is selected by default
- [ ] Make a selection, fill out the rest of the form, and submit
- [ ] Confirm the POST /v4beta/clusters request contains the `stack_type` field you set in its payload

- [ ] Select the "standard" cluster
- [ ] Confirm the IP Version section is not visible
- [ ] Fill out the form, submit
- [ ] Confirm the POST /v4beta/clusters request does not contain the `stack_type` field

- [ ] Confirm lke tests pass without regressions

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>