### PR TITLE
fix: [M3-10383] - Add aria-labels to linode maintenance icons

### DIFF
--- a/packages/manager/.changeset/pr-12599-fixed-1753823330785.md
+++ b/packages/manager/.changeset/pr-12599-fixed-1753823330785.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Add aria-labels to linode maintenance icons ([#12599](https://github.com/linode/manager/pull/12599))

--- a/packages/manager/src/features/Linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
@@ -119,6 +119,7 @@ export const LinodeRow = (props: Props) => {
         )}
         {isInProgress && (
           <TooltipIcon
+            ariaLabel="Maintenance in progress"
             className="ui-TooltipIcon ui-TooltipIcon-isActive"
             icon={statusTooltipIcons.active}
             sx={{ tooltip: { maxWidth: 300 } }}
@@ -133,6 +134,11 @@ export const LinodeRow = (props: Props) => {
         )}
         {isPendingOrScheduled && (
           <TooltipIcon
+            ariaLabel={
+              maintenance?.status === 'pending'
+                ? 'Maintenance pending'
+                : 'Maintenance scheduled'
+            }
             className="ui-TooltipIcon"
             icon={
               maintenance.status === 'pending'

--- a/packages/ui/src/components/TooltipIcon/TooltipIcon.tsx
+++ b/packages/ui/src/components/TooltipIcon/TooltipIcon.tsx
@@ -34,6 +34,10 @@ export interface TooltipIconBaseProps
     'children' | 'disableInteractive' | 'leaveDelay' | 'title'
   > {
   /**
+   * The aria-label for the tooltip icon
+   */
+  ariaLabel?: string;
+  /**
    * An optional className that does absolutely nothing
    */
   className?: string;
@@ -102,6 +106,7 @@ export const TooltipIcon = (props: TooltipIconProps) => {
     icon,
     status,
     sxTooltipIcon,
+    ariaLabel,
     text,
     tooltipAnalyticsEvent,
     tooltipPosition,
@@ -175,6 +180,7 @@ export const TooltipIcon = (props: TooltipIconProps) => {
       width={width}
     >
       <IconButton
+        aria-label={ariaLabel}
         className={className}
         data-qa-help-button
         onClick={(e) => {


### PR DESCRIPTION
## Description 📝
Add aria-label support to TooltipIcon component. The changes improve screen reader support for maintenance-related tooltips in the Linode landing page

## Changes  🔄
- Added `ariaLabel` prop to TooltipIcon component: New optional prop that accepts a string for screen reader accessibility
- Applied aria-labels to LinodeRow maintenance icons

## Target release date 🗓️
N/A

## Preview 📷

**Include a screenshot or screen recording of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
| <img width="1209" height="202" alt="Screenshot 2025-07-29 at 5 02 45 PM" src="https://github.com/user-attachments/assets/b089858a-46c0-4495-b563-b19f52f730df" /> | <img width="1304" height="187" alt="Screenshot 2025-07-29 at 4 54 55 PM" src="https://github.com/user-attachments/assets/fc8715b3-c479-49f9-8c34-438d299030b0" /> <img width="1308" height="197" alt="Screenshot 2025-07-29 at 4 56 19 PM" src="https://github.com/user-attachments/assets/7803480b-e5aa-45ca-b34d-62a3233c0968" /> |

## How to test 🧪

### Verification steps
- You can manually enable these buttons in the code OR

#### Alternative
- Enable MSW
- Use MSW Dev Tools "Maintenance Preset" to create some different statuses
- Setup Maintenance & Notification Presets
- Ensure you have a maintenance that's pending and scheduled
<img width="878" height="476" alt="458186223-2992b625-2dba-47d5-98f2-749ce27fd27b" src="https://github.com/user-attachments/assets/eb594c3d-a500-4e9d-b12e-1c1263e36d22" />


<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>