### PR TITLE
change: [M3-9911] - Add generic description to Premium tab to support both legacy Premium and MTC plans

### DIFF
--- a/packages/manager/.changeset/pr-12601-changed-1753862177012.md
+++ b/packages/manager/.changeset/pr-12601-changed-1753862177012.md
@@ -1,0 +1,5 @@
+---
+'@linode/manager': Changed
+---
+
+Replace the existing Premium tab description with generic description copy that works for both legacy Premium and MTC plans ([#12601](https://github.com/linode/manager/pull/12601))

--- a/packages/manager/src/features/components/PlansPanel/utils.ts
+++ b/packages/manager/src/features/components/PlansPanel/utils.ts
@@ -263,7 +263,7 @@ export const planTabInfoContent = {
     key: 'premium',
     title: 'Premium CPU',
     typography:
-      'Premium CPU instances guarantee a minimum processor generation of AMD EPYC\u2122 Milan or newer to ensure consistent high performance for more demanding workloads.',
+      'Run high-performance, latency-sensitive workloads on dedicated AMD EPYC\u2122 CPUs.',
   },
   prodedicated: {
     dataId: 'data-qa-prodedi',


### PR DESCRIPTION
## Description 📝

The existing Premium tab description only fits legacy Premium plans. This update adds generic copy that works for both legacy Premium and MTC HT plans.

## Changes  🔄
- Replaced the existing Premium tab description with generic description copy that works for both legacy Premium and MTC HT plans

## Target release date 🗓️
N/A

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-07-30 at 1 20 22 PM](https://github.com/user-attachments/assets/3246155d-4461-4d91-bd35-8cec012d4d1f) | ![Screenshot 2025-07-30 at 1 19 08 PM](https://github.com/user-attachments/assets/aa60811d-18f8-4946-98ad-8393920b4be5) |

## How to test 🧪

### Verification steps
- Navigate to Linode -> Create  OR LKE -> Create
- In the Premium tab, verify that the description displays the new generic description copy applicable to both legacy Premium and MTC HT plans

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules