### PR TITLE
fix: [M3-10336] - Checkbox color token - pt2

### DIFF
--- a/packages/ui/.changeset/pr-12603-fixed-1753955503044.md
+++ b/packages/ui/.changeset/pr-12603-fixed-1753955503044.md
@@ -1,0 +1,5 @@
+---
+"@linode/ui": Fixed
+---
+
+Check icon color in dark mode and Color Token for all checkbox states ([#12603](https://github.com/linode/manager/pull/12603))

--- a/packages/ui/src/foundations/themes/dark.ts
+++ b/packages/ui/src/foundations/themes/dark.ts
@@ -490,9 +490,6 @@ export const darkTheme: ThemeOptions = {
     MuiCheckbox: {
       styleOverrides: {
         root: {
-          '& svg path': {
-            fill: `${Component.Checkbox.Checked.Default.Icon}`,
-          },
           '&:active': {
             color: `${Component.Checkbox.Empty.Active.Border} !important`,
           },
@@ -502,6 +499,9 @@ export const darkTheme: ThemeOptions = {
           // Checked
           '&.Mui-checked': {
             color: Component.Checkbox.Checked.Default.Background,
+            '& svg path': {
+              fill: Component.Checkbox.Checked.Default.Icon,
+            },
           },
           // Indeterminate
           '&.MuiCheckbox-indeterminate': {
@@ -523,6 +523,9 @@ export const darkTheme: ThemeOptions = {
           // Checked & Disabled
           '&.Mui-checked.Mui-disabled': {
             color: Component.Checkbox.Checked.Disabled.Background,
+            '& svg path': {
+              fill: Component.Checkbox.Checked.Disabled.Icon,
+            },
           },
           // Indeterminate & Disabled
           '&.MuiCheckbox-indeterminate.Mui-disabled': {

--- a/packages/ui/src/foundations/themes/dark.ts
+++ b/packages/ui/src/foundations/themes/dark.ts
@@ -490,17 +490,69 @@ export const darkTheme: ThemeOptions = {
     MuiCheckbox: {
       styleOverrides: {
         root: {
-          '&:active': {
-            color: `${Component.Checkbox.Empty.Active.Border} !important`,
+          // Default styles
+          '& svg': {
+            backgroundColor: Component.Checkbox.Empty.Default.Background,
+            color: Component.Checkbox.Empty.Default.Border,
           },
+          // Hover state overrides
           '&:hover': {
-            color: `${Component.Checkbox.Empty.Hover.Border} !important`,
+            '& svg': {
+              backgroundColor: Component.Checkbox.Empty.Hover.Background,
+              color: Component.Checkbox.Empty.Hover.Border,
+            },
+          },
+          // Active state overrides
+          '&:active': {
+            '& svg': {
+              backgroundColor: Component.Checkbox.Empty.Active.Background,
+              color: Component.Checkbox.Empty.Active.Border,
+            },
           },
           // Checked
           '&.Mui-checked': {
-            color: Component.Checkbox.Checked.Default.Background,
-            '& svg path': {
-              fill: Component.Checkbox.Checked.Default.Icon,
+            '& svg': {
+              backgroundColor: Component.Checkbox.Checked.Default.Background,
+              color: Component.Checkbox.Checked.Default.Background,
+              '& path': {
+                fill: Component.Checkbox.Checked.Default.Icon,
+              },
+            },
+            '&:hover': {
+              '& svg': {
+                backgroundColor: Component.Checkbox.Checked.Hover.Background,
+                color: Component.Checkbox.Checked.Hover.Background,
+                '& path': {
+                  fill: Component.Checkbox.Checked.Hover.Icon,
+                },
+              },
+            },
+            '&:active': {
+              '& svg': {
+                backgroundColor: Component.Checkbox.Checked.Active.Background,
+                color: Component.Checkbox.Checked.Active.Background,
+                '& path': {
+                  fill: Component.Checkbox.Checked.Active.Icon,
+                },
+              },
+            },
+          },
+          // Unchecked & Disabled
+          '&.Mui-disabled': {
+            '& svg': {
+              backgroundColor: Component.Checkbox.Empty.Disabled.Background,
+              color: Component.Checkbox.Empty.Disabled.Border,
+            },
+            pointerEvents: 'none',
+          },
+          // Checked & Disabled
+          '&.Mui-checked.Mui-disabled': {
+            '& svg': {
+              backgroundColor: Component.Checkbox.Checked.Disabled.Background,
+              color: Component.Checkbox.Checked.Disabled.Background,
+              '& path': {
+                fill: Component.Checkbox.Checked.Disabled.Icon,
+              },
             },
           },
           // Indeterminate
@@ -512,21 +564,6 @@ export const darkTheme: ThemeOptions = {
               },
             },
           },
-          // Unchecked & Disabled
-          '&.Mui-disabled': {
-            '& svg': {
-              backgroundColor: Component.Checkbox.Empty.Disabled.Background,
-            },
-            color: Component.Checkbox.Empty.Disabled.Border,
-            pointerEvents: 'none',
-          },
-          // Checked & Disabled
-          '&.Mui-checked.Mui-disabled': {
-            color: Component.Checkbox.Checked.Disabled.Background,
-            '& svg path': {
-              fill: Component.Checkbox.Checked.Disabled.Icon,
-            },
-          },
           // Indeterminate & Disabled
           '&.MuiCheckbox-indeterminate.Mui-disabled': {
             color: Component.Checkbox.Indeterminated.Disabled.Background,
@@ -536,7 +573,6 @@ export const darkTheme: ThemeOptions = {
               },
             },
           },
-          color: Component.Checkbox.Empty.Default.Border,
         },
       },
     },

--- a/packages/ui/src/foundations/themes/light.ts
+++ b/packages/ui/src/foundations/themes/light.ts
@@ -654,18 +654,70 @@ export const lightTheme: ThemeOptions = {
     MuiCheckbox: {
       styleOverrides: {
         root: {
-          '& svg path': {
-            fill: `${Component.Checkbox.Checked.Default.Icon}`,
+          // Default styles
+          '& svg': {
+            backgroundColor: Component.Checkbox.Empty.Default.Background,
+            color: Component.Checkbox.Empty.Default.Border,
           },
-          '&:active': {
-            color: `${Component.Checkbox.Empty.Active.Border} !important`,
-          },
+          // Hover state overrides
           '&:hover': {
-            color: `${Component.Checkbox.Empty.Hover.Border} !important`,
+            '& svg': {
+              backgroundColor: Component.Checkbox.Empty.Hover.Background,
+              color: Component.Checkbox.Empty.Hover.Border,
+            },
           },
-          // Checked
+          // Active state overrides
+          '&:active': {
+            '& svg': {
+              backgroundColor: Component.Checkbox.Empty.Active.Background,
+              color: Component.Checkbox.Empty.Active.Border,
+            },
+          },
+          // Checked state
           '&.Mui-checked': {
-            color: Component.Checkbox.Checked.Default.Background,
+            '& svg': {
+              backgroundColor: Component.Checkbox.Checked.Default.Background,
+              color: Component.Checkbox.Checked.Default.Background,
+              '& path': {
+                fill: Component.Checkbox.Checked.Default.Icon,
+              },
+            },
+            '&:hover': {
+              '& svg': {
+                backgroundColor: Component.Checkbox.Checked.Hover.Background,
+                color: Component.Checkbox.Checked.Hover.Background,
+                '& path': {
+                  fill: Component.Checkbox.Checked.Hover.Icon,
+                },
+              },
+            },
+            '&:active': {
+              '& svg': {
+                backgroundColor: Component.Checkbox.Checked.Hover.Background,
+                color: Component.Checkbox.Checked.Active.Background,
+                '& path': {
+                  fill: Component.Checkbox.Checked.Active.Icon,
+                },
+              },
+            },
+          },
+          // Unchecked & Disabled
+          '&.Mui-disabled': {
+            '& svg': {
+              backgroundColor: Component.Checkbox.Empty.Disabled.Background,
+              color: Component.Checkbox.Empty.Disabled.Border,
+            },
+            pointerEvents: 'none',
+          },
+          // Checked & Disabled
+          '&.Mui-checked.Mui-disabled': {
+            '& svg': {
+              backgroundColor: Component.Checkbox.Checked.Disabled.Background,
+              color: Component.Checkbox.Checked.Disabled.Background,
+              '& path': {
+                fill: Component.Checkbox.Checked.Disabled.Icon,
+              },
+            },
           },
           // Indeterminate
           '&.MuiCheckbox-indeterminate': {
@@ -676,18 +728,6 @@ export const lightTheme: ThemeOptions = {
               },
             },
           },
-          // Unchecked & Disabled
-          '&.Mui-disabled': {
-            '& svg': {
-              backgroundColor: Component.Checkbox.Empty.Disabled.Background,
-            },
-            color: Component.Checkbox.Empty.Disabled.Border,
-            pointerEvents: 'none',
-          },
-          // Checked & Disabled
-          '&.Mui-checked.Mui-disabled': {
-            color: Component.Checkbox.Checked.Disabled.Background,
-          },
           // Indeterminate & Disabled
           '&.MuiCheckbox-indeterminate.Mui-disabled': {
             color: Component.Checkbox.Indeterminated.Disabled.Background,
@@ -697,7 +737,6 @@ export const lightTheme: ThemeOptions = {
               },
             },
           },
-          color: Component.Checkbox.Empty.Default.Border,
         },
       },
       defaultProps: {


### PR DESCRIPTION
## Description

This PR fixes checkbox styling issues:

- Changing the check icon color from black to white.
- Applying correct color tokens for all checkbox states.

## Changes

- Updated check icon color for dark mode.
- Applied proper color tokens to all checkbox variants.

## Target Release
N/A

## Preview

| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/6a79336c-ab4a-42ad-b672-9f8c76f2dbf7) | ![After](https://github.com/user-attachments/assets/bf4085ef-ba42-4bbd-a989-536d111f0e20) |

## How to Test

1. Enable dark mode.
2. Locate checkboxes across the UI.
3. Confirm white check icon in the disabled state.

## Acceptance

- Correct Check icon color in dark mode.
- All variants use proper color tokens.

<details>
<summary>Author Checklists</summary>

### As an Author, I considered:  
- [x] Self-review  
- [x] Contribution guidelines  
- [x] Small, focused PR  
- [x] Changeset added if needed  
- [x] Tests added or updated  
- [x] No sensitive info  
- [x] Feature flag if needed  
- [x] Reproduction steps  
- [x] Docs updated if needed  
- [x] Mobile and a11y support  

### Before moving from Draft to Open:  
- [x] All unit tests passing  
- [x] TypeScript compiles  
- [x] Linting passes  

</details>
