### PR TITLE
fix: [M3-10394] - Use human readable date/time for maintenance window

### DIFF
--- a/packages/manager/.changeset/pr-12605-fixed-1753890447726.md
+++ b/packages/manager/.changeset/pr-12605-fixed-1753890447726.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Use human readable date/time for Linode maintenance window ([#12605](https://github.com/linode/manager/pull/12605))

--- a/packages/manager/src/features/Linodes/LinodeMaintenanceText.tsx
+++ b/packages/manager/src/features/Linodes/LinodeMaintenanceText.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { DateTimeDisplay } from 'src/components/DateTimeDisplay/DateTimeDisplay';
+
 interface LinodeMaintenanceTextProps {
   isOpened?: boolean;
   maintenanceStartTime: string;
@@ -12,7 +14,13 @@ export const LinodeMaintenanceText = ({
   return (
     <>
       This Linode&rsquo;s maintenance window {isOpened ? 'opened' : 'opens'} at{' '}
-      {maintenanceStartTime}
+      <DateTimeDisplay
+        humanizeCutoff="never"
+        sx={(theme) => ({
+          color: theme.tokens.alias.Content.Text.Secondary.Default,
+        })}
+        value={maintenanceStartTime}
+      />
       {!isOpened && <>. For more information, see your open support tickets</>}.
     </>
   );

--- a/packages/manager/src/features/Linodes/LinodeMaintenanceText.tsx
+++ b/packages/manager/src/features/Linodes/LinodeMaintenanceText.tsx
@@ -15,7 +15,6 @@ export const LinodeMaintenanceText = ({
     <>
       This Linode&rsquo;s maintenance window {isOpened ? 'opened' : 'opens'} at{' '}
       <DateTimeDisplay
-        humanizeCutoff="never"
         sx={(theme) => ({
           color: theme.tokens.alias.Content.Text.Secondary.Default,
         })}


### PR DESCRIPTION
## Description 📝
This PR improves the user experience by converting the maintenance window date/time display in the `LinodeMaintenanceText` component from a database format to a more readable format. Instead of showing dates like "2024-01-15T14:30", the component now displays "2024-01-15 14:30"

## Changes  🔄
- Slightly better formatting instead of `T` being in string

## Target release date 🗓️
N/A

## Preview 📷
> [!note]
Focus on the format, not the times in the screenshots
 
| Before  | After   |
| ------- | ------- |
| <img width="1295" height="371" alt="Screenshot 2025-07-30 at 9 06 13 AM" src="https://github.com/user-attachments/assets/3c57af4c-f3c7-44c2-9a68-1e91d2c1d6dc" /> | <img width="221" height="143" alt="Screenshot 2025-07-30 at 11 33 08 AM" src="https://github.com/user-attachments/assets/6661570c-be2b-4f4a-af74-1b800b7b934f" /> |

## How to test 🧪

### Verification steps
- You can manually enable these buttons in the code OR

#### Alternative
- Enable MSW
- Use MSW Dev Tools "Maintenance Preset" to create some different statuses
- Setup Maintenance & Notification Presets
- Ensure you have a maintenance that's pending and scheduled
<img width="878" height="476" alt="458186223-2992b625-2dba-47d5-98f2-749ce27fd27b" src="https://github.com/user-attachments/assets/eb594c3d-a500-4e9d-b12e-1c1263e36d22" />


<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>