### PR TITLE
chore: [M3-10398] - Release Label Automation

### DIFF
--- a/.github/workflows/release-labeling.yml
+++ b/.github/workflows/release-labeling.yml
@@ -1,23 +1,13 @@
-name: Test Auto-label PR with next release date
+name: Auto-label PR with next release date
 
 permissions:
   pull-requests: write
 
 on:
-  workflow_dispatch:
-    inputs:
-      test_date:
-        description: "Override today's date for testing (YYYY-MM-DD)"
-        required: false
-        type: string
-      pr_number:
-        description: 'PR number to label (for testing)'
-        required: true
-        type: number
   pull_request:
     types: [opened]
     branches:
-      - develop  # Test on develop branch first
+      - develop
 
 jobs:
   add-release-label:
@@ -46,31 +36,18 @@ jobs:
           FREEZE_START_2="2025-12-30"
           FREEZE_END_2="2026-01-06"
 
-          TODAY="${{ github.event.inputs.test_date }}"
-          if [ -z "$TODAY" ]; then
-            TODAY=$(date +%Y-%m-%d)
-          fi
-
-          # DEBUG: Output initial values
-          echo "DEBUG: Today: $TODAY"
-          echo "DEBUG: Release start: $RELEASE_START"
-          echo "DEBUG: Freeze periods: $FREEZE_START_1 to $FREEZE_END_1, $FREEZE_START_2 to $FREEZE_END_2"
+          TODAY=$(date +%Y-%m-%d)
 
           # Calculate which release cycle we're in (releases every 14 days)
           DAYS_SINCE_START=$(( ($(date -d "$TODAY" +%s) - $(date -d "$RELEASE_START" +%s)) / 86400 ))
-          echo "DEBUG: Days since start: $DAYS_SINCE_START"
 
           if [ $DAYS_SINCE_START -lt 0 ]; then
             NEXT_RELEASE_DATE="$RELEASE_START"
-            echo "DEBUG: Using release start date (before first release)"
           else
             CYCLES_PASSED=$(( $DAYS_SINCE_START / 14 ))
             NEXT_CYCLE=$(( $CYCLES_PASSED + 1 ))
             NEXT_RELEASE_DATE=$(date -d "$RELEASE_START + $(( $NEXT_CYCLE * 14 )) days" +%Y-%m-%d)
-            echo "DEBUG: Cycles passed: $CYCLES_PASSED, Next cycle: $NEXT_CYCLE"
           fi
-
-          echo "DEBUG: Initial calculated date: $NEXT_RELEASE_DATE"
 
           # Skip freeze periods - if calculated date falls during freeze,
           # jump to first Tuesday after freeze ends
@@ -84,27 +61,21 @@ jobs:
             FREEZE2_END_TS=$(date -d "$FREEZE_END_2" +%s)
 
             if [ $RELEASE_TIMESTAMP -ge $FREEZE1_START_TS ] && [ $RELEASE_TIMESTAMP -le $FREEZE1_END_TS ]; then
-              echo "DEBUG: Date falls in freeze period 1, adjusting..."
               NEXT_RELEASE_DATE=$(date -d "$FREEZE_END_1 + 1 day" +%Y-%m-%d)
               NEXT_RELEASE_DATE=$(adjust_to_tuesday "$NEXT_RELEASE_DATE")
-              echo "DEBUG: Adjusted to: $NEXT_RELEASE_DATE"
               ITERATION=$((ITERATION + 1))
               continue
             fi
 
             if [ $RELEASE_TIMESTAMP -ge $FREEZE2_START_TS ] && [ $RELEASE_TIMESTAMP -le $FREEZE2_END_TS ]; then
-              echo "DEBUG: Date falls in freeze period 2, adjusting..."
               NEXT_RELEASE_DATE=$(date -d "$FREEZE_END_2 + 1 day" +%Y-%m-%d)
               NEXT_RELEASE_DATE=$(adjust_to_tuesday "$NEXT_RELEASE_DATE")
-              echo "DEBUG: Adjusted to: $NEXT_RELEASE_DATE"
               ITERATION=$((ITERATION + 1))
               continue
             fi
 
             break
           done
-
-          echo "DEBUG: Final iterations used: $ITERATION"
 
           if [ $ITERATION -eq $MAX_ITERATIONS ]; then
             echo "Error: Too many freeze period adjustments" >&2
@@ -116,10 +87,9 @@ jobs:
             exit 1
           fi
 
-          echo "DEBUG: Final release date: $NEXT_RELEASE_DATE"
           echo "date=$NEXT_RELEASE_DATE" >> $GITHUB_OUTPUT
 
-      - name: Add test release label to PR
+      - name: Add release label to PR
         uses: actions/github-script@v4
         with:
           script: |
@@ -130,22 +100,9 @@ jobs:
               throw new Error('Invalid date format received');
             }
 
-            # Get PR number from input or event
-            const prNumber = "${{ github.event.inputs.pr_number }}" || context.payload.pull_request.number;
-
-            console.log(`Adding test label: test-release:${nextReleaseDate} to PR #${prNumber}`);
-
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: prNumber,
-              labels: [`test-release:${nextReleaseDate}`]
-            });
-
-            // Also add a comment for easier verification
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              body: `🧪 **Test Release Labeling**: This PR would be included in release \`${nextReleaseDate}\``
+              issue_number: context.payload.pull_request.number,
+              labels: [`release:${nextReleaseDate}`]
             });

--- a/.github/workflows/release-labeling.yml
+++ b/.github/workflows/release-labeling.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       test_date:
-        description: 'Override today\'s date for testing (YYYY-MM-DD)'
+        description: "Override today's date for testing (YYYY-MM-DD)"
         required: false
         type: string
       pr_number:

--- a/.github/workflows/release-labeling.yml
+++ b/.github/workflows/release-labeling.yml
@@ -1,0 +1,125 @@
+name: Test Auto-label PR with next release date
+
+on:
+  pull_request:
+    types: [opened]
+    branches:
+      - develop  # Test on develop branch first
+
+jobs:
+  add-release-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Calculate next release date
+        id: calculate_date
+        run: |
+          # Function to adjust date to next Tuesday if needed
+          adjust_to_tuesday() {
+            local input_date="$1"
+            local day_of_week=$(date -d "$input_date" +%u)
+            if [ $day_of_week -ne 2 ]; then
+              local days_to_add=$(( (2 - $day_of_week + 7) % 7 ))
+              date -d "$input_date + $days_to_add days" +%Y-%m-%d
+            else
+              echo "$input_date"
+            fi
+          }
+
+          RELEASE_START="2025-08-12"
+
+          FREEZE_START_1="2025-12-02"
+          FREEZE_END_1="2025-12-15"
+          FREEZE_START_2="2025-12-30"
+          FREEZE_END_2="2026-01-06"
+
+          TODAY=$(date +%Y-%m-%d)
+
+          # DEBUG: Output initial values
+          echo "DEBUG: Today: $TODAY"
+          echo "DEBUG: Release start: $RELEASE_START"
+          echo "DEBUG: Freeze periods: $FREEZE_START_1 to $FREEZE_END_1, $FREEZE_START_2 to $FREEZE_END_2"
+
+          # Calculate which release cycle we're in (releases every 14 days)
+          DAYS_SINCE_START=$(( ($(date -d "$TODAY" +%s) - $(date -d "$RELEASE_START" +%s)) / 86400 ))
+          echo "DEBUG: Days since start: $DAYS_SINCE_START"
+
+          if [ $DAYS_SINCE_START -lt 0 ]; then
+            NEXT_RELEASE_DATE="$RELEASE_START"
+            echo "DEBUG: Using release start date (before first release)"
+          else
+            CYCLES_PASSED=$(( $DAYS_SINCE_START / 14 ))
+            NEXT_CYCLE=$(( $CYCLES_PASSED + 1 ))
+            NEXT_RELEASE_DATE=$(date -d "$RELEASE_START + $(( $NEXT_CYCLE * 14 )) days" +%Y-%m-%d)
+            echo "DEBUG: Cycles passed: $CYCLES_PASSED, Next cycle: $NEXT_CYCLE"
+          fi
+
+          echo "DEBUG: Initial calculated date: $NEXT_RELEASE_DATE"
+
+          # Skip freeze periods - if calculated date falls during freeze,
+          # jump to first Tuesday after freeze ends
+          MAX_ITERATIONS=3  # Safety guard - worst case is 2 freeze periods
+          ITERATION=0
+          while [ $ITERATION -lt $MAX_ITERATIONS ]; do
+            if [[ "$NEXT_RELEASE_DATE" >= "$FREEZE_START_1" && "$NEXT_RELEASE_DATE" <= "$FREEZE_END_1" ]]; then
+              echo "DEBUG: Date falls in freeze period 1, adjusting..."
+              NEXT_RELEASE_DATE=$(date -d "$FREEZE_END_1 + 1 day" +%Y-%m-%d)
+              NEXT_RELEASE_DATE=$(adjust_to_tuesday "$NEXT_RELEASE_DATE")
+              echo "DEBUG: Adjusted to: $NEXT_RELEASE_DATE"
+              ITERATION=$((ITERATION + 1))
+              continue
+            fi
+
+            if [[ "$NEXT_RELEASE_DATE" >= "$FREEZE_START_2" && "$NEXT_RELEASE_DATE" <= "$FREEZE_END_2" ]]; then
+              echo "DEBUG: Date falls in freeze period 2, adjusting..."
+              NEXT_RELEASE_DATE=$(date -d "$FREEZE_END_2 + 1 day" +%Y-%m-%d)
+              NEXT_RELEASE_DATE=$(adjust_to_tuesday "$NEXT_RELEASE_DATE")
+              echo "DEBUG: Adjusted to: $NEXT_RELEASE_DATE"
+              ITERATION=$((ITERATION + 1))
+              continue
+            fi
+
+            break
+          done
+
+          echo "DEBUG: Final iterations used: $ITERATION"
+
+          if [ $ITERATION -eq $MAX_ITERATIONS ]; then
+            echo "Error: Too many freeze period adjustments" >&2
+            exit 1
+          fi
+
+          if ! date -d "$NEXT_RELEASE_DATE" >/dev/null 2>&1; then
+            echo "Error: Invalid date calculated" >&2
+            exit 1
+          fi
+
+          echo "DEBUG: Final release date: $NEXT_RELEASE_DATE"
+          echo "date=$NEXT_RELEASE_DATE" >> $GITHUB_OUTPUT
+
+      - name: Add test release label to PR
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const nextReleaseDate = "${{ steps.calculate_date.outputs.date }}";
+
+            // Validate date format
+            if (!/^\d{4}-\d{2}-\d{2}$/.test(nextReleaseDate)) {
+              throw new Error('Invalid date format received');
+            }
+
+            console.log(`Adding test label: test-release:${nextReleaseDate}`);
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: [`test-release:${nextReleaseDate}`]
+            });
+
+            // Also add a comment for easier verification
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: `🧪 **Test Release Labeling**: This PR would be included in release \`${nextReleaseDate}\``
+            });

--- a/.github/workflows/release-labeling.yml
+++ b/.github/workflows/release-labeling.yml
@@ -9,14 +9,6 @@ on:
     branches:
       - develop
 
-env:
-  # Use GitHub secrets for date configuration
-  RELEASE_START: ${{ secrets.RELEASE_START_DATE }}
-  FREEZE_START_1: ${{ secrets.FREEZE_START_1_DATE }}
-  FREEZE_END_1: ${{ secrets.FREEZE_END_1_DATE }}
-  FREEZE_START_2: ${{ secrets.FREEZE_START_2_DATE }}
-  FREEZE_END_2: ${{ secrets.FREEZE_END_2_DATE }}
-
 jobs:
   add-release-label:
     name: Add Release Label
@@ -37,6 +29,13 @@ jobs:
             fi
           }
 
+          RELEASE_START="${{ vars.RELEASE_START_DATE || '2025-08-12' }}"
+
+          FREEZE_START_1="${{ vars.FREEZE_START_1 || '2025-12-02' }}"
+          FREEZE_END_1="${{ vars.FREEZE_END_1 || '2025-12-15' }}"
+          FREEZE_START_2="${{ vars.FREEZE_START_2 || '2025-12-30' }}"
+          FREEZE_END_2="${{ vars.FREEZE_END_2 || '2026-01-06' }}"
+
           TODAY=$(date +%Y-%m-%d)
 
           # Calculate which release cycle we're in (releases every 14 days)
@@ -50,28 +49,46 @@ jobs:
             NEXT_RELEASE_DATE=$(date -d "$RELEASE_START + $(( $NEXT_CYCLE * 14 )) days" +%Y-%m-%d)
           fi
 
-          # Pre-calculate freeze period timestamps for efficiency
-          FREEZE1_START_TS=$(date -d "$FREEZE_START_1" +%s)
-          FREEZE1_END_TS=$(date -d "$FREEZE_END_1" +%s)
-          FREEZE2_START_TS=$(date -d "$FREEZE_START_2" +%s)
-          FREEZE2_END_TS=$(date -d "$FREEZE_END_2" +%s)
-
           # Skip freeze periods - if calculated date falls during freeze,
           # jump to first Tuesday after freeze ends
-          RELEASE_TIMESTAMP=$(date -d "$NEXT_RELEASE_DATE" +%s)
+          MAX_ITERATIONS=3  # Safety guard - worst case is 2 freeze periods
+          ITERATION=0
+          while [ $ITERATION -lt $MAX_ITERATIONS ]; do
+            RELEASE_TIMESTAMP=$(date -d "$NEXT_RELEASE_DATE" +%s)
+            FREEZE1_START_TS=$(date -d "$FREEZE_START_1" +%s)
+            FREEZE1_END_TS=$(date -d "$FREEZE_END_1" +%s)
+            FREEZE2_START_TS=$(date -d "$FREEZE_START_2" +%s)
+            FREEZE2_END_TS=$(date -d "$FREEZE_END_2" +%s)
 
-          # Check if calculated release date falls during December freeze (Dec 2-15)
-          if [ $RELEASE_TIMESTAMP -ge $FREEZE1_START_TS ] && [ $RELEASE_TIMESTAMP -le $FREEZE1_END_TS ]; then
-            # Skip freeze period: move to day after freeze ends, then find next Tuesday
-            NEXT_RELEASE_DATE=$(date -d "$FREEZE_END_1 + 1 day" +%Y-%m-%d)
-            NEXT_RELEASE_DATE=$(adjust_to_tuesday "$NEXT_RELEASE_DATE")
+            # Check if calculated release date falls during December freeze (Dec 2-15)
+            if [ $RELEASE_TIMESTAMP -ge $FREEZE1_START_TS ] && [ $RELEASE_TIMESTAMP -le $FREEZE1_END_TS ]; then
+              # Skip freeze period: move to day after freeze ends, then find next Tuesday
+              NEXT_RELEASE_DATE=$(date -d "$FREEZE_END_1 + 1 day" +%Y-%m-%d)
+              NEXT_RELEASE_DATE=$(adjust_to_tuesday "$NEXT_RELEASE_DATE")
+              ITERATION=$((ITERATION + 1))
+              continue
+            fi
+
+            # Check if calculated release date falls during year-end freeze (Dec 30-Jan 6)
+            if [ $RELEASE_TIMESTAMP -ge $FREEZE2_START_TS ] && [ $RELEASE_TIMESTAMP -le $FREEZE2_END_TS ]; then
+              # Skip freeze period: move to day after freeze ends, then find next Tuesday
+              NEXT_RELEASE_DATE=$(date -d "$FREEZE_END_2 + 1 day" +%Y-%m-%d)
+              NEXT_RELEASE_DATE=$(adjust_to_tuesday "$NEXT_RELEASE_DATE")
+              ITERATION=$((ITERATION + 1))
+              continue
+            fi
+
+            break
+          done
+
+          if [ $ITERATION -eq $MAX_ITERATIONS ]; then
+            echo "Error: Too many freeze period adjustments" >&2
+            exit 1
           fi
 
-          # Check if calculated release date falls during year-end freeze (Dec 30-Jan 6)
-          if [ $RELEASE_TIMESTAMP -ge $FREEZE2_START_TS ] && [ $RELEASE_TIMESTAMP -le $FREEZE2_END_TS ]; then
-            # Skip freeze period: move to day after freeze ends, then find next Tuesday
-            NEXT_RELEASE_DATE=$(date -d "$FREEZE_END_2 + 1 day" +%Y-%m-%d)
-            NEXT_RELEASE_DATE=$(adjust_to_tuesday "$NEXT_RELEASE_DATE")
+          if ! date -d "$NEXT_RELEASE_DATE" >/dev/null 2>&1; then
+            echo "Error: Invalid date calculated" >&2
+            exit 1
           fi
 
           echo "date=$NEXT_RELEASE_DATE" >> $GITHUB_OUTPUT
@@ -80,9 +97,16 @@ jobs:
         uses: actions/github-script@v4
         with:
           script: |
+            const nextReleaseDate = "${{ steps.calculate_date.outputs.date }}";
+
+            // Validate date format
+            if (!/^\d{4}-\d{2}-\d{2}$/.test(nextReleaseDate)) {
+              throw new Error('Invalid date format received');
+            }
+
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              labels: [`release:${{ steps.calculate_date.outputs.date }}`]
+              labels: [`release:${nextReleaseDate}`]
             });

--- a/.github/workflows/release-labeling.yml
+++ b/.github/workflows/release-labeling.yml
@@ -1,6 +1,19 @@
 name: Test Auto-label PR with next release date
 
+permissions:
+  pull-requests: write
+
 on:
+  workflow_dispatch:
+    inputs:
+      test_date:
+        description: 'Override today\'s date for testing (YYYY-MM-DD)'
+        required: false
+        type: string
+      pr_number:
+        description: 'PR number to label (for testing)'
+        required: true
+        type: number
   pull_request:
     types: [opened]
     branches:
@@ -8,6 +21,7 @@ on:
 
 jobs:
   add-release-label:
+    name: Add Release Label
     runs-on: ubuntu-latest
     steps:
       - name: Calculate next release date
@@ -32,7 +46,10 @@ jobs:
           FREEZE_START_2="2025-12-30"
           FREEZE_END_2="2026-01-06"
 
-          TODAY=$(date +%Y-%m-%d)
+          TODAY="${{ github.event.inputs.test_date }}"
+          if [ -z "$TODAY" ]; then
+            TODAY=$(date +%Y-%m-%d)
+          fi
 
           # DEBUG: Output initial values
           echo "DEBUG: Today: $TODAY"
@@ -60,7 +77,13 @@ jobs:
           MAX_ITERATIONS=3  # Safety guard - worst case is 2 freeze periods
           ITERATION=0
           while [ $ITERATION -lt $MAX_ITERATIONS ]; do
-            if [[ "$NEXT_RELEASE_DATE" >= "$FREEZE_START_1" && "$NEXT_RELEASE_DATE" <= "$FREEZE_END_1" ]]; then
+            RELEASE_TIMESTAMP=$(date -d "$NEXT_RELEASE_DATE" +%s)
+            FREEZE1_START_TS=$(date -d "$FREEZE_START_1" +%s)
+            FREEZE1_END_TS=$(date -d "$FREEZE_END_1" +%s)
+            FREEZE2_START_TS=$(date -d "$FREEZE_START_2" +%s)
+            FREEZE2_END_TS=$(date -d "$FREEZE_END_2" +%s)
+
+            if [ $RELEASE_TIMESTAMP -ge $FREEZE1_START_TS ] && [ $RELEASE_TIMESTAMP -le $FREEZE1_END_TS ]; then
               echo "DEBUG: Date falls in freeze period 1, adjusting..."
               NEXT_RELEASE_DATE=$(date -d "$FREEZE_END_1 + 1 day" +%Y-%m-%d)
               NEXT_RELEASE_DATE=$(adjust_to_tuesday "$NEXT_RELEASE_DATE")
@@ -69,7 +92,7 @@ jobs:
               continue
             fi
 
-            if [[ "$NEXT_RELEASE_DATE" >= "$FREEZE_START_2" && "$NEXT_RELEASE_DATE" <= "$FREEZE_END_2" ]]; then
+            if [ $RELEASE_TIMESTAMP -ge $FREEZE2_START_TS ] && [ $RELEASE_TIMESTAMP -le $FREEZE2_END_TS ]; then
               echo "DEBUG: Date falls in freeze period 2, adjusting..."
               NEXT_RELEASE_DATE=$(date -d "$FREEZE_END_2 + 1 day" +%Y-%m-%d)
               NEXT_RELEASE_DATE=$(adjust_to_tuesday "$NEXT_RELEASE_DATE")
@@ -97,7 +120,7 @@ jobs:
           echo "date=$NEXT_RELEASE_DATE" >> $GITHUB_OUTPUT
 
       - name: Add test release label to PR
-        uses: actions/github-script@v6
+        uses: actions/github-script@v4
         with:
           script: |
             const nextReleaseDate = "${{ steps.calculate_date.outputs.date }}";
@@ -107,12 +130,15 @@ jobs:
               throw new Error('Invalid date format received');
             }
 
-            console.log(`Adding test label: test-release:${nextReleaseDate}`);
+            # Get PR number from input or event
+            const prNumber = "${{ github.event.inputs.pr_number }}" || context.payload.pull_request.number;
+
+            console.log(`Adding test label: test-release:${nextReleaseDate} to PR #${prNumber}`);
 
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
+              issue_number: prNumber,
               labels: [`test-release:${nextReleaseDate}`]
             });
 
@@ -120,6 +146,6 @@ jobs:
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
+              issue_number: prNumber,
               body: `🧪 **Test Release Labeling**: This PR would be included in release \`${nextReleaseDate}\``
             });

--- a/.github/workflows/release-labeling.yml
+++ b/.github/workflows/release-labeling.yml
@@ -60,14 +60,18 @@ jobs:
             FREEZE2_START_TS=$(date -d "$FREEZE_START_2" +%s)
             FREEZE2_END_TS=$(date -d "$FREEZE_END_2" +%s)
 
+            # Check if calculated release date falls during December freeze (Dec 2-15)
             if [ $RELEASE_TIMESTAMP -ge $FREEZE1_START_TS ] && [ $RELEASE_TIMESTAMP -le $FREEZE1_END_TS ]; then
+              # Skip freeze period: move to day after freeze ends, then find next Tuesday
               NEXT_RELEASE_DATE=$(date -d "$FREEZE_END_1 + 1 day" +%Y-%m-%d)
               NEXT_RELEASE_DATE=$(adjust_to_tuesday "$NEXT_RELEASE_DATE")
               ITERATION=$((ITERATION + 1))
               continue
             fi
 
+            # Check if calculated release date falls during year-end freeze (Dec 30-Jan 6)
             if [ $RELEASE_TIMESTAMP -ge $FREEZE2_START_TS ] && [ $RELEASE_TIMESTAMP -le $FREEZE2_END_TS ]; then
+              # Skip freeze period: move to day after freeze ends, then find next Tuesday
               NEXT_RELEASE_DATE=$(date -d "$FREEZE_END_2 + 1 day" +%Y-%m-%d)
               NEXT_RELEASE_DATE=$(adjust_to_tuesday "$NEXT_RELEASE_DATE")
               ITERATION=$((ITERATION + 1))

--- a/.github/workflows/release-labeling.yml
+++ b/.github/workflows/release-labeling.yml
@@ -9,6 +9,14 @@ on:
     branches:
       - develop
 
+env:
+  # Use GitHub secrets for date configuration
+  RELEASE_START: ${{ secrets.RELEASE_START_DATE }}
+  FREEZE_START_1: ${{ secrets.FREEZE_START_1_DATE }}
+  FREEZE_END_1: ${{ secrets.FREEZE_END_1_DATE }}
+  FREEZE_START_2: ${{ secrets.FREEZE_START_2_DATE }}
+  FREEZE_END_2: ${{ secrets.FREEZE_END_2_DATE }}
+
 jobs:
   add-release-label:
     name: Add Release Label
@@ -29,13 +37,6 @@ jobs:
             fi
           }
 
-          RELEASE_START="2025-08-12"
-
-          FREEZE_START_1="2025-12-02"
-          FREEZE_END_1="2025-12-15"
-          FREEZE_START_2="2025-12-30"
-          FREEZE_END_2="2026-01-06"
-
           TODAY=$(date +%Y-%m-%d)
 
           # Calculate which release cycle we're in (releases every 14 days)
@@ -49,46 +50,28 @@ jobs:
             NEXT_RELEASE_DATE=$(date -d "$RELEASE_START + $(( $NEXT_CYCLE * 14 )) days" +%Y-%m-%d)
           fi
 
+          # Pre-calculate freeze period timestamps for efficiency
+          FREEZE1_START_TS=$(date -d "$FREEZE_START_1" +%s)
+          FREEZE1_END_TS=$(date -d "$FREEZE_END_1" +%s)
+          FREEZE2_START_TS=$(date -d "$FREEZE_START_2" +%s)
+          FREEZE2_END_TS=$(date -d "$FREEZE_END_2" +%s)
+
           # Skip freeze periods - if calculated date falls during freeze,
           # jump to first Tuesday after freeze ends
-          MAX_ITERATIONS=3  # Safety guard - worst case is 2 freeze periods
-          ITERATION=0
-          while [ $ITERATION -lt $MAX_ITERATIONS ]; do
-            RELEASE_TIMESTAMP=$(date -d "$NEXT_RELEASE_DATE" +%s)
-            FREEZE1_START_TS=$(date -d "$FREEZE_START_1" +%s)
-            FREEZE1_END_TS=$(date -d "$FREEZE_END_1" +%s)
-            FREEZE2_START_TS=$(date -d "$FREEZE_START_2" +%s)
-            FREEZE2_END_TS=$(date -d "$FREEZE_END_2" +%s)
+          RELEASE_TIMESTAMP=$(date -d "$NEXT_RELEASE_DATE" +%s)
 
-            # Check if calculated release date falls during December freeze (Dec 2-15)
-            if [ $RELEASE_TIMESTAMP -ge $FREEZE1_START_TS ] && [ $RELEASE_TIMESTAMP -le $FREEZE1_END_TS ]; then
-              # Skip freeze period: move to day after freeze ends, then find next Tuesday
-              NEXT_RELEASE_DATE=$(date -d "$FREEZE_END_1 + 1 day" +%Y-%m-%d)
-              NEXT_RELEASE_DATE=$(adjust_to_tuesday "$NEXT_RELEASE_DATE")
-              ITERATION=$((ITERATION + 1))
-              continue
-            fi
-
-            # Check if calculated release date falls during year-end freeze (Dec 30-Jan 6)
-            if [ $RELEASE_TIMESTAMP -ge $FREEZE2_START_TS ] && [ $RELEASE_TIMESTAMP -le $FREEZE2_END_TS ]; then
-              # Skip freeze period: move to day after freeze ends, then find next Tuesday
-              NEXT_RELEASE_DATE=$(date -d "$FREEZE_END_2 + 1 day" +%Y-%m-%d)
-              NEXT_RELEASE_DATE=$(adjust_to_tuesday "$NEXT_RELEASE_DATE")
-              ITERATION=$((ITERATION + 1))
-              continue
-            fi
-
-            break
-          done
-
-          if [ $ITERATION -eq $MAX_ITERATIONS ]; then
-            echo "Error: Too many freeze period adjustments" >&2
-            exit 1
+          # Check if calculated release date falls during December freeze (Dec 2-15)
+          if [ $RELEASE_TIMESTAMP -ge $FREEZE1_START_TS ] && [ $RELEASE_TIMESTAMP -le $FREEZE1_END_TS ]; then
+            # Skip freeze period: move to day after freeze ends, then find next Tuesday
+            NEXT_RELEASE_DATE=$(date -d "$FREEZE_END_1 + 1 day" +%Y-%m-%d)
+            NEXT_RELEASE_DATE=$(adjust_to_tuesday "$NEXT_RELEASE_DATE")
           fi
 
-          if ! date -d "$NEXT_RELEASE_DATE" >/dev/null 2>&1; then
-            echo "Error: Invalid date calculated" >&2
-            exit 1
+          # Check if calculated release date falls during year-end freeze (Dec 30-Jan 6)
+          if [ $RELEASE_TIMESTAMP -ge $FREEZE2_START_TS ] && [ $RELEASE_TIMESTAMP -le $FREEZE2_END_TS ]; then
+            # Skip freeze period: move to day after freeze ends, then find next Tuesday
+            NEXT_RELEASE_DATE=$(date -d "$FREEZE_END_2 + 1 day" +%Y-%m-%d)
+            NEXT_RELEASE_DATE=$(adjust_to_tuesday "$NEXT_RELEASE_DATE")
           fi
 
           echo "date=$NEXT_RELEASE_DATE" >> $GITHUB_OUTPUT
@@ -97,16 +80,9 @@ jobs:
         uses: actions/github-script@v4
         with:
           script: |
-            const nextReleaseDate = "${{ steps.calculate_date.outputs.date }}";
-
-            // Validate date format
-            if (!/^\d{4}-\d{2}-\d{2}$/.test(nextReleaseDate)) {
-              throw new Error('Invalid date format received');
-            }
-
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              labels: [`release:${nextReleaseDate}`]
+              labels: [`release:${{ steps.calculate_date.outputs.date }}`]
             });


### PR DESCRIPTION
## Description 📝
Adds a GitHub Action that automatically labels new PRs with their target release date based on our bi-weekly Tuesday release schedule.

**How it works:**
- Triggers when PRs are opened against `develop`
- Calculates next release date + 14-day cycles
- Skips code freeze periods
- Adds label like `release:2025-08-26`

**Why:**
Makes it easy to see which release a PR will ship in without manual tracking.

**Testing:**
Starting on develop branch - can disable via Actions tab if issues arise.

## Changes  🔄
- New `release-labeling.yml` file for github actions

## Target release date 🗓️
N/A
