### PR TITLE
fix: [M3-10399] - Restore the previous date value when Cancel is clicked

### DIFF
--- a/packages/ui/src/components/DatePicker/DateTimeRangePicker/DateTimeRangePicker.test.tsx
+++ b/packages/ui/src/components/DatePicker/DateTimeRangePicker/DateTimeRangePicker.test.tsx
@@ -175,5 +175,37 @@ describe('DateTimeRangePicker', () => {
       // Ensure the local time remains the same, but the timezone changes
       expect(startTimeField).toHaveValue('1:00 PM');
     });
+
+    it('should restore the previous Start Date value when Cancel is clicked after selecting a new date', async () => {
+      renderWithTheme(<DateTimeRangePicker {...defaultProps} />);
+
+      const defaultDateValue = mockDate?.toFormat('yyyy-MM-dd hh:mm a');
+
+      const startDateField = screen.getByRole('textbox', {
+        name: 'Start Date',
+      });
+
+      // Assert initial displayed value
+      expect(startDateField).toHaveDisplayValue(defaultDateValue);
+
+      // Open popover
+      await userEvent.click(startDateField);
+      expect(screen.getByRole('dialog')).toBeVisible();
+
+      // Select preset value
+      const preset = screen.getByRole('button', {
+        name: 'last 7 days',
+      });
+      await userEvent.click(preset);
+
+      // Date should now be updated in the field
+      expect(startDateField).not.toHaveDisplayValue(defaultDateValue);
+
+      // Click Cancel
+      await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      // Expect field to reset to previous value
+      expect(startDateField).toHaveDisplayValue(defaultDateValue);
+    });
   });
 });

--- a/packages/ui/src/components/DatePicker/DateTimeRangePicker/DateTimeRangePicker.tsx
+++ b/packages/ui/src/components/DatePicker/DateTimeRangePicker/DateTimeRangePicker.tsx
@@ -131,6 +131,19 @@ export const DateTimeRangePicker = ({
   const startDateInputRef = useRef<HTMLInputElement | null>(null);
   const endDateInputRef = useRef<HTMLInputElement | null>(null);
 
+  // Persist previous state values
+  const previousValues = useRef<{
+    endDate: DateTime | null;
+    selectedPreset: null | string;
+    startDate: DateTime | null;
+    timeZone: string;
+  }>({
+    endDate: endDateProps?.value ?? null,
+    startDate: startDateProps?.value ?? null,
+    selectedPreset: presetsProps?.defaultValue ?? null,
+    timeZone: timeZoneProps?.defaultValue ?? null,
+  });
+
   const theme = useTheme();
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
 
@@ -144,6 +157,12 @@ export const DateTimeRangePicker = ({
   };
 
   const handleClose = () => {
+    // Revert values
+    setStartDate(previousValues.current.startDate);
+    setEndDate(previousValues.current.endDate);
+    setTimeZone(previousValues.current.timeZone);
+    setSelectedPreset(previousValues.current.selectedPreset);
+
     setOpen(false);
     setAnchorEl(null);
   };
@@ -155,6 +174,15 @@ export const DateTimeRangePicker = ({
       startDate: startDate ? startDate.toISO() : null,
       timeZone,
     });
+
+    // Save current values
+    previousValues.current = {
+      startDate,
+      endDate,
+      timeZone,
+      selectedPreset,
+    };
+
     handleClose();
   };
 


### PR DESCRIPTION
## Description 📝

This PR fixes that when a user opens the DateTimeRangePicker and makes changes to the selected date or time, and then clicks the Cancel button, all changes are discarded and the fields revert to their previous values. This improves the user experience by allowing safe exploration without committing accidental changes.

## Changes  🔄

List any change(s) relevant to the reviewer.

- DateTimeRangePicker.tsx
- DateTimeRangePicker.test.tsx

## Target release date 🗓️

8/12

## Preview 📷

https://github.com/user-attachments/assets/8d4fb6e1-b322-4498-8d74-b4f9b4e0e23a



## How to test 🧪

(How to verify changes)

- [ ] Navigate to http://localhost:3000/metrics
- [ ] Switch to mock user
- [ ] Click on the Start Date field
- [ ] Make changes to the either by selecting new date or time or presets
- [ ] Click Cancel and verify the Start Date field should set to previous value. 
- [ ] Verify no regressions to the existing functionality 

Ensure the popover with calendar and time inputs appears.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

