### PR TITLE
fix: [M310299] - DatePicker: Show error, if end date time is before start date time

### DIFF
--- a/packages/ui/src/components/DatePicker/DateTimeRangePicker/DateTimeRangePicker.tsx
+++ b/packages/ui/src/components/DatePicker/DateTimeRangePicker/DateTimeRangePicker.tsx
@@ -144,11 +144,18 @@ export const DateTimeRangePicker = ({
   };
 
   const handleClose = () => {
+    // Clear errors
+    setStartDateError('');
+    setEndDateError('');
     setOpen(false);
     setAnchorEl(null);
   };
 
   const handleApply = () => {
+    if (startDateError || endDateError) {
+      return;
+    }
+
     onApply?.({
       endDate: endDate ? endDate.toISO() : null,
       selectedPreset,
@@ -185,9 +192,13 @@ export const DateTimeRangePicker = ({
   ) => {
     if (newStartDate && newEndDate && newStartDate > newEndDate) {
       setStartDateError(
-        'Start date must be earlier than or equal to end date.',
+        startDateProps?.errorMessage ??
+          'Start date must be earlier than or equal to end date.',
       );
-      setEndDateError('End date must be later than or equal to start date.');
+      setEndDateError(
+        endDateProps?.errorMessage ??
+          'End date must be later than or equal to start date.',
+      );
     } else {
       setStartDateError('');
       setEndDateError('');
@@ -218,6 +229,34 @@ export const DateTimeRangePicker = ({
       }
     }
     validateDates(startDate, endDate);
+  };
+
+  const handleStartTimeChange = (newTime: DateTime) => {
+    if (newTime) {
+      setStartDate((prev) => {
+        const updatedVale =
+          prev?.set({
+            hour: newTime.hour,
+            minute: newTime.minute,
+          }) ?? newTime;
+        validateDates(updatedVale, endDate);
+        return updatedVale;
+      });
+    }
+  };
+
+  const handleEndTimeChange = (newTime: DateTime) => {
+    if (newTime) {
+      setEndDate((prev) => {
+        const updatedValue =
+          prev?.set({
+            hour: newTime.hour,
+            minute: newTime.minute,
+          }) ?? newTime;
+        validateDates(startDate, updatedValue);
+        return updatedValue;
+      });
+    }
   };
 
   const handlePresetSelect = (
@@ -274,7 +313,11 @@ export const DateTimeRangePicker = ({
           onClose={handleClose}
           open={open}
           role="dialog"
-          sx={{ boxShadow: 3, zIndex: 1300 }}
+          sx={(theme) => ({
+            boxShadow: 3,
+            zIndex: 1300,
+            mt: startDateError || endDateError ? theme.spacingFunction(24) : 0,
+          })}
           transformOrigin={{ horizontal: 'left', vertical: 'top' }}
         >
           <Box
@@ -323,32 +366,12 @@ export const DateTimeRangePicker = ({
               >
                 <TimePicker
                   label="Start Time"
-                  onChange={(newTime) => {
-                    if (newTime) {
-                      setStartDate(
-                        (prev) =>
-                          prev?.set({
-                            hour: newTime.hour,
-                            minute: newTime.minute,
-                          }) ?? newTime,
-                      );
-                    }
-                  }}
+                  onChange={(newTime) => handleStartTimeChange(newTime)}
                   value={startDate}
                 />
                 <TimePicker
                   label="End Time"
-                  onChange={(newTime) => {
-                    if (newTime) {
-                      setEndDate(
-                        (prev) =>
-                          prev?.set({
-                            hour: newTime.hour,
-                            minute: newTime.minute,
-                          }) ?? newTime,
-                      );
-                    }
-                  }}
+                  onChange={(newTime) => handleEndTimeChange(newTime)}
                   value={endDate}
                 />
                 <TimeZoneSelect


### PR DESCRIPTION
## Description 📝

This PR ensures proper validation and error messaging when the selected Start Time is later than the End Time, or vice versa, within the DateTimeRangePicker component.

## Changes  🔄

List any change(s) relevant to the reviewer.

- DateTimeRangePicker.tsx


## Target release date 🗓️

8/12

## Preview 📷


https://github.com/user-attachments/assets/eccee4b3-8e34-48ca-9234-3fee47a0ebe5


## How to test 🧪

(How to verify changes)

- [ ]  Navigate to http://localhost:3000/metrics
- [ ]  Switch to mock user
- [ ]  Click on the Start Date field
- [ ]  Make changes to the either by selecting start time later than end time or vice versa.
- [ ]  Click Cancel and verify the Start Date field should set to previous value.
- [ ]  Verify no regressions to the existing functionality

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

