### PR TITLE
fix: [DI-26114] - Adding in operator check to create-alert schema

### DIFF
--- a/packages/validation/.changeset/pr-12628-fixed-1754307870531.md
+++ b/packages/validation/.changeset/pr-12628-fixed-1754307870531.md
@@ -1,0 +1,5 @@
+---
+"@linode/validation": Fixed
+---
+
+ACLP - Alerting: Fix missing 'in' operator check in dimension filter for create alert schema ([#12628](https://github.com/linode/manager/pull/12628))

--- a/packages/validation/src/cloudpulse.schema.ts
+++ b/packages/validation/src/cloudpulse.schema.ts
@@ -5,7 +5,7 @@ const fieldErrorMessage = 'This field is required.';
 export const dimensionFilters = object({
   dimension_label: string().required(fieldErrorMessage),
   operator: string()
-    .oneOf(['eq', 'neq', 'startswith', 'endswith'])
+    .oneOf(['eq', 'neq', 'startswith', 'endswith', 'in'])
     .required(fieldErrorMessage),
   value: string().required(fieldErrorMessage),
 });


### PR DESCRIPTION
## Description 📝

Bugfix for missing schema validation

## Changes  🔄

List any change(s) relevant to the reviewer.

- Add 'in' to the list of operator values in `cloupulse.schema.ts`

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [] All customers
- [x] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

ASAP

## Preview 📷



| Before  | After   |
| ------- | ------- |
| <img  src="https://github.com/user-attachments/assets/57e3923c-5a66-4716-a021-0510c70a866b" /> | <img src="https://github.com/user-attachments/assets/6bc9a277-893c-4a29-b9e7-2740662f1de1" />|

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Go to Monitor, then Alerts. Click on Create Alert button once it is enabled. 

### Verification steps

(How to verify changes)

- [ ] Fill the Alert creation form with 'in' operator for the dimension filters

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>