### PR TITLE
fix: [UIE-9003] - DBaaS - node selector options for premium and provide plan disabling behavior in resize

### DIFF
--- a/packages/manager/.changeset/pr-12634-added-1754346674408.md
+++ b/packages/manager/.changeset/pr-12634-added-1754346674408.md
@@ -2,4 +2,4 @@
 "@linode/manager": Added
 ---
 
-PlansPanel additionalBanners property to handle rendering additional notification banners provided from parent and disabled property for DatabaseNodeSelector ([#12634](https://github.com/linode/manager/pull/12634))
+PlansPanel additionalBanners property for rendering additional banners and disabled property for DatabaseNodeSelector ([#12634](https://github.com/linode/manager/pull/12634))

--- a/packages/manager/.changeset/pr-12634-added-1754346674408.md
+++ b/packages/manager/.changeset/pr-12634-added-1754346674408.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+PlansPanel additionalBanners property to handle rendering additional notification banners provided from parent  ([#12634](https://github.com/linode/manager/pull/12634))

--- a/packages/manager/.changeset/pr-12634-added-1754346674408.md
+++ b/packages/manager/.changeset/pr-12634-added-1754346674408.md
@@ -2,4 +2,4 @@
 "@linode/manager": Added
 ---
 
-PlansPanel additionalBanners property to handle rendering additional notification banners provided from parent  ([#12634](https://github.com/linode/manager/pull/12634))
+PlansPanel additionalBanners property to handle rendering additional notification banners provided from parent and disabled property for DatabaseNodeSelector ([#12634](https://github.com/linode/manager/pull/12634))

--- a/packages/manager/.changeset/pr-12634-fixed-1754346423085.md
+++ b/packages/manager/.changeset/pr-12634-fixed-1754346423085.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+DBaaS Create and Resize node selector options for premium plans and region disabling behavior and handling not being applied in Resize ([#12634](https://github.com/linode/manager/pull/12634))

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseNodeSelector.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseNodeSelector.test.tsx
@@ -2,11 +2,55 @@ import { waitForElementToBeRemoved } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
+import { databaseTypeFactory, planSelectionTypeFactory } from 'src/factories';
 import { mockMatchMedia, renderWithTheme } from 'src/utilities/testHelpers';
 
 import { DatabaseCreate } from './DatabaseCreate';
+import { DatabaseNodeSelector } from './DatabaseNodeSelector';
+
+import type { ClusterSize, Engine } from '@linode/api-v4';
+import type { PlanSelectionWithDatabaseType } from 'src/features/components/PlansPanel/types';
 
 const loadingTestId = 'circle-progress';
+
+const mockDisplayTypes = [
+  planSelectionTypeFactory.build({
+    class: 'standard',
+  }),
+  planSelectionTypeFactory.build({
+    class: 'nanode',
+  }),
+  planSelectionTypeFactory.build({
+    class: 'dedicated',
+  }),
+  planSelectionTypeFactory.build({
+    class: 'premium',
+    id: 'premium-32',
+    label: 'Premium 32 GB',
+  }),
+];
+
+const mockCurrentPlan = databaseTypeFactory.build({
+  class: 'premium',
+  id: 'premium-32',
+  label: 'Premium 32 GB',
+}) as PlanSelectionWithDatabaseType;
+
+const mockClusterSize: ClusterSize = 1;
+const mockEngine: Engine = 'mysql';
+
+const mockProps = {
+  currentClusterSize: mockClusterSize,
+  currentPlan: mockCurrentPlan,
+  disabled: false,
+  displayTypes: mockDisplayTypes,
+  error: '',
+  handleNodeChange: vi.fn(),
+  selectedClusterSize: mockClusterSize,
+  selectedEngine: mockEngine,
+  selectedPlan: mockCurrentPlan,
+  selectedTab: 0,
+};
 
 beforeAll(() => mockMatchMedia());
 
@@ -17,7 +61,7 @@ describe('database node selector', () => {
       enabled: true,
     },
   };
-  it('should render 3 nodes for dedicated tab', async () => {
+  it('should render 3 node options for dedicated tab', async () => {
     const { getByTestId } = renderWithTheme(<DatabaseCreate />, {
       flags,
     });
@@ -30,7 +74,7 @@ describe('database node selector', () => {
     expect(getByTestId('database-node-3')).toBeInTheDocument();
   });
 
-  it('should render 2 nodes for shared tab', async () => {
+  it('should render 2 node options for shared tab', async () => {
     const { getAllByRole, getByTestId } = renderWithTheme(<DatabaseCreate />, {
       flags,
     });
@@ -43,5 +87,35 @@ describe('database node selector', () => {
     expect(getByTestId('database-nodes').childNodes.length).equal(2);
     expect(getByTestId('database-node-1')).toBeInTheDocument();
     expect(getByTestId('database-node-3')).toBeInTheDocument();
+  });
+
+  it('should render 3 node options for premium tab', async () => {
+    const { getByTestId, getAllByRole } = renderWithTheme(<DatabaseCreate />, {
+      flags,
+    });
+    expect(getByTestId(loadingTestId)).toBeInTheDocument();
+    await waitForElementToBeRemoved(getByTestId(loadingTestId));
+
+    const premiumTab = getAllByRole('tab')[2];
+    await userEvent.click(premiumTab);
+
+    expect(getByTestId('database-nodes').childNodes.length).equal(3);
+    expect(getByTestId('database-node-1')).toBeInTheDocument();
+    expect(getByTestId('database-node-2')).toBeInTheDocument();
+    expect(getByTestId('database-node-3')).toBeInTheDocument();
+  });
+
+  it('should disable 3 node options when disabled is true', async () => {
+    const { getByTestId } = renderWithTheme(
+      <DatabaseNodeSelector {...mockProps} disabled />,
+      {
+        flags,
+      }
+    );
+
+    expect(getByTestId('database-nodes')).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
   });
 });

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseNodeSelector.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseNodeSelector.tsx
@@ -31,6 +31,7 @@ export interface NodePricing {
 interface Props {
   currentClusterSize?: ClusterSize | undefined;
   currentPlan?: PlanSelectionWithDatabaseType | undefined;
+  disabled?: boolean;
   displayTypes: PlanSelectionType[];
   error?: string;
   handleNodeChange: (value: ClusterSize) => void;
@@ -44,6 +45,7 @@ export const DatabaseNodeSelector = (props: Props) => {
   const {
     currentClusterSize,
     currentPlan,
+    disabled,
     displayTypes,
     error,
     handleNodeChange,
@@ -79,6 +81,8 @@ export const DatabaseNodeSelector = (props: Props) => {
       (type) => type.class === 'dedicated'
     );
 
+    const hasPremium = displayTypes.some((type) => type.class === 'premium');
+
     const currentChip = currentClusterSize && initialTab === selectedTab && (
       <StyledChip
         aria-label="This is your current number of nodes"
@@ -104,7 +108,12 @@ export const DatabaseNodeSelector = (props: Props) => {
       },
     ];
 
-    if (hasDedicated && selectedTab === 0) {
+    const isDedicated = hasDedicated && selectedTab === 0;
+    const isPremium = hasPremium && selectedTab === 2;
+
+    const displayTwoNodesOption = isDedicated || isPremium;
+
+    if (displayTwoNodesOption) {
       options.push({
         label: (
           <Typography component="div">
@@ -157,14 +166,14 @@ export const DatabaseNodeSelector = (props: Props) => {
         upgrades and maintenance.
       </Typography>
       <FormControl
-        disabled={isRestricted}
+        disabled={isRestricted || disabled}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
           handleNodeChange(+e.target.value as ClusterSize);
         }}
       >
         {error ? <Notice text={error} variant="error" /> : null}
         <RadioGroup
-          aria-disabled={isRestricted}
+          aria-disabled={isRestricted || disabled}
           data-testid="database-nodes"
           style={{ marginBottom: 0, marginTop: 0 }}
           value={selectedClusterSize ?? ''}

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize.test.tsx
@@ -601,7 +601,8 @@ describe('database resize', () => {
         'aria-disabled',
         'true'
       );
-      const expectedMessage = `Warning: Your current plan is currently unavailable and it can't be used to resize the cluster. You can only resize the cluster using other available plans.`;
+      const expectedMessage =
+        'Warning: Your current plan is currently unavailable and it can\u{2019}t be used to resize the cluster. You can only resize the cluster using other available plans.';
       const unavailableNotice = getAllByText(expectedMessage);
       expect(unavailableNotice[0]).toBeInTheDocument();
     });

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize.test.tsx
@@ -1,3 +1,4 @@
+import { regionAvailabilityFactory, regionFactory } from '@linode/utilities';
 import { waitForElementToBeRemoved } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
@@ -24,6 +25,50 @@ import type { PlanSelectionWithDatabaseType } from 'src/features/components/Plan
 const engine = 'mysql';
 const isResizeEnabled = true;
 const loadingTestId = 'circle-progress';
+
+const mockDedicatedTypes = [
+  databaseTypeFactory.build({
+    class: 'dedicated',
+    disk: 81920,
+    id: 'g6-dedicated-2',
+    label: 'Dedicated 4 GB',
+    memory: 4096,
+  }),
+  databaseTypeFactory.build({
+    class: 'dedicated',
+    disk: 163840,
+    id: 'g6-dedicated-4',
+    label: 'Dedicated 8 GB',
+    memory: 8192,
+  }),
+];
+
+const availabilities = [
+  regionAvailabilityFactory.build({
+    plan: 'premium-32',
+    region: 'us-east',
+    available: false,
+  }),
+];
+
+const queryMocks = vi.hoisted(() => ({
+  useRegionAvailabilityQuery: vi.fn().mockReturnValue({ data: [] }),
+  useRegionQuery: vi.fn().mockReturnValue({ data: {} }),
+}));
+
+vi.mock('@linode/queries', async () => {
+  const actual = await vi.importActual('@linode/queries');
+  return {
+    ...actual,
+    useRegionQuery: queryMocks.useRegionQuery,
+    useRegionAvailabilityQuery: queryMocks.useRegionAvailabilityQuery,
+  };
+});
+
+// Mock response from region availability query to simulate limited availability for premium-32 plan in us-ord region (Chicago)
+queryMocks.useRegionAvailabilityQuery.mockReturnValue({
+  data: availabilities,
+});
 
 beforeAll(() => mockMatchMedia());
 
@@ -187,15 +232,6 @@ describe('database resize', () => {
         }),
         ...databaseTypeFactory.buildList(7, { class: 'standard' }),
       ];
-      const mockDedicatedTypes = [
-        databaseTypeFactory.build({
-          class: 'dedicated',
-          disk: 81920,
-          id: 'g6-dedicated-2',
-          label: 'Dedicated 4 GB',
-          memory: 4096,
-        }),
-      ];
 
       server.use(
         http.get('*/databases/types', () => {
@@ -345,24 +381,6 @@ describe('database resize', () => {
   describe('on rendering of page and isDatabasesV2GA is true and the Dedicated CPU tab is preselected', () => {
     beforeEach(() => {
       // Mock database types
-      const mockDedicatedTypes = [
-        databaseTypeFactory.build({
-          class: 'dedicated',
-          disk: 81920,
-          id: 'g6-dedicated-2',
-          label: 'Dedicated 4 GB',
-          memory: 4096,
-        }),
-        databaseTypeFactory.build({
-          class: 'dedicated',
-          disk: 163840,
-          id: 'g6-dedicated-4',
-          label: 'Dedicated 8 GB',
-          memory: 8192,
-        }),
-      ];
-
-      // Mock database types
       const standardTypes = [
         databaseTypeFactory.build({
           class: 'nanode',
@@ -498,6 +516,94 @@ describe('database resize', () => {
       expect(getByTestId(loadingTestId)).toBeInTheDocument();
       await waitForElementToBeRemoved(getByTestId(loadingTestId));
       expect(getByText('Shared CPU')).toHaveAttribute('aria-disabled', 'true');
+    });
+  });
+
+  describe('on rendering of page and databasePremium flag is true and the current plan for the cluster is unavailable', () => {
+    beforeEach(() => {
+      // Mock database types
+      const standardTypes = [
+        databaseTypeFactory.build({
+          class: 'nanode',
+          id: 'g6-nanode-1',
+          label: `New DBaaS - Nanode 1 GB`,
+          memory: 1024,
+        }),
+      ];
+      const premiumTypes = [
+        databaseTypeFactory.build({
+          class: 'premium',
+          id: 'premium-32',
+          label: `DBaaS - Premium 32 GB`,
+          memory: 1024,
+        }),
+      ];
+
+      const mockRegion = regionFactory.build({
+        capabilities: ['VPCs'],
+        id: 'us-east',
+        label: 'Newark, NJ',
+      });
+      queryMocks.useRegionQuery.mockReturnValue({
+        data: mockRegion,
+      });
+
+      server.use(
+        http.get('*/databases/types', () => {
+          return HttpResponse.json(
+            makeResourcePage([
+              ...mockDedicatedTypes,
+              ...standardTypes,
+              ...premiumTypes,
+            ])
+          );
+        }),
+        http.get('*/account', () => {
+          const account = accountFactory.build({
+            capabilities: ['Managed Databases', 'Managed Databases Beta'],
+          });
+          return HttpResponse.json(account);
+        })
+      );
+    });
+
+    it('should disable node selection and display unavailable current plan notice', async () => {
+      const databaseWithPremiumSelection = {
+        ...mockDatabase,
+        type: 'premium-32',
+        region: 'us-east',
+      };
+
+      const flags = {
+        dbaasV2: {
+          beta: false,
+          enabled: true,
+        },
+        databasePremium: true,
+      };
+
+      const { getByTestId, getAllByText } = renderWithTheme(
+        <DatabaseDetailContext.Provider
+          value={{
+            database: databaseWithPremiumSelection,
+            engine,
+            isResizeEnabled,
+          }}
+        >
+          <DatabaseResize />
+        </DatabaseDetailContext.Provider>,
+        { flags }
+      );
+      expect(getByTestId(loadingTestId)).toBeInTheDocument();
+      await waitForElementToBeRemoved(getByTestId(loadingTestId));
+
+      expect(getByTestId('database-nodes')).toHaveAttribute(
+        'aria-disabled',
+        'true'
+      );
+      const expectedMessage = `Warning: Your current plan is currently unavailable and it can't be used to resize the cluster. You can only resize the cluster using other available plans.`;
+      const unavailableNotice = getAllByText(expectedMessage);
+      expect(unavailableNotice[0]).toBeInTheDocument();
     });
   });
 });

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize.tsx
@@ -96,9 +96,7 @@ export const DatabaseResize = () => {
 
   const { data: regionAvailabilities } = useRegionAvailabilityQuery(
     databaseRegion,
-    Boolean(flags.soldOutChips) &&
-      Boolean(flags.databasePremium) &&
-      Boolean(databaseRegion)
+    Boolean(flags.soldOutChips && flags.databasePremium && databaseRegion)
   );
 
   const { enqueueSnackbar } = useSnackbar();
@@ -202,7 +200,11 @@ export const DatabaseResize = () => {
 
   const currentPlanUnavailableNotice = (
     <Notice variant="warning">
-      <PlanNoticeTypography variant="h3">{`Warning: Your current plan is currently unavailable and it can't be used to resize the cluster. You can only resize the cluster using other available plans.`}</PlanNoticeTypography>
+      <PlanNoticeTypography variant="h3">
+        {
+          'Warning: Your current plan is currently unavailable and it can\u{2019}t be used to resize the cluster. You can only resize the cluster using other available plans.'
+        }
+      </PlanNoticeTypography>
     </Notice>
   );
 

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize.tsx
@@ -1,4 +1,9 @@
-import { useDatabaseMutation, useDatabaseTypesQuery } from '@linode/queries';
+import {
+  useDatabaseMutation,
+  useDatabaseTypesQuery,
+  useRegionAvailabilityQuery,
+  useRegionQuery,
+} from '@linode/queries';
 import {
   Box,
   CircleProgress,
@@ -14,12 +19,17 @@ import { useSnackbar } from 'notistack';
 import * as React from 'react';
 
 import { TypeToConfirmDialog } from 'src/components/TypeToConfirmDialog/TypeToConfirmDialog';
-import { determineInitialPlanCategoryTab } from 'src/features/components/PlansPanel/utils';
+import { PlanNoticeTypography } from 'src/features/components/PlansPanel/PlansAvailabilityNotice.styles';
+import {
+  determineInitialPlanCategoryTab,
+  getIsLimitedAvailability,
+} from 'src/features/components/PlansPanel/utils';
 import { DatabaseNodeSelector } from 'src/features/Databases/DatabaseCreate/DatabaseNodeSelector';
 import { DatabaseSummarySection } from 'src/features/Databases/DatabaseCreate/DatabaseSummarySection';
 import { DatabaseResizeCurrentConfiguration } from 'src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResizeCurrentConfiguration';
 import { useIsDatabasesEnabled } from 'src/features/Databases/utilities';
 import { typeLabelDetails } from 'src/features/Linodes/presentation';
+import { useFlags } from 'src/hooks/useFlags';
 
 import { useDatabaseDetailContext } from '../DatabaseDetailContext';
 import {
@@ -53,6 +63,7 @@ export const DatabaseResize = () => {
 
   const [selectedTab, setSelectedTab] = React.useState(0);
   const { isDatabasesV2GA } = useIsDatabasesEnabled();
+  const flags = useFlags();
   const isNewDatabaseGA =
     isDatabasesV2GA && database.platform !== 'rdbms-legacy';
   const [clusterSize, setClusterSize] = React.useState<ClusterSize | undefined>(
@@ -70,6 +81,22 @@ export const DatabaseResize = () => {
     error: typesError,
     isLoading: typesLoading,
   } = useDatabaseTypesQuery({ platform: database.platform });
+
+  // When databasePremium flag is enabled, provide the database region ID to perform queries and enable additional behavior for the PlansPanel
+  const databaseRegion = flags.databasePremium ? database.region : '';
+
+  const {
+    data: regionData,
+    error: regionError,
+    isLoading: regionLoading,
+  } = useRegionQuery(databaseRegion);
+
+  const { data: regionAvailabilities } = useRegionAvailabilityQuery(
+    database.region || '',
+    Boolean(flags.soldOutChips) &&
+      Boolean(flags.databasePremium) &&
+      Boolean(database.region)
+  );
 
   const { enqueueSnackbar } = useSnackbar();
 
@@ -170,6 +197,12 @@ export const DatabaseResize = () => {
       </>
     );
 
+  const currentPlanUnavailableNotice = (
+    <Notice variant="warning">
+      <PlanNoticeTypography variant="h3">{`Warning: Your current plan is currently unavailable and it can't be used to resize the cluster. You can only resize the cluster using other available plans.`}</PlanNoticeTypography>
+    </Notice>
+  );
+
   const displayTypes: PlanSelectionWithDatabaseType[] = React.useMemo(() => {
     if (!dbTypes) {
       return [];
@@ -206,6 +239,14 @@ export const DatabaseResize = () => {
 
   const currentPlan = displayTypes?.find((type) => type.id === database.type);
 
+  const isCurrentPlanUnavailable = currentPlan
+    ? getIsLimitedAvailability({
+        plan: currentPlan,
+        regionAvailabilities: regionAvailabilities ?? [],
+        selectedRegionId: database.region,
+      })
+    : false;
+
   React.useEffect(() => {
     const initialTab = determineInitialPlanCategoryTab(
       displayTypes,
@@ -232,8 +273,11 @@ export const DatabaseResize = () => {
       displayTypes,
       selectedPlanId
     );
+    // The 2 node selection is not available for Shared plans
     // If 2 Nodes is selected for an incompatible plan, clear selected plan and related information
-    if (size === 2 && selectedPlanTab !== 0) {
+    const isSharedPlan = selectedPlanTab === 1;
+    const hasInvalidSelection = size === 2 && isSharedPlan;
+    if (hasInvalidSelection) {
       setSelectedPlanId(undefined);
     }
     setClusterSize(size);
@@ -273,11 +317,11 @@ export const DatabaseResize = () => {
     return null;
   }
 
-  if (typesLoading) {
+  if (typesLoading || regionLoading) {
     return <CircleProgress />;
   }
 
-  if (typesError) {
+  if (typesError || regionError) {
     return <ErrorState errorText="An unexpected error occurred." />;
   }
 
@@ -291,6 +335,11 @@ export const DatabaseResize = () => {
       </Paper>
       <Paper sx={{ marginTop: 2 }}>
         <StyledPlansPanel
+          additionalBanners={
+            isCurrentPlanUnavailable && Boolean(flags.databasePremium)
+              ? [currentPlanUnavailableNotice]
+              : []
+          }
           currentPlanHeading={currentPlan?.heading}
           data-qa-select-plan
           disabled={disabled}
@@ -302,7 +351,9 @@ export const DatabaseResize = () => {
           header="Choose a Plan"
           isLegacyDatabase={!isNewDatabaseGA}
           onSelect={(selected: string) => setSelectedPlanId(selected)}
+          regionsData={regionData ? [regionData] : undefined}
           selectedId={selectedPlanId}
+          selectedRegionID={databaseRegion}
           tabDisabledMessage="Resizing a 2-node cluster is only allowed with Dedicated plans."
           types={displayTypes}
         />
@@ -312,6 +363,9 @@ export const DatabaseResize = () => {
             <DatabaseNodeSelector
               currentClusterSize={database.cluster_size}
               currentPlan={currentPlan}
+              disabled={
+                isCurrentPlanUnavailable && currentPlan?.id === selectedPlanId
+              }
               displayTypes={displayTypes}
               handleNodeChange={(size: ClusterSize) => {
                 handleNodeChange(size);

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseResize/DatabaseResize.tsx
@@ -82,8 +82,11 @@ export const DatabaseResize = () => {
     isLoading: typesLoading,
   } = useDatabaseTypesQuery({ platform: database.platform });
 
-  // When databasePremium flag is enabled, provide the database region ID to perform queries and enable additional behavior for the PlansPanel
-  const databaseRegion = flags.databasePremium ? database.region : '';
+  // When databasePremium flag is enabled for a new database cluster, provide the database region ID to perform queries and enable additional behavior for the PlansPanel
+  const databaseRegion =
+    flags.databasePremium && database.platform === 'rdbms-default'
+      ? database.region
+      : '';
 
   const {
     data: regionData,
@@ -92,10 +95,10 @@ export const DatabaseResize = () => {
   } = useRegionQuery(databaseRegion);
 
   const { data: regionAvailabilities } = useRegionAvailabilityQuery(
-    database.region || '',
+    databaseRegion,
     Boolean(flags.soldOutChips) &&
       Boolean(flags.databasePremium) &&
-      Boolean(database.region)
+      Boolean(databaseRegion)
   );
 
   const { enqueueSnackbar } = useSnackbar();
@@ -243,7 +246,7 @@ export const DatabaseResize = () => {
     ? getIsLimitedAvailability({
         plan: currentPlan,
         regionAvailabilities: regionAvailabilities ?? [],
-        selectedRegionId: database.region,
+        selectedRegionId: databaseRegion,
       })
     : false;
 

--- a/packages/manager/src/features/components/PlansPanel/PlanInformation.test.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanInformation.test.tsx
@@ -1,3 +1,4 @@
+import { Notice } from '@linode/ui';
 import { screen } from '@testing-library/react';
 import React from 'react';
 
@@ -56,5 +57,23 @@ describe('PlanInformation', () => {
       limitedAvailabilityBannerTestId
     );
     expect(limitedAvailabilityBanner).toBeInTheDocument();
+  });
+
+  it('should render additionalBanners when provided', () => {
+    const infoBanner = (
+      <Notice variant="info">This is an Information Notice</Notice>
+    );
+    const warningBanner = (
+      <Notice variant="warning">This is a Warning Notice</Notice>
+    );
+
+    const additionalBanners = [infoBanner, warningBanner];
+    renderWithTheme(
+      <PlanInformation {...mockProps} additionalBanners={additionalBanners} />
+    );
+    const infoNotice = screen.getByText('This is an Information Notice');
+    const warningNotice = screen.getByText('This is a Warning Notice');
+    expect(infoNotice).toBeInTheDocument();
+    expect(warningNotice).toBeInTheDocument();
   });
 });

--- a/packages/manager/src/features/components/PlansPanel/PlanInformation.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlanInformation.tsx
@@ -28,6 +28,7 @@ interface ExtendedPlanType {
 }
 
 export interface PlanInformationProps extends ExtendedPlanType {
+  additionalBanners?: React.ReactNode[];
   disabledClasses?: LinodeTypeClass[];
   flow: 'kubernetes' | 'linode';
   hasMajorityOfPlansDisabled: boolean;
@@ -40,6 +41,7 @@ export interface PlanInformationProps extends ExtendedPlanType {
 
 export const PlanInformation = (props: PlanInformationProps) => {
   const {
+    additionalBanners,
     disabledClasses,
     flow,
     hasMajorityOfPlansDisabled,
@@ -148,6 +150,10 @@ export const PlanInformation = (props: PlanInformationProps) => {
           </PlanNoticeTypography>
         </Notice>
       )}
+      {additionalBanners &&
+        additionalBanners.map((banner, index) => (
+          <React.Fragment key={index}>{banner}</React.Fragment>
+        ))}
       <ClassDescriptionCopy planType={planType} />
     </>
   );

--- a/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
@@ -33,6 +33,7 @@ import type { LinodeTypeClass, Region } from '@linode/api-v4';
 import type { LinodeCreateQueryParams } from 'src/features/Linodes/types';
 
 export interface PlansPanelProps {
+  additionalBanners?: React.ReactNode[];
   className?: string;
   copy?: string;
   currentPlanHeading?: string;
@@ -68,6 +69,7 @@ export interface PlansPanelProps {
  */
 export const PlansPanel = (props: PlansPanelProps) => {
   const {
+    additionalBanners,
     className,
     copy,
     currentPlanHeading,
@@ -182,6 +184,7 @@ export const PlansPanel = (props: PlansPanelProps) => {
           return (
             <>
               <PlanInformation
+                additionalBanners={additionalBanners}
                 disabledClasses={disabledClasses}
                 flow="linode"
                 hasMajorityOfPlansDisabled={hasMajorityOfPlansDisabled}


### PR DESCRIPTION
## Description 📝

This pull request applies a a fix for the premium plans feature in DBaaS, fixing the node options that are available and applies the plan disabling by region functionality present in Create. It also includes some additional handling for an edge case.

## Changes  🔄

List any change(s) relevant to the reviewer.

- Fixes the node selector options for the premium plans tab so that all 3 node options are available (1, 2, 3 nodes)
- Enables the plan disabling behavior by region in resize for new database clusters.
- Handles edge case where the current plan could appear as disabled, preventing users from making changes to an unavailable plan (ie. node selection) and provides a warning notice (See screenshots below)
- PlansPanel `additionalBanners` property added to handle rendering additional notification banners provided from parent
- `disabled` property added for DatabaseNodeSelector

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [x] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️
8/12/25

## Preview 📷

Node Selection Fix
| Before  | After  |
| ------- | ------- |
 ![before-create-premium-2-nodes-unavailable](https://github.com/user-attachments/assets/c2901a46-c88e-4540-a241-0679b1bdf72c) | ![after-create-2-nodes-available](https://github.com/user-attachments/assets/c24e2bdb-6082-4ff9-8851-d521fcb0b75c)  |
|  ![before-resize-premium-2-nodes-unavailable](https://github.com/user-attachments/assets/d8f394b3-e782-4e7c-a4d1-152ed78e91c3) | ![after-resize-premium-2-node-option-available](https://github.com/user-attachments/assets/33ac9e50-5082-4024-be31-aca51bf5c506)  |

Region Does Not Support Plan Disabling Behavior 
![after-resize-plans-disabled-by-region](https://github.com/user-attachments/assets/469baaab-5efe-4756-9f07-9716cd139cf8)

Current Plan Unavailable Due To Limited Availability in Region with Notification
![after-resize-current-plan-unavailable](https://github.com/user-attachments/assets/b436e1cd-dabc-46a0-880d-9e04577773e9)

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Have access to the databases tab
- Have `databasePremium` feature flag enabled

### Reproduction steps
(How to reproduce the issue, if applicable)
- [ ] Update the serverHandlers.ts to change the mock data by adding the following lines under the [database instance handler](https://github.com/smans-akamai/manager/blob/develop/packages/manager/src/mocks/serverHandlers.ts#L343) right after the database variable is declared.
`database.type = 'premium-4';`
`database.region = 'us-iad';`
`database.platform = 'rdbms-default';`
This will provide consistent data in resize

- [ ] In the develop branch with the mock data running. Access the Database Create view and switch the premium plans tab
- [ ] See that only the 1 and 3 nodes options are displayed
- [ ] Access the details for a database cluster with support for premium plans and navigate to the Resize tab
- [ ] See that only the 1 and 3 nodes options are displayed

### Verification steps

(How to verify changes)
**Scenario 1: View updated node selection for premium plans in Create and Resize:**
- [ ] Update the serverHandlers.ts to change the mock data by adding the following lines under the [database instance handler](https://github.com/smans-akamai/manager/blob/develop/packages/manager/src/mocks/serverHandlers.ts#L343) right after the database variable is declared.
`database.type = 'premium-4';`
`database.region = 'us-iad';`
`database.platform = 'rdbms-default';`
This will provide consistent data in resize for this scenario

- [ ] Switch back to the branch with these changes
- [ ] In this feature branch with the mock data running. Access the Database Create view and switch the premium plans tab
- [ ] Verify that all nodes options are displayed 
- [ ] Access the details for a database cluster with support for premium plans and navigate to the resize tab
- [ ] Verify that all nodes options are displayed (1, 2, and 3).

**Scenario 2: View scenario when current plan is unavailable:**
- [ ] Update the serverHandlers.ts to change the mock data by adding the following lines under the [database instance handler](https://github.com/smans-akamai/manager/blob/develop/packages/manager/src/mocks/serverHandlers.ts#L343) right after the database variable is declared.
`database.region = 'us-iad';`
`database.type = 'premium-32';`
`database.platform = 'rdbms-default';`
This will provide consistent data in resize for this scenario.

- [ ] Access the details for a database cluster and navigate to the resize tab
- [ ] Verify that the current plan is disabled
- [ ] Verify that the node selections are disabled
- [ ] Verify that all node selections are disabled (1, 2, and 3) and you can't make changes to the node selection to enable the resize button
- [ ] Verify that the node selector buttons are enabled upon selecting a new plan
- [ ] Verify that a notification is displayed at the top that says, `"Warning: The current plan for this cluster is currently unavailable and can't be used to resize the cluster. You can only resize the cluster using other available plans."`


**Scenario 3: View Disabled panel when premium plans are not supported by the region**
- [ ] Update the serverHandlers.ts to change the mock data by adding the following lines under the [database instance handler](https://github.com/smans-akamai/manager/blob/develop/packages/manager/src/mocks/serverHandlers.ts#L343) right after the database variable is declared.
`database.region = 'us-east';`
`database.platform = 'rdbms-default';`
This will provide consistent data in resize for this scenario.

- [ ] Access the details for a database cluster and navigate to the resize tab
- [ ] Verify that all plans in the premium plans panel is disabled with a notice above the plans panel


<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

-->