### PR TITLE
fix: [M3-10439] - Non-Human-Readable Validation Messages for Linode Alert Numeric Input

### DIFF
--- a/packages/validation/.changeset/pr-12635-fixed-1754392274805.md
+++ b/packages/validation/.changeset/pr-12635-fixed-1754392274805.md
@@ -1,0 +1,5 @@
+---
+'@linode/validation': Fixed
+---
+
+Non-human-readable validation messages for Linode Alert numeric input ([#12635](https://github.com/linode/manager/pull/12635))

--- a/packages/validation/src/linodes.schema.ts
+++ b/packages/validation/src/linodes.schema.ts
@@ -418,10 +418,10 @@ const alerts = object({
     .typeError('CPU Usage must be a number')
     .min(0, 'Must be between 0 and 4800')
     .max(4800, 'Must be between 0 and 4800'),
-  network_in: number(),
-  network_out: number(),
-  transfer_quota: number(),
-  io: number(),
+  network_in: number().typeError('Incoming Traffic must be a number'),
+  network_out: number().typeError('Outbound Traffic must be a number'),
+  transfer_quota: number().typeError('Transfer Quota must be a number'),
+  io: number().typeError('Disk I/O Rate must be a number'),
 }).notRequired();
 
 const schedule = object({


### PR DESCRIPTION
## Description 📝

A quick follow-up to https://github.com/linode/manager/pull/12626 and fixes the non-human-readable validation messages for Linode Alert numeric input.

## Changes  🔄
- Added human-readable typeerror validation messages to the Linode Alerts object schema.

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [x] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️
12 August 2025

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-08-05 at 3 22 15 PM](https://github.com/user-attachments/assets/c9865a0b-10e0-4d16-8400-d0438a1019e7) | ![Screenshot 2025-08-05 at 4 33 15 PM](https://github.com/user-attachments/assets/99ef85c6-4e3d-4023-8d2b-f611ce93a932) |

## How to test 🧪

### Verification steps
- Verify that validation messages for Linode Alert numeric input fields are now human-readable when fields are empty or invalid.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules