### PR TITLE
fix: [DI-26621] - Replaced isFetching check with isLoading check

### DIFF
--- a/packages/manager/.changeset/pr-12636-fixed-1754395419312.md
+++ b/packages/manager/.changeset/pr-12636-fixed-1754395419312.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+ACLP: `loading` screen on auto refetch in edit alert page ([#12636](https://github.com/linode/manager/pull/12636))

--- a/packages/manager/src/features/CloudPulse/Alerts/EditAlert/EditAlertLanding.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/EditAlert/EditAlertLanding.test.tsx
@@ -34,7 +34,7 @@ describe('Edit Alert Landing tests', () => {
     queryMocks.useAlertDefinitionQuery.mockReturnValue({
       data: undefined,
       isError: true, // simulate error
-      isFetching: false,
+      isLoading: false,
     });
 
     const { getByText } = renderWithTheme(<EditAlertLanding />, {
@@ -50,7 +50,7 @@ describe('Edit Alert Landing tests', () => {
     queryMocks.useAlertDefinitionQuery.mockReturnValue({
       data: undefined,
       isError: false,
-      isFetching: true, // simulate loading
+      isLoading: true, // simulate loading
     });
 
     const { getByTestId } = renderWithTheme(<EditAlertLanding />, {
@@ -64,7 +64,7 @@ describe('Edit Alert Landing tests', () => {
     queryMocks.useAlertDefinitionQuery.mockReturnValue({
       data: undefined, // simulate empty
       isError: false,
-      isFetching: false,
+      isLoading: false,
     });
 
     const { getByText } = renderWithTheme(<EditAlertLanding />, {

--- a/packages/manager/src/features/CloudPulse/Alerts/EditAlert/EditAlertLanding.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/EditAlert/EditAlertLanding.tsx
@@ -33,11 +33,11 @@ export const EditAlertLanding = () => {
   const {
     data: alertDetails,
     isError,
-    isFetching,
+    isLoading,
   } = useAlertDefinitionQuery(alertId, serviceType);
   const pathname = '/Definition/Edit';
 
-  if (isFetching) {
+  if (isLoading) {
     return (
       <EditAlertLoadingState overrides={overrides} pathname={pathname}>
         <CircleProgress />


### PR DESCRIPTION
## Description 📝

Replaced `isFetching` check with `isLoading` check in EditAlertLanding 

## Changes  🔄

List any change(s) relevant to the reviewer.

1. Updated EditAlertLanding to use isFetching instead of isLoading state

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [x] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

12th August
## Preview 📷

**Include a screenshot `<img src="" />` or video `<video src="" />` of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: For changes requiring multiple steps to validate, prefer a video for clarity.

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/user-attachments/assets/46888404-6281-4d4d-9c8c-f8aca91c7863" /> | <video src="https://github.com/user-attachments/assets/7d245c99-c287-48e7-bec9-1cc0dcc7fdb8"/> |

## How to test 🧪

1. Go to alerts tab
2. Edit any alert
3. Wait on that page for >= 2 min
4. Without this change you'll notice page gets auto refresh every 2 min but now it'll not

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
