### PR TITLE
change: [DI-26319] - Updated logic to render filters based on dashboard id instead of service type

### DIFF
--- a/packages/manager/cypress/e2e/core/cloudpulse/linode-widget-verification.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/linode-widget-verification.spec.ts
@@ -67,6 +67,7 @@ const { dashboardName, id, metrics, region, resource, serviceType } =
 const dashboard = dashboardFactory.build({
   label: dashboardName,
   service_type: serviceType,
+  id,
   widgets: metrics.map(({ name, title, unit, yLabel }) => {
     return widgetFactory.build({
       label: title,

--- a/packages/manager/cypress/e2e/core/cloudpulse/nodebalancer-widget-verification.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/nodebalancer-widget-verification.spec.ts
@@ -78,6 +78,7 @@ const { dashboardName, id, metrics, region, resource, serviceType } =
 const dashboard = dashboardFactory.build({
   label: dashboardName,
   service_type: serviceType,
+  id,
   widgets: metrics.map(({ name, title, unit, yLabel }) => {
     return widgetFactory.build({
       label: title,

--- a/packages/manager/cypress/support/constants/widgets.ts
+++ b/packages/manager/cypress/support/constants/widgets.ts
@@ -55,7 +55,7 @@ export const widgetDetails = {
   },
   linode: {
     dashboardName: 'Linode Dashboard',
-    id: 1,
+    id: 2,
     metrics: [
       {
         expectedAggregation: 'max',
@@ -100,7 +100,7 @@ export const widgetDetails = {
   },
   nodebalancer: {
     dashboardName: 'NodeBalancer Dashboard',
-    id: 1,
+    id: 4,
     metrics: [
       {
         expectedAggregation: 'max',

--- a/packages/manager/cypress/support/constants/widgets.ts
+++ b/packages/manager/cypress/support/constants/widgets.ts
@@ -100,7 +100,7 @@ export const widgetDetails = {
   },
   nodebalancer: {
     dashboardName: 'NodeBalancer Dashboard',
-    id: 4,
+    id: 3,
     metrics: [
       {
         expectedAggregation: 'max',

--- a/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardLanding.tsx
+++ b/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardLanding.tsx
@@ -96,8 +96,8 @@ export const CloudPulseDashboardLanding = () => {
               />
               {dashboard?.service_type && showAppliedFilters && (
                 <CloudPulseAppliedFilterRenderer
+                  dashboardId={dashboard.id}
                   filters={filterData.label}
-                  serviceType={dashboard.service_type}
                 />
               )}
             </Box>

--- a/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardRenderer.tsx
+++ b/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardRenderer.tsx
@@ -19,8 +19,8 @@ export const CloudPulseDashboardRenderer = React.memo(
       'Select a dashboard and apply filters to visualize metrics.';
 
     const getMetricsCall = React.useMemo(
-      () => getMetricsCallCustomFilters(filterValue, dashboard?.service_type),
-      [dashboard?.service_type, filterValue]
+      () => getMetricsCallCustomFilters(filterValue, dashboard?.id),
+      [dashboard?.id, filterValue]
     );
 
     if (!dashboard) {
@@ -31,7 +31,7 @@ export const CloudPulseDashboardRenderer = React.memo(
       );
     }
 
-    if (!FILTER_CONFIG.get(dashboard.service_type)) {
+    if (!FILTER_CONFIG.get(dashboard.id)) {
       return (
         <CloudPulseErrorPlaceholder errorMessage="No filters are configured for the selected dashboard's service type." />
       );

--- a/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardWithFilters.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardWithFilters.test.tsx
@@ -87,7 +87,6 @@ describe('CloudPulseDashboardWithFilters component tests', () => {
 
   it('renders a CloudPulseDashboardWithFilters component successfully without error placeholders', () => {
     queryMocks.useCloudPulseDashboardByIdQuery.mockReturnValue({
-      data: mockDashboard,
       error: false,
       isError: false,
       isLoading: false,
@@ -141,14 +140,14 @@ describe('CloudPulseDashboardWithFilters component tests', () => {
 
   it('renders a CloudPulseDashboardWithFilters component with no filters configured error', () => {
     queryMocks.useCloudPulseDashboardByIdQuery.mockReturnValue({
-      data: { ...mockDashboard, service_type: 'xyz' },
+      data: { ...mockDashboard, id: -1, service_type: 'xyz' },
       error: false,
       isError: false,
       isLoading: false,
     });
 
     renderWithTheme(
-      <CloudPulseDashboardWithFilters dashboardId={1} resource={1} />
+      <CloudPulseDashboardWithFilters dashboardId={-1} resource={1} />
     );
 
     const noFilterText = screen.getByText(

--- a/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardWithFilters.tsx
+++ b/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardWithFilters.tsx
@@ -102,7 +102,7 @@ export const CloudPulseDashboardWithFilters = React.memo(
       return <CircleProgress />;
     }
 
-    if (!FILTER_CONFIG.get(dashboard.service_type)) {
+    if (!FILTER_CONFIG.get(dashboard.id)) {
       return (
         <ErrorState
           errorText={`No Filters Configured for Service Type - ${dashboard.service_type}`}
@@ -175,8 +175,8 @@ export const CloudPulseDashboardWithFilters = React.memo(
             >
               {showAppliedFilters && (
                 <CloudPulseAppliedFilterRenderer
+                  dashboardId={dashboard.id}
                   filters={filterData.label}
-                  serviceType={dashboard.service_type}
                 />
               )}
             </GridLegacy>

--- a/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardWithFilters.tsx
+++ b/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardWithFilters.tsx
@@ -37,7 +37,6 @@ export const CloudPulseDashboardWithFilters = React.memo(
     const { dashboardId, resource } = props;
     const { data: dashboard, isError } =
       useCloudPulseDashboardByIdQuery(dashboardId);
-
     const [filterData, setFilterData] = React.useState<FilterData>({
       id: {},
       label: {},
@@ -102,7 +101,7 @@ export const CloudPulseDashboardWithFilters = React.memo(
       return <CircleProgress />;
     }
 
-    if (!FILTER_CONFIG.get(dashboard.id)) {
+    if (!FILTER_CONFIG.get(dashboardId)) {
       return (
         <ErrorState
           errorText={`No Filters Configured for Service Type - ${dashboard.service_type}`}

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.test.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.test.ts
@@ -30,9 +30,9 @@ const linodeConfig = FILTER_CONFIG.get(2);
 
 const dbaasConfig = FILTER_CONFIG.get(1);
 
-const nodeBalancerConfig = FILTER_CONFIG.get(4);
+const nodeBalancerConfig = FILTER_CONFIG.get(3);
 
-const firewallConfig = FILTER_CONFIG.get(3);
+const firewallConfig = FILTER_CONFIG.get(4);
 
 const dbaasDashboard = dashboardFactory.build({ service_type: 'dbaas', id: 1 });
 

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.test.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.test.ts
@@ -26,15 +26,15 @@ import { CloudPulseSelectTypes } from './models';
 
 const mockDashboard = dashboardFactory.build();
 
-const linodeConfig = FILTER_CONFIG.get('linode');
+const linodeConfig = FILTER_CONFIG.get(2);
 
-const dbaasConfig = FILTER_CONFIG.get('dbaas');
+const dbaasConfig = FILTER_CONFIG.get(1);
 
-const nodeBalancerConfig = FILTER_CONFIG.get('nodebalancer');
+const nodeBalancerConfig = FILTER_CONFIG.get(4);
 
-const firewallConfig = FILTER_CONFIG.get('firewall');
+const firewallConfig = FILTER_CONFIG.get(3);
 
-const dbaasDashboard = dashboardFactory.build({ service_type: 'dbaas' });
+const dbaasDashboard = dashboardFactory.build({ service_type: 'dbaas', id: 1 });
 
 it('test getRegionProperties method', () => {
   const regionConfig = linodeConfig?.filters.find(
@@ -101,7 +101,7 @@ it('test getResourceSelectionProperties method', () => {
     } = getResourcesProperties(
       {
         config: resourceSelectionConfig,
-        dashboard: mockDashboard,
+        dashboard: { ...mockDashboard, id: 2 },
         dependentFilters: { region: 'us-east' },
         isServiceAnalyticsIntegration: true,
       },
@@ -154,7 +154,7 @@ describe('shouldDisableFilterByFilterKey', () => {
     const result = shouldDisableFilterByFilterKey(
       'resource_id',
       { region: 'us-east' },
-      mockDashboard
+      { ...mockDashboard, id: 2 }
     );
     expect(result).toEqual(false);
   });
@@ -275,7 +275,7 @@ it('test checkIfAllMandatoryFiltersAreSelected method', () => {
   expect(resourceSelectionConfig).toBeDefined();
   const now = DateTime.now();
   let result = checkIfAllMandatoryFiltersAreSelected({
-    dashboard: mockDashboard,
+    dashboard: { ...mockDashboard, id: 2 },
     filterValue: { region: 'us-east', resource_id: ['1', '2'] },
     timeDuration: {
       end: now.toISO(),
@@ -423,7 +423,7 @@ it('test getFiltersForMetricsCallFromCustomSelect method', () => {
     {
       resource_id: [1, 2, 3],
     },
-    'linode'
+    2
   );
 
   expect(result).toBeDefined();
@@ -436,7 +436,7 @@ it('test constructAdditionalRequestFilters method', () => {
       {
         resource_id: [1, 2, 3],
       },
-      'linode'
+      2
     )
   );
 
@@ -497,10 +497,7 @@ it('returns false for different arrays', () => {
 });
 
 it('should return the filters based on dashboard', () => {
-  const filters = getFilters(
-    dashboardFactory.build({ service_type: 'dbaas' }),
-    true
-  );
+  const filters = getFilters(dashboardFactory.build({ id: 1 }), true);
 
   expect(filters?.length).toBe(1);
 });

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
@@ -393,7 +393,7 @@ export const shouldDisableFilterByFilterKey = (
   preferences?: AclpConfig
 ): boolean | undefined => {
   if (dashboard?.service_type) {
-    const serviceTypeConfig = FILTER_CONFIG.get(dashboard.service_type);
+    const serviceTypeConfig = FILTER_CONFIG.get(dashboard.id);
     const filters = serviceTypeConfig?.filters ?? [];
 
     const filter = filters.find(
@@ -443,7 +443,7 @@ export const checkIfAllMandatoryFiltersAreSelected = (
   mandatoryFilterObj: CloudPulseMandatoryFilterCheckProps
 ): boolean => {
   const { dashboard, filterValue, timeDuration } = mandatoryFilterObj;
-  const serviceTypeConfig = FILTER_CONFIG?.get(dashboard.service_type);
+  const serviceTypeConfig = FILTER_CONFIG?.get(dashboard.id);
 
   if (!serviceTypeConfig) {
     return false;
@@ -467,17 +467,17 @@ export const checkIfAllMandatoryFiltersAreSelected = (
 
 /**
  * @param selectedFilters The selected filters from the global filters view from custom select component
- * @param serviceType The serviceType assosicated with the dashboard like linode, dbaas etc.,
+ * @param dashboardId The ID of the dashboard
  * @returns Constructs and returns the metrics call filters based on selected filters and service type
  */
 export const getMetricsCallCustomFilters = (
   selectedFilters: {
     [key: string]: FilterValueType;
   },
-  serviceType?: string
+  dashboardId?: number
 ): CloudPulseMetricsAdditionalFilters[] => {
-  const serviceTypeConfig = serviceType
-    ? FILTER_CONFIG.get(serviceType)
+  const serviceTypeConfig = dashboardId
+    ? FILTER_CONFIG.get(dashboardId)
     : undefined;
 
   // If configuration exists, filter and map it to the desired CloudPulseMetricsAdditionalFilters format
@@ -532,7 +532,7 @@ const getDependentFiltersByFilterKey = (
   filterKey: string,
   dashboard: Dashboard
 ): string[] => {
-  const serviceTypeConfig = FILTER_CONFIG.get(dashboard.service_type);
+  const serviceTypeConfig = FILTER_CONFIG.get(dashboard.id);
 
   if (!serviceTypeConfig) {
     return [];
@@ -623,7 +623,7 @@ export const getFilters = (
   dashboard: Dashboard,
   isServiceAnalyticsIntegration: boolean
 ): CloudPulseServiceTypeFilters[] | undefined => {
-  return FILTER_CONFIG.get(dashboard.service_type)?.filters.filter((config) =>
+  return FILTER_CONFIG.get(dashboard.id)?.filters.filter((config) =>
     isServiceAnalyticsIntegration
       ? config.configuration.neededInViews.includes(
           CloudPulseAvailableViews.service

--- a/packages/manager/src/features/CloudPulse/Utils/FilterConfig.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterConfig.ts
@@ -266,10 +266,10 @@ export const FIREWALL_CONFIG: Readonly<CloudPulseServiceTypeFilterMap> = {
 };
 
 export const FILTER_CONFIG: Readonly<
-  Map<string, CloudPulseServiceTypeFilterMap>
+  Map<number, CloudPulseServiceTypeFilterMap>
 > = new Map([
-  ['dbaas', DBAAS_CONFIG],
-  ['firewall', FIREWALL_CONFIG],
-  ['linode', LINODE_CONFIG],
-  ['nodebalancer', NODEBALANCER_CONFIG],
+  [1, DBAAS_CONFIG],
+  [2, LINODE_CONFIG],
+  [3, FIREWALL_CONFIG],
+  [4, NODEBALANCER_CONFIG],
 ]);

--- a/packages/manager/src/features/CloudPulse/Utils/FilterConfig.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterConfig.ts
@@ -270,6 +270,6 @@ export const FILTER_CONFIG: Readonly<
 > = new Map([
   [1, DBAAS_CONFIG],
   [2, LINODE_CONFIG],
-  [3, FIREWALL_CONFIG],
-  [4, NODEBALANCER_CONFIG],
+  [3, NODEBALANCER_CONFIG],
+  [4, FIREWALL_CONFIG],
 ]);

--- a/packages/manager/src/features/CloudPulse/Utils/ReusableDashboardFilterUtils.test.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/ReusableDashboardFilterUtils.test.ts
@@ -34,7 +34,7 @@ it('test checkMandatoryFiltersSelected method for time duration and resource', (
   });
   expect(result).toBe(false);
   result = checkMandatoryFiltersSelected({
-    dashboardObj: mockDashboard,
+    dashboardObj: { ...mockDashboard, id: 2 },
     filterValue: { region: 'us-east' },
     resource: 1,
     timeDuration: {
@@ -100,26 +100,26 @@ it('test constructDimensionFilters method', () => {
 });
 
 it('test checkIfFilterNeededInMetricsCall method', () => {
-  let result = checkIfFilterNeededInMetricsCall('region', 'linode');
+  let result = checkIfFilterNeededInMetricsCall('region', 2);
   expect(result).toEqual(false);
 
-  result = checkIfFilterNeededInMetricsCall('resource_id', 'linode');
+  result = checkIfFilterNeededInMetricsCall('resource_id', 2);
   expect(result).toEqual(false); // not needed as dimension filter
 
-  result = checkIfFilterNeededInMetricsCall('node_type', 'dbaas');
+  result = checkIfFilterNeededInMetricsCall('node_type', 1);
   expect(result).toEqual(true);
 
-  result = checkIfFilterNeededInMetricsCall('engine', 'dbaas');
+  result = checkIfFilterNeededInMetricsCall('engine', 1);
   expect(result).toEqual(false);
 
-  result = checkIfFilterNeededInMetricsCall('node_type', 'xyz'); // xyz service type
+  result = checkIfFilterNeededInMetricsCall('node_type', 2);
   expect(result).toEqual(false);
 });
 
 it('test checkIfFilterBuilderNeeded method', () => {
   let result = checkIfFilterBuilderNeeded({
     ...mockDashboard,
-    service_type: 'linode',
+    id: 2,
   });
   expect(result).toBe(false); // should be false for linode
 

--- a/packages/manager/src/features/CloudPulse/Utils/ReusableDashboardFilterUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/ReusableDashboardFilterUtils.ts
@@ -58,7 +58,7 @@ export const checkMandatoryFiltersSelected = (
   props: ReusableDashboardFilterUtilProps
 ): boolean => {
   const { dashboardObj, filterValue, resource, timeDuration } = props;
-  const serviceTypeConfig = FILTER_CONFIG.get(dashboardObj.service_type);
+  const serviceTypeConfig = FILTER_CONFIG.get(dashboardObj.id);
 
   if (!serviceTypeConfig) {
     return true;
@@ -93,14 +93,14 @@ export const checkMandatoryFiltersSelected = (
 
 /**
  * @param filterKey The current filterKey for which the check needs to made against the config
- * @param serviceType The serviceType of the selected dashboard
+ * @param dashboardId The ID of the dashboard
  * @returns True, if the filter is needed in the metrics call, else false
  */
 export const checkIfFilterNeededInMetricsCall = (
   filterKey: string,
-  serviceType: string
+  dashboardId: number
 ): boolean => {
-  const serviceTypeConfig = FILTER_CONFIG.get(serviceType);
+  const serviceTypeConfig = FILTER_CONFIG.get(dashboardId);
 
   if (!serviceTypeConfig) {
     return false;
@@ -131,9 +131,7 @@ export const constructDimensionFilters = (
 ): CloudPulseMetricsAdditionalFilters[] => {
   const { dashboardObj, filterValue } = props;
   return Object.keys(filterValue)
-    .filter((key) =>
-      checkIfFilterNeededInMetricsCall(key, dashboardObj.service_type)
-    )
+    .filter((key) => checkIfFilterNeededInMetricsCall(key, dashboardObj.id))
     .map((key) => ({
       filterKey: key,
       filterValue: filterValue[key],
@@ -149,7 +147,7 @@ export const checkIfFilterBuilderNeeded = (dashboard?: Dashboard): boolean => {
     return false;
   }
 
-  const serviceTypeConfig = FILTER_CONFIG.get(dashboard.service_type);
+  const serviceTypeConfig = FILTER_CONFIG.get(dashboard.id);
 
   if (!serviceTypeConfig) {
     return false;

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseAppliedFilter.test.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseAppliedFilter.test.tsx
@@ -31,7 +31,7 @@ describe('CloudPulse Applied Filter', () => {
 
   it('should not render the applied filter component', () => {
     const { queryByTestId } = renderWithTheme(
-      <CloudPulseAppliedFilterRenderer filters={{}} serviceType="abc" />
+      <CloudPulseAppliedFilterRenderer dashboardId={-1} filters={{}} />
     );
 
     expect(queryByTestId(testId)).toBe(null);

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseAppliedFilterRenderer.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseAppliedFilterRenderer.tsx
@@ -6,15 +6,15 @@ import { CloudPulseAppliedFilter } from './CloudPulseAppliedFilter';
 import type { CloudPulseAppliedFilterProps } from './CloudPulseAppliedFilter';
 
 interface AppliedFilterRendererProps extends CloudPulseAppliedFilterProps {
-  serviceType: string;
+  dashboardId: number;
 }
 
 export const CloudPulseAppliedFilterRenderer = (
   props: AppliedFilterRendererProps
 ) => {
-  const { filters, serviceType } = props;
+  const { filters, dashboardId } = props;
 
-  const filterConfig = FILTER_CONFIG.get(serviceType);
+  const filterConfig = FILTER_CONFIG.get(dashboardId);
 
   if (!filterConfig) {
     return <></>;

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardFilterBuilder.test.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardFilterBuilder.test.tsx
@@ -26,6 +26,7 @@ describe('CloudPulseDashboardFilterBuilder component tests', () => {
       <CloudPulseDashboardFilterBuilder
         dashboard={dashboardFactory.build({
           service_type: 'dbaas',
+          id: 1,
         })}
         emitFilterChange={vi.fn()}
         handleToggleAppliedFilter={vi.fn()}

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardFilterBuilder.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardFilterBuilder.tsx
@@ -97,7 +97,7 @@ export const CloudPulseDashboardFilterBuilder = React.memo(
     const checkAndUpdateDependentFilters = React.useCallback(
       (filterKey: string, value: FilterValueType) => {
         if (dashboard && dashboard.service_type) {
-          const serviceTypeConfig = FILTER_CONFIG.get(dashboard.service_type);
+          const serviceTypeConfig = FILTER_CONFIG.get(dashboard.id);
           const filters = serviceTypeConfig?.filters ?? [];
 
           for (const filter of filters) {
@@ -390,7 +390,7 @@ export const CloudPulseDashboardFilterBuilder = React.memo(
     if (
       !dashboard ||
       !dashboard.service_type ||
-      !FILTER_CONFIG.has(dashboard.service_type)
+      !FILTER_CONFIG.has(dashboard.id)
     ) {
       return <NullComponent />; // in this we don't want to show the filters at all
     }

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.test.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.test.tsx
@@ -176,7 +176,7 @@ describe('CloudPulseRegionSelect', () => {
     expect(errorMessage).not.toBeNull();
   });
 
-  it('should render a Region Select component with capability specific and launchDarkly based supported regions', async () => {
+  it('should render a Region Select component with capability specific', async () => {
     const user = userEvent.setup();
 
     // resources are present only in us-west, no other regions like us-east here should be listed
@@ -191,13 +191,15 @@ describe('CloudPulseRegionSelect', () => {
     renderWithTheme(
       <CloudPulseRegionSelect
         {...props}
-        selectedDashboard={dashboardFactory.build({ service_type: 'dbaas' })}
-      />,
-      { flags }
+        selectedDashboard={dashboardFactory.build({
+          service_type: 'dbaas',
+          id: 1,
+        })}
+      />
     );
 
     await user.click(screen.getByRole('button', { name: 'Open' }));
-    // example: region id => 'us-west' belongs to service type - 'dbaas', capability -'Managed Databases', and is supported via launchDarkly
+    // example: region id => 'us-west' belongs to service type - 'dbaas', capability -'Managed Databases', and is supported
     const usWestRegion = screen.getByRole('option', {
       name: 'US, Fremont, CA (us-west)',
     });

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.test.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.test.tsx
@@ -12,7 +12,6 @@ import { CloudPulseRegionSelect } from './CloudPulseRegionSelect';
 import type { CloudPulseRegionSelectProps } from './CloudPulseRegionSelect';
 import type { Region } from '@linode/api-v4';
 import type { useRegionsQuery } from '@linode/queries';
-import type { CloudPulseResourceTypeMapFlag, Flags } from 'src/featureFlags';
 
 const props: CloudPulseRegionSelectProps = {
   handleRegionChange: vi.fn(),
@@ -26,17 +25,6 @@ const queryMocks = vi.hoisted(() => ({
   useRegionsQuery: vi.fn().mockReturnValue({}),
   useResourcesQuery: vi.fn().mockReturnValue({}),
 }));
-
-const flags: Partial<Flags> = {
-  aclpResourceTypeMap: [
-    {
-      serviceType: 'dbaas',
-    },
-    {
-      serviceType: 'linode',
-    },
-  ] as CloudPulseResourceTypeMapFlag[],
-};
 
 const allRegions: Region[] = [
   regionFactory.build({

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.tsx
@@ -68,9 +68,10 @@ export const CloudPulseRegionSelect = React.memo(
       flags.gecko2?.la
     );
 
-    const serviceType: string | undefined = selectedDashboard?.service_type;
-    const capability = serviceType
-      ? FILTER_CONFIG.get(serviceType)?.capability
+    const dashboardId = selectedDashboard?.id;
+    const serviceType = selectedDashboard?.service_type;
+    const capability = dashboardId
+      ? FILTER_CONFIG.get(dashboardId)?.capability
       : undefined;
 
     const [selectedRegion, setSelectedRegion] = React.useState<string>();

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -2943,7 +2943,7 @@ export const handlers = [
     if (params.serviceType === 'nodebalancer') {
       response.data.push(
         dashboardFactory.build({
-          id: 4,
+          id: 3,
           label: 'Nodebalancer Dashboard',
           service_type: 'nodebalancer',
         })
@@ -2953,7 +2953,7 @@ export const handlers = [
     if (params.serviceType === 'firewall') {
       response.data.push(
         dashboardFactory.build({
-          id: 3,
+          id: 4,
           label: 'Firewall Dashboard',
           service_type: 'firewall',
         })
@@ -3095,15 +3095,15 @@ export const handlers = [
       label:
         params.id === '1'
           ? 'DBaaS Service I/O Statistics'
-          : params.id === '4'
+          : params.id === '3'
             ? 'NodeBalancer Service I/O Statistics'
             : 'Linode Service I/O Statistics',
       service_type:
         params.id === '1'
           ? 'dbaas'
-          : params.id === '3'
+          : params.id === '4'
             ? 'firewall'
-            : params.id === '4'
+            : params.id === '3'
               ? 'nodebalancer'
               : 'linode', // just update the service type and label and use same widget configs
       type: 'standard',

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -3089,23 +3089,30 @@ export const handlers = [
   }),
 
   http.get('*/monitor/dashboards/:id', ({ params }) => {
+    let serviceType: string;
+    let dashboardLabel: string;
+
+    const id = params.id;
+
+    if (id === '1') {
+      serviceType = 'dbaas';
+      dashboardLabel = 'DBaaS Service I/O Statistics';
+    } else if (id === '3') {
+      serviceType = 'nodebalancer';
+      dashboardLabel = 'NodeBalancer Service I/O Statistics';
+    } else if (id === '4') {
+      serviceType = 'firewall';
+      dashboardLabel = 'Linode Service I/O Statistics';
+    } else {
+      serviceType = 'linode';
+      dashboardLabel = 'Linode Service I/O Statistics';
+    }
+
     const response = {
       created: '2024-04-29T17:09:29',
       id: params.id,
-      label:
-        params.id === '1'
-          ? 'DBaaS Service I/O Statistics'
-          : params.id === '3'
-            ? 'NodeBalancer Service I/O Statistics'
-            : 'Linode Service I/O Statistics',
-      service_type:
-        params.id === '1'
-          ? 'dbaas'
-          : params.id === '4'
-            ? 'firewall'
-            : params.id === '3'
-              ? 'nodebalancer'
-              : 'linode', // just update the service type and label and use same widget configs
+      label: dashboardLabel,
+      service_type: serviceType,
       type: 'standard',
       updated: null,
       widgets: [

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -2943,7 +2943,7 @@ export const handlers = [
     if (params.serviceType === 'nodebalancer') {
       response.data.push(
         dashboardFactory.build({
-          id: 3,
+          id: 4,
           label: 'Nodebalancer Dashboard',
           service_type: 'nodebalancer',
         })
@@ -2953,7 +2953,7 @@ export const handlers = [
     if (params.serviceType === 'firewall') {
       response.data.push(
         dashboardFactory.build({
-          id: 4,
+          id: 3,
           label: 'Firewall Dashboard',
           service_type: 'firewall',
         })
@@ -3095,16 +3095,16 @@ export const handlers = [
       label:
         params.id === '1'
           ? 'DBaaS Service I/O Statistics'
-          : params.id === '3'
+          : params.id === '4'
             ? 'NodeBalancer Service I/O Statistics'
             : 'Linode Service I/O Statistics',
       service_type:
         params.id === '1'
           ? 'dbaas'
           : params.id === '3'
-            ? 'nodebalancer'
+            ? 'firewall'
             : params.id === '4'
-              ? 'firewall'
+              ? 'nodebalancer'
               : 'linode', // just update the service type and label and use same widget configs
       type: 'standard',
       updated: null,


### PR DESCRIPTION
## Description 📝

Dashboard filters now will be rendered based on dashboard id instead of service type

## Changes  🔄

List any change(s) relevant to the reviewer.

1. Updated filter config to map based on id number instead of service type
2. All the consumer components using the config will now use dashboard id instead of service type

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [X] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

26th August

## Preview 📷

> [!NOTE]
> No difference in the UI after this change.

## How to test 🧪

1. Switch to mock and go to metrics tab
2. Select dashboard from dashboard dropdown.
3. You'll notice no difference in the UI compared to this branch and current production branch.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>