### PR TITLE
feat: [UIE-8872] - IAM RBAC - Firewalls / Nodebalancers permissions

### DIFF
--- a/packages/manager/.changeset/pr-12641-changed-1754424739002.md
+++ b/packages/manager/.changeset/pr-12641-changed-1754424739002.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Added IAM permission check to the Firewall Details / Add Node Balancer drawer ([#12641](https://github.com/linode/manager/pull/12641))

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddNodebalancerDrawer.test.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddNodebalancerDrawer.test.tsx
@@ -15,6 +15,15 @@ const props = {
 
 const queryMocks = vi.hoisted(() => ({
   useParams: vi.fn().mockReturnValue({}),
+  userPermissions: vi.fn(() => ({
+    data: {
+      create_firewall_device: true,
+    },
+  })),
+}));
+
+vi.mock('src/features/IAM/hooks/usePermissions', () => ({
+  usePermissions: queryMocks.userPermissions,
 }));
 
 vi.mock('@tanstack/react-router', async () => {
@@ -50,5 +59,21 @@ describe('AddNodeBalancerDrawer', () => {
   it('should contain an Add button', () => {
     const { getByText } = renderWithTheme(<AddNodebalancerDrawer {...props} />);
     expect(getByText('Add')).toBeInTheDocument();
+  });
+
+  it('should disable "Add" button if the user does not have create_firewall_device permission', async () => {
+    queryMocks.userPermissions.mockReturnValue({
+      data: {
+        create_firewall_device: false,
+      },
+    });
+
+    const { getByRole } = renderWithTheme(<AddNodebalancerDrawer {...props} />);
+
+    const addButton = getByRole('button', {
+      name: 'Add',
+    });
+    expect(addButton).toBeInTheDocument();
+    expect(addButton).toBeDisabled();
   });
 });

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddNodebalancerDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddNodebalancerDrawer.tsx
@@ -14,6 +14,7 @@ import * as React from 'react';
 import { Link } from 'src/components/Link';
 import { SupportLink } from 'src/components/SupportLink';
 import { FIREWALL_LIMITS_CONSIDERATIONS_LINK } from 'src/constants';
+import { usePermissions } from 'src/features/IAM/hooks/usePermissions';
 import { NodeBalancerSelect } from 'src/features/NodeBalancers/NodeBalancerSelect';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { sanitizeHTML } from 'src/utilities/sanitizeHTML';
@@ -37,6 +38,12 @@ export const AddNodebalancerDrawer = (props: Props) => {
   const { data, error, isLoading } = useAllFirewallsQuery(open);
 
   const firewall = data?.find((firewall) => firewall.id === Number(id));
+
+  const { data: permissions } = usePermissions(
+    'firewall',
+    ['create_firewall_device'],
+    firewall?.id
+  );
 
   const theme = useTheme();
 
@@ -204,7 +211,9 @@ export const AddNodebalancerDrawer = (props: Props) => {
         />
         <ActionsPanel
           primaryButtonProps={{
-            disabled: selectedNodebalancers.length === 0,
+            disabled:
+              selectedNodebalancers.length === 0 ||
+              !permissions.create_firewall_device,
             label: 'Add',
             loading: addDeviceIsLoading,
             onClick: handleSubmit,


### PR DESCRIPTION
## Description 📝

This PR adds the new IAM permissions feature to the Firewall details / Node Balancers UI.  The only needed update was to the Add drawer.

## Changes  🔄

- The Add NodeBalancer to Firewall drawer now abides by the IAM permissions - users without the proper permissions should not be able to add Node Balancers to a firewall.

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [x] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

Aug 13

## Preview 📷

| Before  | After   |
| ------- | ------- |
| 📷 | ![Screenshot 2025-08-05 at 4 04 39 PM](https://github.com/user-attachments/assets/c2078dd7-2f1e-4aac-b37a-56c884e1eabd) |

## How to test 🧪

### Prerequisites

- In an IAM account, have users with both `create_firewall_device` values

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] Test that a user with `create_firewall_device` capability can add Node Balancers via this drawer
- [ ] Test that a user without `create_firewall_device` capability cannot add Node Balancers via this drawer

### Verification steps

(How to verify changes)

- [ ] Using an IAM account, and user with `create_firewall_device`, verify you can add Node Balancers to a firewall
- [ ] Using an IAM account, and user without `create_firewall_device`, verify you can NOT add Node Balancers

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>