### PR TITLE
fix: [DI-26688] - Fixed incorrect unit display in metric widget

### DIFF
--- a/packages/manager/.changeset/pr-12647-fixed-1754492562580.md
+++ b/packages/manager/.changeset/pr-12647-fixed-1754492562580.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+ACLP: not display `/s` with *PS units on initial widget loading ([#12647](https://github.com/linode/manager/pull/12647))

--- a/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.tsx
+++ b/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.tsx
@@ -307,7 +307,10 @@ export const CloudPulseWidget = (props: CloudPulseWidgetProperties) => {
             <Typography flex={{ sm: 2, xs: 0 }} marginLeft={1} variant="h2">
               {convertStringToCamelCasesWithSpaces(widget.label)} (
               {scaledWidgetUnit.current}
-              {unit.endsWith('ps') ? '/s' : ''})
+              {unit.endsWith('ps') && !scaledWidgetUnit.current.endsWith('ps')
+                ? '/s'
+                : ''}
+              )
             </Typography>
             <Stack
               direction={{ sm: 'row' }}


### PR DESCRIPTION
## Description 📝

Fixed incorrect unit display for per second units in metric widget

## Changes  🔄

List any change(s) relevant to the reviewer.

1. Added logic in CloudPulseWidget.tsx to not show /s if unit is bps but there is no scaled unit

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

12th August

## Preview 📷

**Include a screenshot `<img src="" />` or video `<video src="" />` of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: For changes requiring multiple steps to validate, prefer a video for clarity.

| Before  | After   |
| ------- | ------- |
|![Screenshot 2025-08-06 at 6 35 31 PM](https://github.com/user-attachments/assets/bfb1a49f-a792-42a5-ab2d-ce472e301866)|![Screenshot 2025-08-06 at 6 37 41 PM](https://github.com/user-attachments/assets/f5ea21d8-e807-4bf5-832e-4ece3c9182e0)|
## How to test 🧪
> [!NOTE]
> In serverHandlers.ts file, at line 3259, set unit to 'BPS

1. Switch as mock user
2. Go to metrics tab
3. Select all the filters 
4. On initial loading of widgets before data loads, you'll notice that with current product code, you'll see widget unit as `BPS/s` which is fixed in current code to display `BPS`

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>