### PR TITLE
M3-10409 Remove clean up from longview.spec.ts

### DIFF
--- a/packages/manager/.changeset/pr-12651-tests-1754580443465.md
+++ b/packages/manager/.changeset/pr-12651-tests-1754580443465.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Remove clean up from longview.spec.ts ([#12651](https://github.com/linode/manager/pull/12651))

--- a/packages/manager/cypress/e2e/core/longview/longview.spec.ts
+++ b/packages/manager/cypress/e2e/core/longview/longview.spec.ts
@@ -14,7 +14,6 @@ import {
   mockUpdateLongviewClient,
 } from 'support/intercepts/longview';
 import { ui } from 'support/ui';
-import { cleanUp } from 'support/util/cleanup';
 import { randomLabel } from 'support/util/random';
 
 import {
@@ -132,10 +131,6 @@ const longviewGetLatestValueInstalled = longviewResponseFactory.build({
 
 authenticate();
 describe('longview', () => {
-  before(() => {
-    cleanUp(['linodes', 'longview-clients']);
-  });
-
   /*
    * - Tests Longview installation end-to-end using mock API data.
    * - Confirms that Cloud Manager UI updates to reflect Longview installation and data.


### PR DESCRIPTION
## Description 📝

Remove clean up from longview tests.

## Changes  🔄

List any change(s) relevant to the reviewer.
- Remove `cleanUp()` function within the `before` block.

## How to test 🧪
```
pnpm cy:run -s "cypress/e2e/core/longview/longview.spec.ts"
```