### PR TITLE
Release v1.148.0 - release → staging

### DIFF
--- a/packages/api-v4/.changeset/pr-12512-removed-1752621192730.md
+++ b/packages/api-v4/.changeset/pr-12512-removed-1752621192730.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Removed
----
-
-Remove unnecessary in-progress event.status type during earlier development ([#12512](https://github.com/linode/manager/pull/12512))

--- a/packages/api-v4/.changeset/pr-12551-upcoming-features-1753739808377.md
+++ b/packages/api-v4/.changeset/pr-12551-upcoming-features-1753739808377.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Upcoming Features
----
-
-Add optional vpc_id and subnet_id fields to CreateKubeClusterPayload for LKE-E ([#12551](https://github.com/linode/manager/pull/12551))

--- a/packages/api-v4/.changeset/pr-12557-upcoming-features-1753340103984.md
+++ b/packages/api-v4/.changeset/pr-12557-upcoming-features-1753340103984.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Upcoming Features
----
-
-Add validation to Create Stream POST request ([#12557](https://github.com/linode/manager/pull/12557))

--- a/packages/api-v4/.changeset/pr-12559-upcoming-features-1753279380100.md
+++ b/packages/api-v4/.changeset/pr-12559-upcoming-features-1753279380100.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Upcoming Features
----
-
-GET API endpoints for Destinations ([#12559](https://github.com/linode/manager/pull/12559))

--- a/packages/api-v4/.changeset/pr-12572-upcoming-features-1753360891663.md
+++ b/packages/api-v4/.changeset/pr-12572-upcoming-features-1753360891663.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Upcoming Features
----
-
-Remove the docs and costs from streams and destinations landing pages and stream create form ([#12572](https://github.com/linode/manager/pull/12572))

--- a/packages/api-v4/.changeset/pr-12573-added-1753364724800.md
+++ b/packages/api-v4/.changeset/pr-12573-added-1753364724800.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Added
----
-
-ACLP: `string` type for `capabilityServiceTypeMapping` constant ([#12573](https://github.com/linode/manager/pull/12573))

--- a/packages/api-v4/.changeset/pr-12594-upcoming-features-1753822524437.md
+++ b/packages/api-v4/.changeset/pr-12594-upcoming-features-1753822524437.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Upcoming Features
----
-
-Add type and update cluster payload and interface to support optional stack_type field for LKE-E ([#12594](https://github.com/linode/manager/pull/12594))

--- a/packages/api-v4/.changeset/pr-12596-removed-1753881626360.md
+++ b/packages/api-v4/.changeset/pr-12596-removed-1753881626360.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Removed
----
-
-`getNodePoolBeta` in favor of `getNodePool` ([#12596](https://github.com/linode/manager/pull/12596))

--- a/packages/api-v4/.changeset/pr-12596-removed-1753881663728.md
+++ b/packages/api-v4/.changeset/pr-12596-removed-1753881663728.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Removed
----
-
-`createNodePoolBeta` in favor of `createNodePool` ([#12596](https://github.com/linode/manager/pull/12596))

--- a/packages/api-v4/.changeset/pr-12596-removed-1753881690938.md
+++ b/packages/api-v4/.changeset/pr-12596-removed-1753881690938.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Removed
----
-
-`updateNodePoolBeta` in favor of `updateNodePool` ([#12596](https://github.com/linode/manager/pull/12596))

--- a/packages/api-v4/.changeset/pr-12596-removed-1753881761737.md
+++ b/packages/api-v4/.changeset/pr-12596-removed-1753881761737.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Removed
----
-
-`CreateNodePoolDataBeta` in favor of `CreateNodePoolData` ([#12596](https://github.com/linode/manager/pull/12596))

--- a/packages/api-v4/.changeset/pr-12596-removed-1753881785816.md
+++ b/packages/api-v4/.changeset/pr-12596-removed-1753881785816.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Removed
----
-
-`UpdateNodePoolDataBeta` in favor of `UpdateNodePoolData` ([#12596](https://github.com/linode/manager/pull/12596))

--- a/packages/api-v4/.changeset/pr-12600-changed-1754316679946.md
+++ b/packages/api-v4/.changeset/pr-12600-changed-1754316679946.md
@@ -1,5 +1,0 @@
----
-"@linode/api-v4": Changed
----
-
-Update `LinodeIPsResponseIPV6` to include `vpc` array ([#12600](https://github.com/linode/manager/pull/12600))

--- a/packages/api-v4/CHANGELOG.md
+++ b/packages/api-v4/CHANGELOG.md
@@ -1,3 +1,31 @@
+## [2025-08-12] - v0.146.0
+
+
+### Added:
+
+- ACLP: `string` type for `capabilityServiceTypeMapping` constant ([#12573](https://github.com/linode/manager/pull/12573))
+
+### Changed:
+
+- Update `LinodeIPsResponseIPV6` to include `vpc` array ([#12600](https://github.com/linode/manager/pull/12600))
+
+### Removed:
+
+- Remove unnecessary in-progress event.status type during earlier development ([#12512](https://github.com/linode/manager/pull/12512))
+- `getNodePoolBeta` in favor of `getNodePool` ([#12596](https://github.com/linode/manager/pull/12596))
+- `createNodePoolBeta` in favor of `createNodePool` ([#12596](https://github.com/linode/manager/pull/12596))
+- `updateNodePoolBeta` in favor of `updateNodePool` ([#12596](https://github.com/linode/manager/pull/12596))
+- `CreateNodePoolDataBeta` in favor of `CreateNodePoolData` ([#12596](https://github.com/linode/manager/pull/12596))
+- `UpdateNodePoolDataBeta` in favor of `UpdateNodePoolData` ([#12596](https://github.com/linode/manager/pull/12596))
+
+### Upcoming Features:
+
+- Add optional vpc_id and subnet_id fields to CreateKubeClusterPayload for LKE-E ([#12551](https://github.com/linode/manager/pull/12551))
+- Add validation to Create Stream POST request ([#12557](https://github.com/linode/manager/pull/12557))
+- GET API endpoints for Destinations ([#12559](https://github.com/linode/manager/pull/12559))
+- Remove the docs and costs from streams and destinations landing pages and stream create form ([#12572](https://github.com/linode/manager/pull/12572))
+- Add type and update cluster payload and interface to support optional stack_type field for LKE-E ([#12594](https://github.com/linode/manager/pull/12594))
+
 ## [2025-07-29] - v0.145.0
 
 

--- a/packages/api-v4/package.json
+++ b/packages/api-v4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linode/api-v4",
-  "version": "0.145.0",
+  "version": "0.146.0",
   "homepage": "https://github.com/linode/manager/tree/develop/packages/api-v4",
   "bugs": {
     "url": "https://github.com/linode/manager/issues"

--- a/packages/manager/.changeset/pr-12305-upcoming-features-1753137015399.md
+++ b/packages/manager/.changeset/pr-12305-upcoming-features-1753137015399.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Add IPv6 columns to VPC Subnet and Subnet Linodes tables ([#12305](https://github.com/linode/manager/pull/12305))

--- a/packages/manager/.changeset/pr-12512-upcoming-features-1752621282205.md
+++ b/packages/manager/.changeset/pr-12512-upcoming-features-1752621282205.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Show GPU warning notice conditionally based on policy type - display for "migrate" policy but hide for "power-off-on" policy ([#12512](https://github.com/linode/manager/pull/12512))

--- a/packages/manager/.changeset/pr-12540-tests-1752873012740.md
+++ b/packages/manager/.changeset/pr-12540-tests-1752873012740.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Tests for ACLP alerts in Linode create flow ([#12540](https://github.com/linode/manager/pull/12540))

--- a/packages/manager/.changeset/pr-12551-upcoming-features-1753739741936.md
+++ b/packages/manager/.changeset/pr-12551-upcoming-features-1753739741936.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Add BYO VPC support to LKE-E create cluster flow ([#12551](https://github.com/linode/manager/pull/12551))

--- a/packages/manager/.changeset/pr-12553-added-1753197976652.md
+++ b/packages/manager/.changeset/pr-12553-added-1753197976652.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Added
----
-
-Improved search to the Volumes landing page ([#12553](https://github.com/linode/manager/pull/12553))

--- a/packages/manager/.changeset/pr-12554-tech-stories-1753272667661.md
+++ b/packages/manager/.changeset/pr-12554-tech-stories-1753272667661.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-Improve Create Linode code splitting & routing ([#12554](https://github.com/linode/manager/pull/12554))

--- a/packages/manager/.changeset/pr-12555-changed-1753281074340.md
+++ b/packages/manager/.changeset/pr-12555-changed-1753281074340.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Changed
----
-
-Use Search field on Images landing page rather than a classic Text field ([#12555](https://github.com/linode/manager/pull/12555))

--- a/packages/manager/.changeset/pr-12557-upcoming-features-1753340182313.md
+++ b/packages/manager/.changeset/pr-12557-upcoming-features-1753340182313.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Datastream form validation on create stream and destination ([#12557](https://github.com/linode/manager/pull/12557))

--- a/packages/manager/.changeset/pr-12558-upcoming-features-1753278473938.md
+++ b/packages/manager/.changeset/pr-12558-upcoming-features-1753278473938.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-ACLP: add `linode id to label` translation logic for legend rows, add `entities` to `CloudPulseResouces` interface ([#12558](https://github.com/linode/manager/pull/12558))

--- a/packages/manager/.changeset/pr-12559-upcoming-features-1753279327877.md
+++ b/packages/manager/.changeset/pr-12559-upcoming-features-1753279327877.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-DataStream: add destination's details for selected destination ([#12559](https://github.com/linode/manager/pull/12559))

--- a/packages/manager/.changeset/pr-12560-upcoming-features-1753279716756.md
+++ b/packages/manager/.changeset/pr-12560-upcoming-features-1753279716756.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Modified the query parameter to allow varying use cases. Return any errors from the API along with isLoading, isError values. ([#12560](https://github.com/linode/manager/pull/12560))

--- a/packages/manager/.changeset/pr-12561-upcoming-features-1753283335594.md
+++ b/packages/manager/.changeset/pr-12561-upcoming-features-1753283335594.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-IAM RBAC: add a permission check in Profile and Account/Billing ([#12561](https://github.com/linode/manager/pull/12561))

--- a/packages/manager/.changeset/pr-12563-upcoming-features-1753372466262.md
+++ b/packages/manager/.changeset/pr-12563-upcoming-features-1753372466262.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Add subnet IPv6 to VPC create page ([#12563](https://github.com/linode/manager/pull/12563))

--- a/packages/manager/.changeset/pr-12564-tests-1753288873223.md
+++ b/packages/manager/.changeset/pr-12564-tests-1753288873223.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Add Cypress tests for QEMU Upgrade Notice  ([#12564](https://github.com/linode/manager/pull/12564))

--- a/packages/manager/.changeset/pr-12568-tests-1753428442028.md
+++ b/packages/manager/.changeset/pr-12568-tests-1753428442028.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Add Cypress verification tests for CloudPulse NodeBalancer widget ([#12568](https://github.com/linode/manager/pull/12568))

--- a/packages/manager/.changeset/pr-12569-changed-1753705894806.md
+++ b/packages/manager/.changeset/pr-12569-changed-1753705894806.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Changed
----
-
-Akamai Design System: Link Component ([#12569](https://github.com/linode/manager/pull/12569))

--- a/packages/manager/.changeset/pr-12571-fixed-1753356045864.md
+++ b/packages/manager/.changeset/pr-12571-fixed-1753356045864.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Alignment of Closeicon in Textfields ([#12571](https://github.com/linode/manager/pull/12571))

--- a/packages/manager/.changeset/pr-12571-fixed-1753697731353.md
+++ b/packages/manager/.changeset/pr-12571-fixed-1753697731353.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Disabled Region select in NB create flow for restricted user ([#12571](https://github.com/linode/manager/pull/12571))

--- a/packages/manager/.changeset/pr-12573-added-1753364742642.md
+++ b/packages/manager/.changeset/pr-12573-added-1753364742642.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Added
----
-
-ACLP: `filterRegionByServiceType` method to alerts/utils/utils.ts, remove `supportedRegionIds` property from `CloudPulseResourceTypeMapFlag` feature flag  ([#12573](https://github.com/linode/manager/pull/12573))

--- a/packages/manager/.changeset/pr-12574-tech-stories-1753455956281.md
+++ b/packages/manager/.changeset/pr-12574-tech-stories-1753455956281.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-Add MSW Crud support for Linode Config profiles and prevent deletion of vpcs/subnets with resources ([#12574](https://github.com/linode/manager/pull/12574))

--- a/packages/manager/.changeset/pr-12576-tests-1753390501259.md
+++ b/packages/manager/.changeset/pr-12576-tests-1753390501259.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Improve stability of Linode create password field tests ([#12576](https://github.com/linode/manager/pull/12576))

--- a/packages/manager/.changeset/pr-12578-fixed-1753437741673.md
+++ b/packages/manager/.changeset/pr-12578-fixed-1753437741673.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Longview UI alignment issue ([#12578](https://github.com/linode/manager/pull/12578))

--- a/packages/manager/.changeset/pr-12578-upcoming-features-1753437780675.md
+++ b/packages/manager/.changeset/pr-12578-upcoming-features-1753437780675.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Add/update inline docs for ACLP Alerts logic ([#12578](https://github.com/linode/manager/pull/12578))

--- a/packages/manager/.changeset/pr-12579-fixed-1753443210506.md
+++ b/packages/manager/.changeset/pr-12579-fixed-1753443210506.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Hover styling of disabled state for zebra striped table rows ([#12579](https://github.com/linode/manager/pull/12579))

--- a/packages/manager/.changeset/pr-12581-fixed-1753687703762.md
+++ b/packages/manager/.changeset/pr-12581-fixed-1753687703762.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Standardize `<FormHelperText />` error handling across components ([#12581](https://github.com/linode/manager/pull/12581))

--- a/packages/manager/.changeset/pr-12582-upcoming-features-1753455419647.md
+++ b/packages/manager/.changeset/pr-12582-upcoming-features-1753455419647.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-ACLP: add checkbox functionality in `AlertRegions`.  ([#12582](https://github.com/linode/manager/pull/12582))

--- a/packages/manager/.changeset/pr-12583-fixed-1753471654074.md
+++ b/packages/manager/.changeset/pr-12583-fixed-1753471654074.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-UI and accessibility of disabled Autocomplete options ([#12583](https://github.com/linode/manager/pull/12583))

--- a/packages/manager/.changeset/pr-12584-fixed-1753473403068.md
+++ b/packages/manager/.changeset/pr-12584-fixed-1753473403068.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Geographical Area state in Distributed Region select in Linode Create flow ([#12584](https://github.com/linode/manager/pull/12584))

--- a/packages/manager/.changeset/pr-12586-fixed-1753562679377.md
+++ b/packages/manager/.changeset/pr-12586-fixed-1753562679377.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-UIE-8955] - IAM RBAC: Fix removing entity can cause empty page ([#12586](https://github.com/linode/manager/pull/12586))

--- a/packages/manager/.changeset/pr-12591-upcoming-features-1753731039330.md
+++ b/packages/manager/.changeset/pr-12591-upcoming-features-1753731039330.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Add Linode Interface support for Linode CLI codesnippets tool ([#12591](https://github.com/linode/manager/pull/12591))

--- a/packages/manager/.changeset/pr-12592-fixed-1753738232161.md
+++ b/packages/manager/.changeset/pr-12592-fixed-1753738232161.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Left alignment of Encryption checkbox in Linode Create, Linode Rebuild, and Volume Create forms ([#12592](https://github.com/linode/manager/pull/12592))

--- a/packages/manager/.changeset/pr-12593-fixed-1753820672649.md
+++ b/packages/manager/.changeset/pr-12593-fixed-1753820672649.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Text overflow in SupportTicketDialog and QuotasIncreaseForm preview sections ([#12593](https://github.com/linode/manager/pull/12593))

--- a/packages/manager/.changeset/pr-12594-upcoming-features-1753822274393.md
+++ b/packages/manager/.changeset/pr-12594-upcoming-features-1753822274393.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Add IP Version (IPv4/IPv6) support to LKE-E cluster create flow ([#12594](https://github.com/linode/manager/pull/12594))

--- a/packages/manager/.changeset/pr-12596-added-1753881869923.md
+++ b/packages/manager/.changeset/pr-12596-added-1753881869923.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Added
----
-
-Node Pool versions to Kubernetes Cluster detail page for LKE-E clusters ([#12596](https://github.com/linode/manager/pull/12596))

--- a/packages/manager/.changeset/pr-12597-tests-1753819485057.md
+++ b/packages/manager/.changeset/pr-12597-tests-1753819485057.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Mock LKE versions in `lke-create.spec.ts` to fix test failure due to LKE version 1.31 being deprecated ([#12597](https://github.com/linode/manager/pull/12597))

--- a/packages/manager/.changeset/pr-12600-upcoming-features-1754316525220.md
+++ b/packages/manager/.changeset/pr-12600-upcoming-features-1754316525220.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Add VPC IPv4 and IPv6 columns to node pools table on LKE-E cluster details page ([#12600](https://github.com/linode/manager/pull/12600))

--- a/packages/manager/.changeset/pr-12601-changed-1753862177012.md
+++ b/packages/manager/.changeset/pr-12601-changed-1753862177012.md
@@ -1,5 +1,0 @@
----
-'@linode/manager': Changed
----
-
-Replace the existing Premium tab description with generic description copy that works for both legacy Premium and MTC plans ([#12601](https://github.com/linode/manager/pull/12601))

--- a/packages/manager/.changeset/pr-12604-fixed-1753883735502.md
+++ b/packages/manager/.changeset/pr-12604-fixed-1753883735502.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Add borders to countries with white backgrounds ([#12604](https://github.com/linode/manager/pull/12604))

--- a/packages/manager/.changeset/pr-12605-fixed-1753890447726.md
+++ b/packages/manager/.changeset/pr-12605-fixed-1753890447726.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Use human readable date/time for Linode maintenance window ([#12605](https://github.com/linode/manager/pull/12605))

--- a/packages/manager/.changeset/pr-12606-fixed-1753902396081.md
+++ b/packages/manager/.changeset/pr-12606-fixed-1753902396081.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Negative values in volume size field ([#12606](https://github.com/linode/manager/pull/12606))

--- a/packages/manager/.changeset/pr-12608-tech-stories-1753905809598.md
+++ b/packages/manager/.changeset/pr-12608-tech-stories-1753905809598.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-Revise PR template to recommend video previews ([#12608](https://github.com/linode/manager/pull/12608))

--- a/packages/manager/.changeset/pr-12609-tech-stories-1753907236327.md
+++ b/packages/manager/.changeset/pr-12609-tech-stories-1753907236327.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tech Stories
----
-
-Update PR template to hide a section; add a Scope subsection for confirmation of customer-facing changes ([#12609](https://github.com/linode/manager/pull/12609))

--- a/packages/manager/.changeset/pr-12610-upcoming-features-1753907488370.md
+++ b/packages/manager/.changeset/pr-12610-upcoming-features-1753907488370.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Add VPC IPv6 address in Linode Detail > Summary panel ([#12610](https://github.com/linode/manager/pull/12610))

--- a/packages/manager/.changeset/pr-12616-fixed-1753979832000.md
+++ b/packages/manager/.changeset/pr-12616-fixed-1753979832000.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Creation of nodepool with a `--number` of nodes for LKE clusters ([#12616](https://github.com/linode/manager/pull/12616))

--- a/packages/manager/.changeset/pr-12617-upcoming-features-1754321494449.md
+++ b/packages/manager/.changeset/pr-12617-upcoming-features-1754321494449.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Update the usePermissions hook to return consistent with the other queries ([#12617](https://github.com/linode/manager/pull/12617))

--- a/packages/manager/.changeset/pr-12618-upcoming-features-1754482223158.md
+++ b/packages/manager/.changeset/pr-12618-upcoming-features-1754482223158.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Integrate RBAC permission checks in edit billing info ([#12618](https://github.com/linode/manager/pull/12618))

--- a/packages/manager/.changeset/pr-12620-tests-1754059094056.md
+++ b/packages/manager/.changeset/pr-12620-tests-1754059094056.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Fix Cypress test result notifications missing test names ([#12620](https://github.com/linode/manager/pull/12620))

--- a/packages/manager/.changeset/pr-12624-upcoming-features-1754056061785.md
+++ b/packages/manager/.changeset/pr-12624-upcoming-features-1754056061785.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-ACLP-Alerting: Changed the `aclpAlerting` to include alert and metric limits and other relevant changes  ([#12624](https://github.com/linode/manager/pull/12624))

--- a/packages/manager/.changeset/pr-12626-fixed-1754294099293.md
+++ b/packages/manager/.changeset/pr-12626-fixed-1754294099293.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
- Premature validation of Linode Alert numeric input ([#12626](https://github.com/linode/manager/pull/12626))

--- a/packages/manager/.changeset/pr-12629-upcoming-features-1754315228379.md
+++ b/packages/manager/.changeset/pr-12629-upcoming-features-1754315228379.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-ACLP-Alerting: Custom config_id validation, dynamic schema resolver, helperText map, TextField logic, and mock API for nodebalancer metrics added ([#12629](https://github.com/linode/manager/pull/12629))

--- a/packages/manager/.changeset/pr-12632-upcoming-features-1754340020342.md
+++ b/packages/manager/.changeset/pr-12632-upcoming-features-1754340020342.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Upcoming Features
----
-
-Update VM Host Maintenance GPU Notice Text ([#12632](https://github.com/linode/manager/pull/12632))

--- a/packages/manager/.changeset/pr-12634-added-1754346674408.md
+++ b/packages/manager/.changeset/pr-12634-added-1754346674408.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Added
----
-
-PlansPanel additionalBanners property for rendering additional banners and disabled property for DatabaseNodeSelector ([#12634](https://github.com/linode/manager/pull/12634))

--- a/packages/manager/.changeset/pr-12634-fixed-1754346423085.md
+++ b/packages/manager/.changeset/pr-12634-fixed-1754346423085.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-DBaaS Create and Resize node selector options for premium plans and region disabling behavior and handling not being applied in Resize ([#12634](https://github.com/linode/manager/pull/12634))

--- a/packages/manager/.changeset/pr-12636-fixed-1754395419312.md
+++ b/packages/manager/.changeset/pr-12636-fixed-1754395419312.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-ACLP: `loading` screen on auto refetch in edit alert page ([#12636](https://github.com/linode/manager/pull/12636))

--- a/packages/manager/.changeset/pr-12637-changed-1754397265777.md
+++ b/packages/manager/.changeset/pr-12637-changed-1754397265777.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Changed
----
-
-ACLP: dashboard filters will be rendered based on `dashboardId` instead of `serviceType` ([#12637](https://github.com/linode/manager/pull/12637))

--- a/packages/manager/.changeset/pr-12639-tests-1754412275063.md
+++ b/packages/manager/.changeset/pr-12639-tests-1754412275063.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Tests
----
-
-Fix the time format of the start time in QEMU Update Notice ([#12639](https://github.com/linode/manager/pull/12639))

--- a/packages/manager/.changeset/pr-12641-changed-1754424739002.md
+++ b/packages/manager/.changeset/pr-12641-changed-1754424739002.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Changed
----
-
-Added IAM permission check to the Firewall Details / Add Node Balancer drawer ([#12641](https://github.com/linode/manager/pull/12641))

--- a/packages/manager/.changeset/pr-12642-added-1754493605017.md
+++ b/packages/manager/.changeset/pr-12642-added-1754493605017.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Added
----
-
-ArangoDB, Memgraph, and Neo4j apps to Marketplace ([#12642](https://github.com/linode/manager/pull/12642))

--- a/packages/manager/.changeset/pr-12647-fixed-1754492562580.md
+++ b/packages/manager/.changeset/pr-12647-fixed-1754492562580.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-ACLP: not display `/s` with *PS units on initial widget loading ([#12647](https://github.com/linode/manager/pull/12647))

--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -4,6 +4,85 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2025-08-12] - v1.148.0
+
+### Added:
+
+- Improved search to the Volumes landing page ([#12553](https://github.com/linode/manager/pull/12553))
+- ACLP: `filterRegionByServiceType` method to alerts/utils/utils.ts, remove `supportedRegionIds` property from `CloudPulseResourceTypeMapFlag` feature flag  ([#12573](https://github.com/linode/manager/pull/12573))
+- Node Pool versions to Kubernetes Cluster detail page for LKE-E clusters ([#12596](https://github.com/linode/manager/pull/12596))
+- PlansPanel additionalBanners property for rendering additional banners and disabled property for DatabaseNodeSelector ([#12634](https://github.com/linode/manager/pull/12634))
+- ArangoDB, Memgraph, and Neo4j apps to Marketplace ([#12642](https://github.com/linode/manager/pull/12642))
+
+### Changed:
+
+- Use Search field on Images landing page rather than a classic Text field ([#12555](https://github.com/linode/manager/pull/12555))
+- Akamai Design System: Link Component ([#12569](https://github.com/linode/manager/pull/12569))
+- ACLP: dashboard filters will be rendered based on `dashboardId` instead of `serviceType` ([#12637](https://github.com/linode/manager/pull/12637))
+- Added IAM permission check to the Firewall Details / Add Node Balancer drawer ([#12641](https://github.com/linode/manager/pull/12641))
+- Replace the existing Premium tab description with generic description copy that works for both legacy Premium and MTC plans ([#12601](https://github.com/linode/manager/pull/12601))
+
+### Fixed:
+
+- Alignment of Closeicon in Textfields ([#12571](https://github.com/linode/manager/pull/12571))
+- Disabled Region select in NB create flow for restricted user ([#12571](https://github.com/linode/manager/pull/12571))
+- Longview UI alignment issue ([#12578](https://github.com/linode/manager/pull/12578))
+- Hover styling of disabled state for zebra striped table rows ([#12579](https://github.com/linode/manager/pull/12579))
+- Standardize `<FormHelperText />` error handling across components ([#12581](https://github.com/linode/manager/pull/12581))
+- UI and accessibility of disabled Autocomplete options ([#12583](https://github.com/linode/manager/pull/12583))
+- Geographical Area state in Distributed Region select in Linode Create flow ([#12584](https://github.com/linode/manager/pull/12584))
+- UIE-8955] - IAM RBAC: Fix removing entity can cause empty page ([#12586](https://github.com/linode/manager/pull/12586))
+- Left alignment of Encryption checkbox in Linode Create, Linode Rebuild, and Volume Create forms ([#12592](https://github.com/linode/manager/pull/12592))
+- Text overflow in SupportTicketDialog and QuotasIncreaseForm preview sections ([#12593](https://github.com/linode/manager/pull/12593))
+- Add borders to countries with white backgrounds ([#12604](https://github.com/linode/manager/pull/12604))
+- Use human readable date/time for Linode maintenance window ([#12605](https://github.com/linode/manager/pull/12605))
+- Negative values in volume size field ([#12606](https://github.com/linode/manager/pull/12606))
+- Creation of nodepool with a `--number` of nodes for LKE clusters ([#12616](https://github.com/linode/manager/pull/12616))
+- Premature validation of Linode Alert numeric input ([#12626](https://github.com/linode/manager/pull/12626))
+- DBaaS Create and Resize node selector options for premium plans and region disabling behavior and handling not being applied in Resize ([#12634](https://github.com/linode/manager/pull/12634))
+- ACLP: `loading` screen on auto refetch in edit alert page ([#12636](https://github.com/linode/manager/pull/12636))
+- ACLP: not display `/s` with *PS units on initial widget loading ([#12647](https://github.com/linode/manager/pull/12647))
+
+### Tech Stories:
+
+- Improve Create Linode code splitting & routing ([#12554](https://github.com/linode/manager/pull/12554))
+- Add MSW Crud support for Linode Config profiles and prevent deletion of vpcs/subnets with resources ([#12574](https://github.com/linode/manager/pull/12574))
+- Revise PR template to recommend video previews ([#12608](https://github.com/linode/manager/pull/12608))
+- Update PR template to hide a section; add a Scope subsection for confirmation of customer-facing changes ([#12609](https://github.com/linode/manager/pull/12609))
+
+### Tests:
+
+- Tests for ACLP alerts in Linode create flow ([#12540](https://github.com/linode/manager/pull/12540))
+- Add Cypress tests for QEMU Upgrade Notice  ([#12564](https://github.com/linode/manager/pull/12564))
+- Add Cypress verification tests for CloudPulse NodeBalancer widget ([#12568](https://github.com/linode/manager/pull/12568))
+- Improve stability of Linode create password field tests ([#12576](https://github.com/linode/manager/pull/12576))
+- Mock LKE versions in `lke-create.spec.ts` to fix test failure due to LKE version 1.31 being deprecated ([#12597](https://github.com/linode/manager/pull/12597))
+- Fix Cypress test result notifications missing test names ([#12620](https://github.com/linode/manager/pull/12620))
+- Fix the time format of the start time in QEMU Update Notice ([#12639](https://github.com/linode/manager/pull/12639))
+
+### Upcoming Features:
+
+- Add IPv6 columns to VPC Subnet and Subnet Linodes tables ([#12305](https://github.com/linode/manager/pull/12305))
+- Show GPU warning notice conditionally based on policy type - display for "migrate" policy but hide for "power-off-on" policy ([#12512](https://github.com/linode/manager/pull/12512))
+- Add BYO VPC support to LKE-E create cluster flow ([#12551](https://github.com/linode/manager/pull/12551))
+- Datastream form validation on create stream and destination ([#12557](https://github.com/linode/manager/pull/12557))
+- ACLP: add `linode id to label` translation logic for legend rows, add `entities` to `CloudPulseResouces` interface ([#12558](https://github.com/linode/manager/pull/12558))
+- DataStream: add destination's details for selected destination ([#12559](https://github.com/linode/manager/pull/12559))
+- Modified the query parameter to allow varying use cases. Return any errors from the API along with isLoading, isError values. ([#12560](https://github.com/linode/manager/pull/12560))
+- IAM RBAC: add a permission check in Profile and Account/Billing ([#12561](https://github.com/linode/manager/pull/12561))
+- Add subnet IPv6 to VPC create page ([#12563](https://github.com/linode/manager/pull/12563))
+- Add/update inline docs for ACLP Alerts logic ([#12578](https://github.com/linode/manager/pull/12578))
+- ACLP: add checkbox functionality in `AlertRegions`.  ([#12582](https://github.com/linode/manager/pull/12582))
+- Add Linode Interface support for Linode CLI codesnippets tool ([#12591](https://github.com/linode/manager/pull/12591))
+- Add IP Version (IPv4/IPv6) support to LKE-E cluster create flow ([#12594](https://github.com/linode/manager/pull/12594))
+- Add VPC IPv4 and IPv6 columns to node pools table on LKE-E cluster details page ([#12600](https://github.com/linode/manager/pull/12600))
+- Add VPC IPv6 address in Linode Detail > Summary panel ([#12610](https://github.com/linode/manager/pull/12610))
+- Update the usePermissions hook to return consistent with the other queries ([#12617](https://github.com/linode/manager/pull/12617))
+- Integrate RBAC permission checks in edit billing info ([#12618](https://github.com/linode/manager/pull/12618))
+- ACLP-Alerting: Changed the `aclpAlerting` to include alert and metric limits and other relevant changes  ([#12624](https://github.com/linode/manager/pull/12624))
+- ACLP-Alerting: Custom config_id validation, dynamic schema resolver, helperText map, TextField logic, and mock API for nodebalancer metrics added ([#12629](https://github.com/linode/manager/pull/12629))
+- Update VM Host Maintenance GPU Notice Text ([#12632](https://github.com/linode/manager/pull/12632))
+
 ## [2025-07-29] - v1.147.0
 
 ### Changed:

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.147.0",
+  "version": "1.148.0",
   "private": true,
   "type": "module",
   "bugs": {

--- a/packages/queries/.changeset/pr-12559-upcoming-features-1753279473242.md
+++ b/packages/queries/.changeset/pr-12559-upcoming-features-1753279473242.md
@@ -1,5 +1,0 @@
----
-"@linode/queries": Upcoming Features
----
-
-Add GET queries for destinations endpoints ([#12559](https://github.com/linode/manager/pull/12559))

--- a/packages/queries/CHANGELOG.md
+++ b/packages/queries/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2025-08-12] - v0.11.0
+
+
+### Upcoming Features:
+
+- Add GET queries for destinations endpoints ([#12559](https://github.com/linode/manager/pull/12559))
+
 ## [2025-07-29] - v0.10.0
 
 

--- a/packages/queries/package.json
+++ b/packages/queries/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linode/queries",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Linode Utility functions library",
   "main": "src/index.js",
   "module": "src/index.ts",

--- a/packages/shared/.changeset/pr-12585-changed-1753475926906.md
+++ b/packages/shared/.changeset/pr-12585-changed-1753475926906.md
@@ -1,5 +1,0 @@
----
-"@linode/shared": Changed
----
-
-Allow Linode Select options to be disabled on a per-option basis ([#12585](https://github.com/linode/manager/pull/12585))

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2025-08-12] - v0.7.0
+
+
+### Changed:
+
+- Allow Linode Select options to be disabled on a per-option basis ([#12585](https://github.com/linode/manager/pull/12585))
+
 ## [2025-07-29] - v0.6.0
 
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linode/shared",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Linode shared feature component library",
   "main": "src/index.ts",
   "module": "src/index.ts",

--- a/packages/ui/.changeset/pr-12512-changed-1752621151511.md
+++ b/packages/ui/.changeset/pr-12512-changed-1752621151511.md
@@ -1,5 +1,0 @@
----
-"@linode/ui": Changed
----
-
-Use gap for TableSortLabel spacing of text and icons ([#12512](https://github.com/linode/manager/pull/12512))

--- a/packages/ui/.changeset/pr-12603-fixed-1753955503044.md
+++ b/packages/ui/.changeset/pr-12603-fixed-1753955503044.md
@@ -1,5 +1,0 @@
----
-"@linode/ui": Fixed
----
-
-Check icon color in dark mode and Color Token for all checkbox states ([#12603](https://github.com/linode/manager/pull/12603))

--- a/packages/ui/.changeset/pr-12611-fixed-1753907723282.md
+++ b/packages/ui/.changeset/pr-12611-fixed-1753907723282.md
@@ -1,5 +1,0 @@
----
-"@linode/ui": Fixed
----
-
-Restore the previous date value when Cancel is clicked ([#12611](https://github.com/linode/manager/pull/12611))

--- a/packages/ui/.changeset/pr-12614-fixed-1753928477441.md
+++ b/packages/ui/.changeset/pr-12614-fixed-1753928477441.md
@@ -1,5 +1,0 @@
----
-"@linode/ui": Fixed
----
-
-DatePicker:  Show error if end date time is before start date time ([#12614](https://github.com/linode/manager/pull/12614))

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [2025-08-12] - v0.18.0
+
+
+### Changed:
+
+- Use gap for TableSortLabel spacing of text and icons ([#12512](https://github.com/linode/manager/pull/12512))
+
+### Fixed:
+
+- Check icon color in dark mode and Color Token for all checkbox states ([#12603](https://github.com/linode/manager/pull/12603))
+- Restore the previous date value when Cancel is clicked ([#12611](https://github.com/linode/manager/pull/12611))
+- DatePicker:  Show error if end date time is before start date time ([#12614](https://github.com/linode/manager/pull/12614))
+
 ## [2025-07-29] - v0.17.0
 
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -2,7 +2,7 @@
   "name": "@linode/ui",
   "author": "Linode",
   "description": "Linode UI component library",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "type": "module",
   "main": "src/index.ts",
   "module": "src/index.ts",

--- a/packages/utilities/.changeset/pr-12305-upcoming-features-1753219916941.md
+++ b/packages/utilities/.changeset/pr-12305-upcoming-features-1753219916941.md
@@ -1,5 +1,0 @@
----
-"@linode/utilities": Upcoming Features
----
-
-Update linodeConfigInterfaceFactoryWithVPC and linodeInterfaceFactoryVPC with IPv6 data ([#12305](https://github.com/linode/manager/pull/12305))

--- a/packages/utilities/.changeset/pr-12574-removed-1753885111694.md
+++ b/packages/utilities/.changeset/pr-12574-removed-1753885111694.md
@@ -1,5 +1,0 @@
----
-"@linode/utilities": Removed
----
-
-IPAM address from `linodeConfigInterfaceFactoryWithVPC` ([#12574](https://github.com/linode/manager/pull/12574))

--- a/packages/utilities/CHANGELOG.md
+++ b/packages/utilities/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [2025-08-12] - v0.7.0
+
+
+### Removed:
+
+- IPAM address from `linodeConfigInterfaceFactoryWithVPC` ([#12574](https://github.com/linode/manager/pull/12574))
+
+### Upcoming Features:
+
+- Update linodeConfigInterfaceFactoryWithVPC and linodeInterfaceFactoryVPC with IPv6 data ([#12305](https://github.com/linode/manager/pull/12305))
+
 ## [2025-07-29] - v0.6.0
 
 

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linode/utilities",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Linode Utility functions library",
   "main": "src/index.ts",
   "module": "src/index.ts",

--- a/packages/validation/.changeset/pr-12557-upcoming-features-1753339964453.md
+++ b/packages/validation/.changeset/pr-12557-upcoming-features-1753339964453.md
@@ -1,5 +1,0 @@
----
-"@linode/validation": Upcoming Features
----
-
-Validation for datastream forms: create stream and destination. Validation for datastream create POST request ([#12557](https://github.com/linode/manager/pull/12557))

--- a/packages/validation/.changeset/pr-12563-changed-1753372533337.md
+++ b/packages/validation/.changeset/pr-12563-changed-1753372533337.md
@@ -1,5 +1,0 @@
----
-"@linode/validation": Changed
----
-
-Update `createVPCSchema` to support IPv6 subnets ([#12563](https://github.com/linode/manager/pull/12563))

--- a/packages/validation/.changeset/pr-12596-removed-1753881967320.md
+++ b/packages/validation/.changeset/pr-12596-removed-1753881967320.md
@@ -1,5 +1,0 @@
----
-"@linode/validation": Removed
----
-
-`nodePoolBetaSchema` in favor of `nodePoolSchema` ([#12596](https://github.com/linode/manager/pull/12596))

--- a/packages/validation/.changeset/pr-12628-fixed-1754307870531.md
+++ b/packages/validation/.changeset/pr-12628-fixed-1754307870531.md
@@ -1,5 +1,0 @@
----
-"@linode/validation": Fixed
----
-
-ACLP - Alerting: Fix missing 'in' operator check in dimension filter for create alert schema ([#12628](https://github.com/linode/manager/pull/12628))

--- a/packages/validation/.changeset/pr-12635-fixed-1754392274805.md
+++ b/packages/validation/.changeset/pr-12635-fixed-1754392274805.md
@@ -1,5 +1,0 @@
----
-'@linode/validation': Fixed
----
-
-Non-human-readable validation messages for Linode Alert numeric input ([#12635](https://github.com/linode/manager/pull/12635))

--- a/packages/validation/CHANGELOG.md
+++ b/packages/validation/CHANGELOG.md
@@ -1,3 +1,23 @@
+## [2025-08-12] - v0.72.0
+
+
+### Changed:
+
+- Update `createVPCSchema` to support IPv6 subnets ([#12563](https://github.com/linode/manager/pull/12563))
+
+### Fixed:
+
+- ACLP - Alerting: Fix missing 'in' operator check in dimension filter for create alert schema ([#12628](https://github.com/linode/manager/pull/12628))
+- Non-human-readable validation messages for Linode Alert numeric input ([#12635](https://github.com/linode/manager/pull/12635))
+
+### Removed:
+
+- `nodePoolBetaSchema` in favor of `nodePoolSchema` ([#12596](https://github.com/linode/manager/pull/12596))
+
+### Upcoming Features:
+
+- Validation for datastream forms: create stream and destination. Validation for datastream create POST request ([#12557](https://github.com/linode/manager/pull/12557))
+
 ## [2025-07-29] - v0.71.0
 
 

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linode/validation",
-  "version": "0.71.0",
+  "version": "0.72.0",
   "description": "Yup validation schemas for use with the Linode APIv4",
   "type": "module",
   "main": "lib/index.cjs",


### PR DESCRIPTION
# Cloud Manager
## [2025-08-12] - v1.148.0


### Added:

- Improved search to the Volumes landing page ([#12553](https://github.com/linode/manager/pull/12553))
- ACLP: `filterRegionByServiceType` method to alerts/utils/utils.ts, remove `supportedRegionIds` property from `CloudPulseResourceTypeMapFlag` feature flag  ([#12573](https://github.com/linode/manager/pull/12573))
- Node Pool versions to Kubernetes Cluster detail page for LKE-E clusters ([#12596](https://github.com/linode/manager/pull/12596))
- PlansPanel additionalBanners property for rendering additional banners and disabled property for DatabaseNodeSelector ([#12634](https://github.com/linode/manager/pull/12634))
- ArangoDB, Memgraph, and Neo4j apps to Marketplace ([#12642](https://github.com/linode/manager/pull/12642))

### Changed:

- Use Search field on Images landing page rather than a classic Text field ([#12555](https://github.com/linode/manager/pull/12555))
- Akamai Design System: Link Component ([#12569](https://github.com/linode/manager/pull/12569))
- ACLP: dashboard filters will be rendered based on `dashboardId` instead of `serviceType` ([#12637](https://github.com/linode/manager/pull/12637))
- Added IAM permission check to the Firewall Details / Add Node Balancer drawer ([#12641](https://github.com/linode/manager/pull/12641))
- Replace the existing Premium tab description with generic description copy that works for both legacy Premium and MTC plans ([#12601](https://github.com/linode/manager/pull/12601))

### Fixed:

- Alignment of Closeicon in Textfields ([#12571](https://github.com/linode/manager/pull/12571))
- Disabled Region select in NB create flow for restricted user ([#12571](https://github.com/linode/manager/pull/12571))
- Longview UI alignment issue ([#12578](https://github.com/linode/manager/pull/12578))
- Hover styling of disabled state for zebra striped table rows ([#12579](https://github.com/linode/manager/pull/12579))
- Standardize `<FormHelperText />` error handling across components ([#12581](https://github.com/linode/manager/pull/12581))
- UI and accessibility of disabled Autocomplete options ([#12583](https://github.com/linode/manager/pull/12583))
- Geographical Area state in Distributed Region select in Linode Create flow ([#12584](https://github.com/linode/manager/pull/12584))
- UIE-8955] - IAM RBAC: Fix removing entity can cause empty page ([#12586](https://github.com/linode/manager/pull/12586))
- Left alignment of Encryption checkbox in Linode Create, Linode Rebuild, and Volume Create forms ([#12592](https://github.com/linode/manager/pull/12592))
- Text overflow in SupportTicketDialog and QuotasIncreaseForm preview sections ([#12593](https://github.com/linode/manager/pull/12593))
- Add borders to countries with white backgrounds ([#12604](https://github.com/linode/manager/pull/12604))
- Use human readable date/time for Linode maintenance window ([#12605](https://github.com/linode/manager/pull/12605))
- Negative values in volume size field ([#12606](https://github.com/linode/manager/pull/12606))
- Creation of nodepool with a `--number` of nodes for LKE clusters ([#12616](https://github.com/linode/manager/pull/12616))
- Premature validation of Linode Alert numeric input ([#12626](https://github.com/linode/manager/pull/12626))
- DBaaS Create and Resize node selector options for premium plans and region disabling behavior and handling not being applied in Resize ([#12634](https://github.com/linode/manager/pull/12634))
- ACLP: `loading` screen on auto refetch in edit alert page ([#12636](https://github.com/linode/manager/pull/12636))
- ACLP: not display `/s` with *PS units on initial widget loading ([#12647](https://github.com/linode/manager/pull/12647))

### Tech Stories:

- Improve Create Linode code splitting & routing ([#12554](https://github.com/linode/manager/pull/12554))
- Add MSW Crud support for Linode Config profiles and prevent deletion of vpcs/subnets with resources ([#12574](https://github.com/linode/manager/pull/12574))
- Revise PR template to recommend video previews ([#12608](https://github.com/linode/manager/pull/12608))
- Update PR template to hide a section; add a Scope subsection for confirmation of customer-facing changes ([#12609](https://github.com/linode/manager/pull/12609))

### Tests:

- Tests for ACLP alerts in Linode create flow ([#12540](https://github.com/linode/manager/pull/12540))
- Add Cypress tests for QEMU Upgrade Notice  ([#12564](https://github.com/linode/manager/pull/12564))
- Add Cypress verification tests for CloudPulse NodeBalancer widget ([#12568](https://github.com/linode/manager/pull/12568))
- Improve stability of Linode create password field tests ([#12576](https://github.com/linode/manager/pull/12576))
- Mock LKE versions in `lke-create.spec.ts` to fix test failure due to LKE version 1.31 being deprecated ([#12597](https://github.com/linode/manager/pull/12597))
- Fix Cypress test result notifications missing test names ([#12620](https://github.com/linode/manager/pull/12620))
- Fix the time format of the start time in QEMU Update Notice ([#12639](https://github.com/linode/manager/pull/12639))

### Upcoming Features:

- Add IPv6 columns to VPC Subnet and Subnet Linodes tables ([#12305](https://github.com/linode/manager/pull/12305))
- Show GPU warning notice conditionally based on policy type - display for "migrate" policy but hide for "power-off-on" policy ([#12512](https://github.com/linode/manager/pull/12512))
- Add BYO VPC support to LKE-E create cluster flow ([#12551](https://github.com/linode/manager/pull/12551))
- Datastream form validation on create stream and destination ([#12557](https://github.com/linode/manager/pull/12557))
- ACLP: add `linode id to label` translation logic for legend rows, add `entities` to `CloudPulseResouces` interface ([#12558](https://github.com/linode/manager/pull/12558))
- DataStream: add destination's details for selected destination ([#12559](https://github.com/linode/manager/pull/12559))
- Modified the query parameter to allow varying use cases. Return any errors from the API along with isLoading, isError values. ([#12560](https://github.com/linode/manager/pull/12560))
- IAM RBAC: add a permission check in Profile and Account/Billing ([#12561](https://github.com/linode/manager/pull/12561))
- Add subnet IPv6 to VPC create page ([#12563](https://github.com/linode/manager/pull/12563))
- Add/update inline docs for ACLP Alerts logic ([#12578](https://github.com/linode/manager/pull/12578))
- ACLP: add checkbox functionality in `AlertRegions`.  ([#12582](https://github.com/linode/manager/pull/12582))
- Add Linode Interface support for Linode CLI codesnippets tool ([#12591](https://github.com/linode/manager/pull/12591))
- Add IP Version (IPv4/IPv6) support to LKE-E cluster create flow ([#12594](https://github.com/linode/manager/pull/12594))
- Add VPC IPv4 and IPv6 columns to node pools table on LKE-E cluster details page ([#12600](https://github.com/linode/manager/pull/12600))
- Add VPC IPv6 address in Linode Detail > Summary panel ([#12610](https://github.com/linode/manager/pull/12610))
- Update the usePermissions hook to return consistent with the other queries ([#12617](https://github.com/linode/manager/pull/12617))
- Integrate RBAC permission checks in edit billing info ([#12618](https://github.com/linode/manager/pull/12618))
- ACLP-Alerting: Changed the `aclpAlerting` to include alert and metric limits and other relevant changes  ([#12624](https://github.com/linode/manager/pull/12624))
- ACLP-Alerting: Custom config_id validation, dynamic schema resolver, helperText map, TextField logic, and mock API for nodebalancer metrics added ([#12629](https://github.com/linode/manager/pull/12629))
- Update VM Host Maintenance GPU Notice Text ([#12632](https://github.com/linode/manager/pull/12632))

# APIv4
### Added:

- ACLP: `string` type for `capabilityServiceTypeMapping` constant ([#12573](https://github.com/linode/manager/pull/12573))

### Changed:

- Update `LinodeIPsResponseIPV6` to include `vpc` array ([#12600](https://github.com/linode/manager/pull/12600))

### Removed:

- Remove unnecessary in-progress event.status type during earlier development ([#12512](https://github.com/linode/manager/pull/12512))
- `getNodePoolBeta` in favor of `getNodePool` ([#12596](https://github.com/linode/manager/pull/12596))
- `createNodePoolBeta` in favor of `createNodePool` ([#12596](https://github.com/linode/manager/pull/12596))
- `updateNodePoolBeta` in favor of `updateNodePool` ([#12596](https://github.com/linode/manager/pull/12596))
- `CreateNodePoolDataBeta` in favor of `CreateNodePoolData` ([#12596](https://github.com/linode/manager/pull/12596))
- `UpdateNodePoolDataBeta` in favor of `UpdateNodePoolData` ([#12596](https://github.com/linode/manager/pull/12596))

### Upcoming Features:

- Add optional vpc_id and subnet_id fields to CreateKubeClusterPayload for LKE-E ([#12551](https://github.com/linode/manager/pull/12551))
- Add validation to Create Stream POST request ([#12557](https://github.com/linode/manager/pull/12557))
- GET API endpoints for Destinations ([#12559](https://github.com/linode/manager/pull/12559))
- Remove the docs and costs from streams and destinations landing pages and stream create form ([#12572](https://github.com/linode/manager/pull/12572))
- Add type and update cluster payload and interface to support optional stack_type field for LKE-E ([#12594](https://github.com/linode/manager/pull/12594))

# UI
## [2025-08-12] - v0.18.0


### Changed:

- Use gap for TableSortLabel spacing of text and icons ([#12512](https://github.com/linode/manager/pull/12512))

### Fixed:

- Check icon color in dark mode and Color Token for all checkbox states ([#12603](https://github.com/linode/manager/pull/12603))
- Restore the previous date value when Cancel is clicked ([#12611](https://github.com/linode/manager/pull/12611))
- DatePicker:  Show error if end date time is before start date time ([#12614](https://github.com/linode/manager/pull/12614))

# Queries
## [2025-08-12] - v0.11.0


### Upcoming Features:

- Add GET queries for destinations endpoints ([#12559](https://github.com/linode/manager/pull/12559))

# Validation
## [2025-08-12] - v0.72.0

### Changed:

- Update `createVPCSchema` to support IPv6 subnets ([#12563](https://github.com/linode/manager/pull/12563))

### Fixed:

- ACLP - Alerting: Fix missing 'in' operator check in dimension filter for create alert schema ([#12628](https://github.com/linode/manager/pull/12628))
- Non-human-readable validation messages for Linode Alert numeric input ([#12635](https://github.com/linode/manager/pull/12635))

### Removed:

- `nodePoolBetaSchema` in favor of `nodePoolSchema` ([#12596](https://github.com/linode/manager/pull/12596))

### Upcoming Features:

- Validation for datastream forms: create stream and destination. Validation for datastream create POST request ([#12557](https://github.com/linode/manager/pull/12557))

# Shared
## [2025-08-12] - v0.7.0


### Changed:

- Allow Linode Select options to be disabled on a per-option basis ([#12585](https://github.com/linode/manager/pull/12585))

# Utilities
## [2025-08-12] - v0.7.0


### Removed:

- IPAM address from `linodeConfigInterfaceFactoryWithVPC` ([#12574](https://github.com/linode/manager/pull/12574))

### Upcoming Features:

- Update linodeConfigInterfaceFactoryWithVPC and linodeInterfaceFactoryVPC with IPv6 data ([#12305](https://github.com/linode/manager/pull/12305))