### PR TITLE
fix test broken in backup-linode.spec.ts

### DIFF
--- a/packages/manager/src/features/Linodes/LinodeEntityDetailFooter.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetailFooter.tsx
@@ -39,8 +39,7 @@ export const LinodeEntityDetailFooter = React.memo((props: FooterProps) => {
     linodeRegionDisplay,
     linodeTags,
   } = props;
-
-  const { data: permissions } = usePermissions('account', ['update_account']);
+  const { data: permissions } = usePermissions('linode', ['update_linode']);
 
   const { mutateAsync: updateLinode } = useLinodeUpdateMutation(linodeId);
 
@@ -143,7 +142,7 @@ export const LinodeEntityDetailFooter = React.memo((props: FooterProps) => {
         }}
       >
         <TagCell
-          disabled={!permissions.update_account}
+          disabled={!permissions.update_linode}
           entityLabel={linodeLabel}
           sx={{
             width: '100%',


### PR DESCRIPTION
demo of how to fix broken test in packages/manager/cypress/e2e/core/account/restricted-user-details-pages.spec.ts

this test is failing in multiple PRs, but i don't think it's flakey due to linode bottlenecks. idk anything about how the new permissions are supposed to work, but i can fix it w/ this change to the hook. no idea if this fix is a good idea or not, but it seems to work in my local dev env browser as well as cypress locally.