### PR TITLE
fix: [UIE-8142] - IAM RBAC: fix roles table expand

### DIFF
--- a/packages/manager/.changeset/pr-12659-fixed-1754657214437.md
+++ b/packages/manager/.changeset/pr-12659-fixed-1754657214437.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+IAM RBAC: Accidental row expansion in Roles table when selecting roles via checkbox ([#12659](https://github.com/linode/manager/pull/12659))

--- a/packages/manager/src/features/IAM/Roles/RolesTable/RolesTable.tsx
+++ b/packages/manager/src/features/IAM/Roles/RolesTable/RolesTable.tsx
@@ -44,7 +44,6 @@ interface Props {
 }
 const DEFAULT_PAGE_SIZE = 10;
 export const RolesTable = ({ roles = [] }: Props) => {
-  const [expandedRows, setExpandedRows] = useState<string[]>([]);
   // Filter string for the search bar
   const [filterString, setFilterString] = React.useState('');
   const [filterableEntityType, setFilterableEntityType] =
@@ -147,12 +146,7 @@ export const RolesTable = ({ roles = [] }: Props) => {
     pagination.handlePageSizeChange(newSize);
     pagination.handlePageChange(1);
   };
-  const handleExpandToggle = (e: React.MouseEvent, name: string) => {
-    e.stopPropagation();
-    setExpandedRows((prev) =>
-      prev.includes(name) ? prev.filter((n) => n !== name) : [...prev, name]
-    );
-  };
+
   return (
     <>
       <Paper sx={(theme) => ({ marginTop: theme.tokens.spacing.S16 })}>
@@ -253,7 +247,6 @@ export const RolesTable = ({ roles = [] }: Props) => {
               paginatedRows.map((roleRow) => (
                 <TableRow
                   expandable
-                  expanded={expandedRows.includes(roleRow.name)}
                   hoverable
                   key={roleRow.name}
                   rowborder
@@ -262,7 +255,6 @@ export const RolesTable = ({ roles = [] }: Props) => {
                   selected={selectedRows.includes(roleRow)}
                 >
                   <TableCell
-                    onClick={(e) => handleExpandToggle(e, roleRow.name)}
                     style={{ minWidth: '26%', wordBreak: 'break-word' }}
                   >
                     {roleRow.name}
@@ -296,11 +288,7 @@ export const RolesTable = ({ roles = [] }: Props) => {
                     slot="expanded"
                     style={{ marginBottom: 12, padding: 0, width: '100%' }}
                   >
-                    {expandedRows.includes(roleRow.name) && (
-                      <RolesTableExpandedRow
-                        permissions={roleRow.permissions}
-                      />
-                    )}
+                    <RolesTableExpandedRow permissions={roleRow.permissions} />
                   </TableRowExpanded>
                 </TableRow>
               ))


### PR DESCRIPTION
## Description 📝

This PR updates the expand/collapse behavior in the IAM RBAC Roles table to prevent accidental row expansion when interacting with the selection checkbox.

## Changes  🔄

List any change(s) relevant to the reviewer.

- Fixed expand/collapse behavior in the IAM RBAC Roles table to prevent accidental row expansion when interacting with the selection checkbox.


### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [x] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

August 26th

## How to test 🧪

### Prerequisites

(How to setup test environment)

- devcloud IAM account or local devenv setup or mock data

### Verification steps

(How to verify changes)

- [ ] Go to the Roles tab
- [ ] Select one or more roles using the checkbox, the row should **not** expand.
- [ ] Click the expand toggle icon, the row should expand/collapse as expected.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>