### PR TITLE
refactor:[M3-9877][SECURITY] - Fix excessive secrets exposure warning in e2e GHA workflow

### DIFF
--- a/.github/workflows/e2e_schedule_and_push.yml
+++ b/.github/workflows/e2e_schedule_and_push.yml
@@ -15,7 +15,6 @@ env:
   CY_TEST_SPLIT_RUN: 1
   CY_TEST_SPLIT_RUN_TOTAL: 4
 on:
-  workflow_dispatch:
   schedule:
     - cron: "0 13 * * 1-5"
   push:
@@ -45,7 +44,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20.17"
-      - run: echo "Hello World"
       - run: |
           echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
       - run: |
@@ -55,7 +53,7 @@ jobs:
           echo "REACT_APP_API_ROOT=${{ secrets.REACT_APP_API_ROOT }}" >> ./packages/manager/.env
           echo "REACT_APP_APP_ROOT=${{ secrets.REACT_APP_APP_ROOT }}" >> ./packages/manager/.env
           echo "REACT_APP_DISABLE_NEW_RELIC=1" >> ./packages/manager/.env
-          echo "MANAGER_OAUTH=${{ secrets[matrix.user.name] }}" >> ./packages/manager/.env
+          echo "MANAGER_OAUTH=${{ env[matrix.user.name] }}" >> ./packages/manager/.env
           echo "CY_TEST_SPLIT_RUN_INDEX=${{ matrix.user.index }}" >> ./packages/manager/.env
       - run: pnpm install --frozen-lockfile
       - run: pnpm run --filter @linode/validation build

--- a/.github/workflows/e2e_schedule_and_push.yml
+++ b/.github/workflows/e2e_schedule_and_push.yml
@@ -31,10 +31,10 @@ jobs:
       fail-fast: false
       matrix:
         user:
-          - { index: 1, name: 'USER_1' }
-          - { index: 2, name: 'USER_2' }
-          - { index: 3, name: 'USER_3' }
-          - { index: 4, name: 'USER_4' }
+          - { index: 1, name: "USER_1" }
+          - { index: 2, name: "USER_2" }
+          - { index: 3, name: "USER_3" }
+          - { index: 4, name: "USER_4" }
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -44,6 +44,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20.17"
+      - run: echo "Hello World"
       - run: |
           echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
       - run: |

--- a/.github/workflows/e2e_schedule_and_push.yml
+++ b/.github/workflows/e2e_schedule_and_push.yml
@@ -15,6 +15,7 @@ env:
   CY_TEST_SPLIT_RUN: 1
   CY_TEST_SPLIT_RUN_TOTAL: 4
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 13 * * 1-5"
   push:

--- a/packages/manager/.changeset/pr-12664-tech-stories-1754933120939.md
+++ b/packages/manager/.changeset/pr-12664-tech-stories-1754933120939.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Fix Excessive Secrets Exposure vulnerability in E2E GitHub Action ([#12664](https://github.com/linode/manager/pull/12664))


### PR DESCRIPTION
## Description 📝

This PR fixes the [Excessive Secrets Exposure](https://github.com/linode/manager/security/code-scanning/188) vulnerability in our E2E GitHub Actions workflow to stop using dynamic secret lookups and instead use `env` variables scoped to each matrix job.

## Changes  🔄

- Replaced dynamic secret access (`secrets[matrix.user.name]`) with env-based access (`env[matrix.user.name]`) for `MANAGER_OAUTH` in `.github/workflows/e2e_schedule_and_push.yml`

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [x] No customers / Not applicable


### Verification steps

Full verification will need to be done after merging. In the meantime, I was able to partially verify in my forked repo by adding a copy of the `.github/workflows/e2e_schedule_and_push.yml` file with my change as this [debug Action](https://github.com/bill-akamai/manager/actions/workflows/debug-M3-9877.yml) in GitHub. I added secrets for `USER_1` and `USER_2` in my repo and could see that they're logging a masked value with the new format of `env[matrix.user.name]`. I ran my repo's [CodeQL](https://github.com/linode/manager/actions/workflows/github-code-scanning/codeql) Action and saw it only logs an Excessive Secrets Exposure issue for the existing `.github/workflows/e2e_schedule_and_push.yml` and not the new debug version as expected. IRL, we can verify post-merge as follows:

- [ ] After this PR is merged to develop, check for successful run on [Tests On Push/Schedule](https://github.com/linode/manager/actions/workflows/e2e_schedule_and_push.yml) GitHub action
- [ ] Confirm CodeQL completes without Excessive Secrets Exposure warnings for this file in the Security/Code scanning area in GitHub: https://github.com/linode/manager/security/code-scanning

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>