### PR TITLE
fix: [UIE-9071, UIE-9072] - IAM RBAC: clone linode permission fix, edit linode label permission fix

### DIFF
--- a/packages/manager/.changeset/pr-12668-fixed-1754917016678.md
+++ b/packages/manager/.changeset/pr-12668-fixed-1754917016678.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+IAM RBAC: Missing 'update_linode' check for label edits, missing 'create_linode' account check when enabling Clone button ([#12668](https://github.com/linode/manager/pull/12668))

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
@@ -8,6 +8,7 @@ import * as React from 'react';
 import { LandingHeader } from 'src/components/LandingHeader';
 import { ProductInformationBanner } from 'src/components/ProductInformationBanner/ProductInformationBanner';
 import { PENDING_MAINTENANCE_FILTER } from 'src/features/Account/Maintenance/utilities';
+import { usePermissions } from 'src/features/IAM/hooks/usePermissions';
 import { LinodeEntityDetail } from 'src/features/Linodes/LinodeEntityDetail';
 import { MigrateLinode } from 'src/features/Linodes/MigrateLinode/MigrateLinode';
 import { PowerActionsDialog } from 'src/features/Linodes/PowerActionsDialogOrDrawer';
@@ -55,6 +56,11 @@ export const LinodeDetailHeader = () => {
   const { mutateAsync: updateLinode } =
     useLinodeUpdateMutation(matchedLinodeId);
 
+  const { data: permissions } = usePermissions(
+    'linode',
+    ['update_linode'],
+    linodeId
+  );
   const [powerAction, setPowerAction] = React.useState<Action>('Reboot');
   const [powerDialogOpen, setPowerDialogOpen] = React.useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(search.delete);
@@ -193,6 +199,7 @@ export const LinodeDetailHeader = () => {
           },
           pathname: `/linodes/${linode.label}`,
         }}
+        disabledBreadcrumbEditButton={!permissions.update_linode}
         docsLabel="Docs"
         docsLink="https://techdocs.akamai.com/cloud-computing/docs/getting-started"
         onDocsClick={() => {

--- a/packages/manager/src/features/Linodes/LinodesLanding/LinodeActionMenu/LinodeActionMenu.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/LinodeActionMenu/LinodeActionMenu.tsx
@@ -57,6 +57,10 @@ export const LinodeActionMenu = (props: LinodeActionMenuProps) => {
   const isBareMetalInstance = linodeType?.class === 'metal';
   const hasHostMaintenance = linodeStatus === 'stopped';
 
+  const { data: accountPermissions } = usePermissions('account', [
+    'create_linode',
+  ]);
+
   const { data: permissions } = usePermissions(
     'linode',
     [
@@ -144,6 +148,7 @@ export const LinodeActionMenu = (props: LinodeActionMenuProps) => {
       condition: !isBareMetalInstance,
       disabled:
         !permissions.clone_linode ||
+        !accountPermissions.create_linode ||
         hasHostMaintenance ||
         linodeIsInDistributedRegion,
       isReadOnly: !permissions.clone_linode,


### PR DESCRIPTION
## Description 📝

Disable Linode label editing for users without the ``update_linode`` permission.
Check for both ``clone_linode`` and ``create_linode`` permissions before enabling the “Clone Linode” button.

## Changes  🔄

List any change(s) relevant to the reviewer.

- Disable Linode label editing for users without the ``update_linode`` permission.
- Check for both ``clone_linode`` and ``create_linode`` permissions before enabling the “Clone Linode” button.

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [x] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

August 26th

## How to test 🧪

### Prerequisites

(How to setup test environment)

- devcloud IAM account or local devenv setup or mock data (use the User Permissions presets)
- _Note: The unrestricted account has full access — permission checks are skipped._

To test permissions using presets:

Enable MSW and use Legacy MSW Handlers.

- Use the Custom Profile preset with the restricted option selected.
- For account-related permissions (e.g. const { permissions } = usePermissions('account', ['create_linode']) ), use the Custom User Account Permissions preset.
- For entity-related permissions, use the Custom User Entity Permissions preset.
- Add the required permissions to the Custom User Account Permissions preset in the following format:
```
[
  "update_linode",
  "clone_linode",
  "create_linode",
]
```
### Verification steps

(How to verify changes)

- [ ] Navigate to Linodes → Select Linode.
- [ ] Confirm that Linode label editing is disabled if the user does not have the ``update_linode`` permission.
- [ ] Confirm that the Clone button is disabled if the user does not have both ``clone_linode`` and ``create_linode`` permissions.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>