### PR TITLE
fix: [M3-10467] - Improve Primary Nav Active Link Matching

### DIFF
--- a/packages/manager/src/components/PrimaryNav/utils.ts
+++ b/packages/manager/src/components/PrimaryNav/utils.ts
@@ -14,7 +14,15 @@ export const linkIsActive = (locationPathname: string, to: LinkProps['to']) => {
     return currentlyOnOneClickTab && isOneClickTab;
   }
 
-  return to?.split('/')[1] === locationPathname.split('/')[1];
+  if (to === locationPathname) {
+    return true;
+  }
+
+  if (locationPathname.startsWith(to + '/')) {
+    return true;
+  }
+
+  return false;
 };
 
 /**


### PR DESCRIPTION
## Description 📝
After merging [the new "Administration" navigation section](https://github.com/linode/manager/pull/12633), I noticed that the activeLink matching was not working well in this case.

This PR improves the pattern to match segmentation to account for those cases

We do not need a changeset since this is not affecting prod yet

## Changes  🔄
- Improve `linkIsActive` util

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [x] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️
8/26

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-08-12 at 11 12 53](https://github.com/user-attachments/assets/fe1d1cc4-ec82-45cf-83cd-cebce72102a1) | ![Screenshot 2025-08-12 at 11 12 35](https://github.com/user-attachments/assets/b32a4d25-db8e-4100-8814-6431c193563b) |

## How to test 🧪

### Verification steps
- Pull current code and ensure the new "Administration" main nav category's active links behave properly
- Ensure no regressions with existing active links in other sections

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support
</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules