### PR TITLE
feat: [UIE-9076, UIE-9076] - IAM RBAC: fix permission check for rebuilding and resizing linode 

### DIFF
--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeRebuild/LinodeRebuildForm.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeRebuild/LinodeRebuildForm.tsx
@@ -8,7 +8,7 @@ import { useSnackbar } from 'notistack';
 import React, { useEffect, useRef, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
-import { useIsResourceRestricted } from 'src/hooks/useIsResourceRestricted';
+import { usePermissions } from 'src/features/IAM/hooks/usePermissions';
 import { useEventsPollingActions } from 'src/queries/events/events';
 
 import { StackScriptSelectionList } from '../../LinodeCreate/Tabs/StackScripts/StackScriptSelectionList';
@@ -43,11 +43,11 @@ export const LinodeRebuildForm = (props: Props) => {
 
   const [type, setType] = useState<LinodeRebuildType>('Image');
 
-  const isLinodeReadOnly = useIsResourceRestricted({
-    grantLevel: 'read_only',
-    grantType: 'linode',
-    id: linode.id,
-  });
+  const { data: permissions } = usePermissions(
+    'linode',
+    ['rebuild_linode'],
+    linode.id
+  );
 
   const { data: isTypeToConfirmEnabled } = usePreferences(
     (preferences) => preferences?.type_to_confirm ?? true
@@ -127,7 +127,7 @@ export const LinodeRebuildForm = (props: Props) => {
     <FormProvider {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)}>
         <Stack spacing={2}>
-          {isLinodeReadOnly && <LinodePermissionsError />}
+          {!permissions.rebuild_linode && <LinodePermissionsError />}
           {form.formState.errors.root && (
             <Notice text={form.formState.errors.root.message} variant="error" />
           )}
@@ -150,7 +150,7 @@ export const LinodeRebuildForm = (props: Props) => {
             }}
           >
             <RebuildFromSelect
-              disabled={isLinodeReadOnly}
+              disabled={!permissions.rebuild_linode}
               setType={setType}
               type={type}
             />
@@ -167,21 +167,21 @@ export const LinodeRebuildForm = (props: Props) => {
               <StackScriptSelectionList type="Community" />
             )}
             {type.includes('StackScript') && <UserDefinedFields />}
-            <Image disabled={isLinodeReadOnly} />
-            <Password disabled={isLinodeReadOnly} />
-            <SSHKeys disabled={isLinodeReadOnly} />
+            <Image disabled={!permissions.rebuild_linode} />
+            <Password disabled={!permissions.rebuild_linode} />
+            <SSHKeys disabled={!permissions.rebuild_linode} />
             <DiskEncryption
-              disabled={isLinodeReadOnly}
+              disabled={!permissions.rebuild_linode}
               isLKELinode={linode.lke_cluster_id !== null}
               linodeRegion={linode.region}
             />
-            <UserData disabled={isLinodeReadOnly} linode={linode} />
+            <UserData disabled={!permissions.rebuild_linode} linode={linode} />
             <Confirmation
-              disabled={isLinodeReadOnly}
+              disabled={!permissions.rebuild_linode}
               linodeLabel={linode.label}
             />
           </Stack>
-          <Actions disabled={isLinodeReadOnly} />
+          <Actions disabled={!permissions.rebuild_linode} />
         </Stack>
       </form>
     </FormProvider>


### PR DESCRIPTION
## Description 📝

This PR fixes the missing IAM permission checks for rebuilding and resizing linodes in the drawers


## Changes  🔄

List any change(s) relevant to the reviewer.

- Add permission check for rebuild linode drawer
- Add permission check for resize linode drawer
- Update tests

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [x] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

August 26

## How to test 🧪

### Prerequisites

(How to setup test environment)

MSW or iam (restricted) + regular account to compare
Permissions to check:

`Custom User Entity Permissions` preset:
```
[
    "resize_linode",
    "rebuild_linode"
]
```

### Verification steps

(How to verify changes)

- [ ] Confirm the buttons/inputs are disabled according the grant model with IAM is off, and according to the RBAC model when IAM is on.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
