### PR TITLE
test: [M3-10464] - Add Cypress test confirming LKE-E cluster details page shows VPC details

### DIFF
--- a/packages/api-v4/src/kubernetes/types.ts
+++ b/packages/api-v4/src/kubernetes/types.ts
@@ -39,7 +39,7 @@ export interface KubernetesCluster {
    * Upcoming Feature Notice - LKE-E:** this property may not be available to all customers
    * and may change in subsequent releases.
    */
-  subnet_id?: number;
+  subnet_id?: null | number;
   tags: string[];
   /** Marked as 'optional' in this existing interface to prevent duplicated code for beta functionality, in line with the apl_enabled approach.
    * @todo LKE-E - Make this field required once LKE-E is in GA. tier defaults to 'standard' in the API.
@@ -50,7 +50,7 @@ export interface KubernetesCluster {
    * Upcoming Feature Notice - LKE-E:** this property may not be available to all customers
    * and may change in subsequent releases.
    */
-  vpc_id?: number;
+  vpc_id?: null | number;
 }
 
 export interface KubeNodePoolResponse {

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-enterprise-read.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-enterprise-read.spec.ts
@@ -1,0 +1,97 @@
+import { profileFactory } from '@linode/utilities';
+import { mockAppendFeatureFlags } from 'support/intercepts/feature-flags';
+import {
+  mockGetCluster,
+  mockGetClusterPools,
+  mockGetKubernetesVersions,
+} from 'support/intercepts/lke';
+import { mockGetProfile } from 'support/intercepts/profile';
+import { mockGetVPC } from 'support/intercepts/vpc';
+
+import { kubernetesClusterFactory, vpcFactory } from 'src/factories';
+
+const mockProfile = profileFactory.build();
+
+/**
+ * Confirms read operations on LKE-Enterprise clusters.
+ */
+describe('LKE-E Cluster Summary - VPC Section', () => {
+  beforeEach(() => {
+    // TODO LKE-E: Remove once feature is in GA
+    mockAppendFeatureFlags({
+      lkeEnterprise: { enabled: true, la: true, phase2Mtc: true },
+    });
+  });
+  /*
+   * - Confirms LKE-E summary page shows VPC info and links to the correct VPC page when a vpc_id is present.
+   */
+  it('shows linked VPC in summary for cluster with a VPC', () => {
+    const mockVPC = vpcFactory.build({
+      id: 123,
+      label: 'lke-e-vpc',
+    });
+
+    const mockClusterWithVPC = kubernetesClusterFactory.build({
+      id: 1,
+      vpc_id: mockVPC.id,
+      tier: 'enterprise',
+    });
+    mockGetCluster(mockClusterWithVPC).as('getCluster');
+    mockGetKubernetesVersions().as('getVersions');
+    mockGetClusterPools(mockClusterWithVPC.id, []).as('getNodePools');
+    mockGetVPC(mockVPC).as('getVPC');
+    mockGetProfile(mockProfile).as('getProfile');
+
+    cy.visitWithLogin(`/kubernetes/clusters/${mockClusterWithVPC.id}/summary`);
+    cy.wait([
+      '@getCluster',
+      '@getNodePools',
+      '@getVersions',
+      '@getVPC',
+      '@getProfile',
+    ]);
+
+    // Verify VPC details appear in the summary
+    cy.get('[data-qa-kube-entity-footer]').within(() => {
+      cy.contains('VPC:').should('exist');
+      cy.findByTestId('assigned-lke-cluster-label')
+        .should('contain.text', mockVPC.label)
+        .should('have.attr', 'href')
+        .and('include', `/vpcs/${mockVPC.id}`);
+    });
+
+    // Navigate to the VPC by clicking the link
+    cy.findByTestId('assigned-lke-cluster-label').click();
+
+    // Verify the VPC details page loads
+    cy.url().should('include', `/vpcs/${mockVPC.id}`);
+    cy.contains(mockVPC.label).should('exist');
+  });
+
+  /*
+   * - Confirms VPC info is not shown when cluster's vpc_id is null.
+   */
+  it('does not show linked VPC in summary when cluster does not have a VPC', () => {
+    const mockClusterWithoutVPC = kubernetesClusterFactory.build({
+      id: 2,
+      vpc_id: null,
+      tier: 'enterprise',
+    });
+
+    mockGetCluster(mockClusterWithoutVPC).as('getCluster');
+    mockGetKubernetesVersions().as('getVersions');
+    mockGetClusterPools(mockClusterWithoutVPC.id, []).as('getNodePools');
+    mockGetProfile(mockProfile).as('getProfile');
+
+    cy.visitWithLogin(
+      `/kubernetes/clusters/${mockClusterWithoutVPC.id}/summary`
+    );
+    cy.wait(['@getCluster', '@getNodePools', '@getVersions', '@getProfile']);
+
+    // Confirm that no VPC label or link is shown in the summary section
+    cy.get('[data-qa-kube-entity-footer]').within(() => {
+      cy.contains('VPC:').should('not.exist');
+      cy.findByTestId('assigned-lke-cluster-label').should('not.exist');
+    });
+  });
+});

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeEntityDetailFooter.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeEntityDetailFooter.tsx
@@ -34,7 +34,7 @@ interface FooterProps {
   isLoadingKubernetesACL: boolean;
   setControlPlaneACLDrawerOpen: React.Dispatch<React.SetStateAction<boolean>>;
   sx?: SxProps;
-  vpcId: number | undefined;
+  vpcId: null | number | undefined;
 }
 
 export const KubeEntityDetailFooter = React.memo((props: FooterProps) => {


### PR DESCRIPTION
## Description 📝

**Case**: LKE-E cluster details page shows VPC details
**Description**: LKE cluster details page shows information related to VPC
Verify:
- Details page for LKE-E clusters shows the VPC in the summary section
- The VPC is a link, user can click it to navigate to the VPC
- IPv4 and IPv6 columns are present in node pool tables
 
**Case**: VPC detail not shown on regular LKE cluster details page
**Description**: LKE cluster details page does not show "VPC" section for regular clusters when phase 2 feature flag is enabled.
Verify:
- Regular LKE cluster details page has no section dedicated to VPC in the summary section at the top of the page
- IPv4 and IPv6 node pool table columns are absent

## Changes  🔄
- ...

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

8/26

## Preview 📷

![Screenshot 2025-08-14 at 7 43 50 AM](https://github.com/user-attachments/assets/de560a5f-b96e-4d5d-a208-715cf519ef28)

## How to test 🧪

### Verification steps

(How to verify changes)

```
pnpm cy:run -s "cypress/e2e/core/kubernetes/lke-enterprise-read.spec.ts"```

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

-->