### PR TITLE
upcoming: [M3-10417], [M3-10418], [M3-10419] and [M3-10420] - Redirects account tabs to flag route /login-history, /settings, /maintenance and /service-transfers

### DIFF
--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -289,7 +289,7 @@ export const PrimaryNav = (props: PrimaryNavProps) => {
               },
               {
                 display: 'Login History',
-                to: '/account/login-history', // TODO: replace with '/login-history' when flat route is added
+                to: '/login-history',
               },
               {
                 display: 'Service Transfers',

--- a/packages/manager/src/features/Account/AccountLogins.tsx
+++ b/packages/manager/src/features/Account/AccountLogins.tsx
@@ -15,6 +15,7 @@ import { TableRowEmpty } from 'src/components/TableRowEmpty/TableRowEmpty';
 import { TableRowError } from 'src/components/TableRowError/TableRowError';
 import { TableRowLoading } from 'src/components/TableRowLoading/TableRowLoading';
 import { TableSortCell } from 'src/components/TableSortCell';
+import { useFlags } from 'src/hooks/useFlags';
 import { useOrderV2 } from 'src/hooks/useOrderV2';
 import { usePaginationV2 } from 'src/hooks/usePaginationV2';
 
@@ -43,11 +44,14 @@ const useStyles = makeStyles()((theme: Theme) => ({
 
 const AccountLogins = () => {
   const { classes } = useStyles();
+  const flags = useFlags();
   const { data: permissions } = usePermissions('account', [
     'list_account_logins',
   ]);
   const pagination = usePaginationV2({
-    currentRoute: '/account/login-history',
+    currentRoute: flags?.iamRbacPrimaryNavChanges
+      ? '/login-history'
+      : '/account/login-history',
     preferenceKey: 'account-logins-pagination',
   });
 
@@ -57,7 +61,9 @@ const AccountLogins = () => {
         order: 'desc',
         orderBy: 'datetime',
       },
-      from: '/account/login-history',
+      from: flags?.iamRbacPrimaryNavChanges
+        ? '/login-history'
+        : '/account/login-history',
     },
     preferenceKey: `${preferenceKey}-order`,
   });

--- a/packages/manager/src/features/LoginHistory/LoginHistoryLanding.tsx
+++ b/packages/manager/src/features/LoginHistory/LoginHistoryLanding.tsx
@@ -1,0 +1,38 @@
+import { Navigate, useLocation } from '@tanstack/react-router';
+import * as React from 'react';
+
+import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import { LandingHeader } from 'src/components/LandingHeader';
+import { MaintenanceBannerV2 } from 'src/components/MaintenanceBanner/MaintenanceBannerV2';
+import { PlatformMaintenanceBanner } from 'src/components/PlatformMaintenanceBanner/PlatformMaintenanceBanner';
+import { useFlags } from 'src/hooks/useFlags';
+
+import AccountLogins from '../Account/AccountLogins';
+
+import type { LandingHeaderProps } from 'src/components/LandingHeader';
+
+export const LoginHistoryLanding = () => {
+  const flags = useFlags();
+  const location = useLocation();
+
+  if (
+    !flags?.iamRbacPrimaryNavChanges &&
+    location.pathname !== '/account/login-history'
+  ) {
+    return <Navigate replace to="/account/login-history" />;
+  }
+
+  const landingHeaderProps: LandingHeaderProps = {
+    title: 'Login History',
+  };
+
+  return (
+    <>
+      <PlatformMaintenanceBanner pathname={location.pathname} />
+      <MaintenanceBannerV2 pathname={location.pathname} />
+      <DocumentTitleSegment segment="Login History" />
+      <LandingHeader {...landingHeaderProps} spacingBottom={4} />
+      <AccountLogins />
+    </>
+  );
+};

--- a/packages/manager/src/features/LoginHistory/loginHistoryLandingLazyRoute.ts
+++ b/packages/manager/src/features/LoginHistory/loginHistoryLandingLazyRoute.ts
@@ -1,0 +1,7 @@
+import { createLazyRoute } from '@tanstack/react-router';
+
+import { LoginHistoryLanding } from './LoginHistoryLanding';
+
+export const loginHistoryLandingLazyRoute = createLazyRoute('/login-history')({
+  component: LoginHistoryLanding,
+});

--- a/packages/manager/src/features/TopMenu/UserMenu/UserMenuPopover.tsx
+++ b/packages/manager/src/features/TopMenu/UserMenu/UserMenuPopover.tsx
@@ -124,7 +124,9 @@ export const UserMenuPopover = (props: UserMenuPopoverProps) => {
       },
       {
         display: 'Login History',
-        to: '/account/login-history',
+        to: flags?.iamRbacPrimaryNavChanges
+          ? '/login-history'
+          : '/account/login-history',
       },
       // Restricted users can't view the Transfers tab regardless of their grants
       {

--- a/packages/manager/src/routes/account/index.ts
+++ b/packages/manager/src/routes/account/index.ts
@@ -76,6 +76,14 @@ const accountQuotasRoute = createRoute({
 const accountLoginHistoryRoute = createRoute({
   getParentRoute: () => accountTabsRoute,
   path: '/login-history',
+  beforeLoad: ({ context }) => {
+    if (context?.flags?.iamRbacPrimaryNavChanges) {
+      throw redirect({
+        to: `/login-history`,
+        replace: true,
+      });
+    }
+  },
 }).lazy(() =>
   import('src/features/Account/accountLoginsLazyRoute').then(
     (m) => m.accountLoginsLazyRoute

--- a/packages/manager/src/routes/index.tsx
+++ b/packages/manager/src/routes/index.tsx
@@ -24,6 +24,7 @@ import { iamRouteTree } from './IAM';
 import { imagesRouteTree } from './images';
 import { kubernetesRouteTree } from './kubernetes';
 import { linodesRouteTree } from './linodes';
+import { loginHistoryRouteTree } from './loginHistory/';
 import { longviewRouteTree } from './longview';
 import { managedRouteTree } from './managed';
 import { cloudPulseMetricsRouteTree } from './metrics';
@@ -68,6 +69,7 @@ export const routeTree = rootRoute.addChildren([
   imagesRouteTree,
   kubernetesRouteTree,
   linodesRouteTree,
+  loginHistoryRouteTree,
   longviewRouteTree,
   managedRouteTree,
   nodeBalancersRouteTree,

--- a/packages/manager/src/routes/loginHistory/LoginHistoryRoute.tsx
+++ b/packages/manager/src/routes/loginHistory/LoginHistoryRoute.tsx
@@ -1,0 +1,14 @@
+import { Outlet } from '@tanstack/react-router';
+import React from 'react';
+
+import { ProductInformationBanner } from 'src/components/ProductInformationBanner/ProductInformationBanner';
+import { SuspenseLoader } from 'src/components/SuspenseLoader';
+
+export const LoginHistoryRoute = () => {
+  return (
+    <React.Suspense fallback={<SuspenseLoader />}>
+      <ProductInformationBanner bannerLocation="Account" />
+      <Outlet />
+    </React.Suspense>
+  );
+};

--- a/packages/manager/src/routes/loginHistory/index.ts
+++ b/packages/manager/src/routes/loginHistory/index.ts
@@ -1,0 +1,42 @@
+import { createRoute, redirect } from '@tanstack/react-router';
+
+import { rootRoute } from '../root';
+import { LoginHistoryRoute } from './LoginHistoryRoute';
+
+const loginHistoryRoute = createRoute({
+  component: LoginHistoryRoute,
+  getParentRoute: () => rootRoute,
+  path: 'login-history',
+});
+
+// Catch all route for login historyRoute page
+const loginHistoryCatchAllRoute = createRoute({
+  getParentRoute: () => loginHistoryRoute,
+  path: '/$invalidPath',
+  beforeLoad: () => {
+    throw redirect({ to: '/login-history' });
+  },
+});
+
+// Index route: /login-history (main login-history content)
+const loginHistoryIndexRoute = createRoute({
+  getParentRoute: () => loginHistoryRoute,
+  path: '/',
+  beforeLoad: ({ context }) => {
+    if (!context?.flags?.iamRbacPrimaryNavChanges) {
+      throw redirect({
+        to: `/account/login-history`,
+        replace: true,
+      });
+    }
+  },
+}).lazy(() =>
+  import('src/features/LoginHistory/loginHistoryLandingLazyRoute').then(
+    (m) => m.loginHistoryLandingLazyRoute
+  )
+);
+
+export const loginHistoryRouteTree = loginHistoryRoute.addChildren([
+  loginHistoryIndexRoute,
+  loginHistoryCatchAllRoute,
+]);


### PR DESCRIPTION
## Description 📝

This PR  to redirect users to below rotues when the `iamRbacPrimaryNavChanges` feature flag is enabled.
1. `/account/login-history`the new `/login-history` 
2.  `/account/maintenance`the new `/maintenance` 
3. `/account/settings`the new `/settings` 
4. `/account/service-transfers`the new `/service-transfers` 

Todo: 

- [x] 1. `/account/login-history`the new `/login-history` 
- [ ] 2.  `/account/maintenance`the new `/maintenance` 
- [ ] 3. `/account/settings`the new `/settings` 
- [ ] 4. `/account/service-transfers`the new `/service-transfers` 

## Changes  🔄

List any change(s) relevant to the reviewer.

- Added new` /loginHistory` route with conditional redirect to '/account/login-history'
- Added conditional redirect to '/login-history' in the account route.
- Updated cypress tests by disabling the mock flag.

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [x] All customers
- [x] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

8/26

## Preview 📷

**Include a screenshot `<img src="" />` or video `<video src="" />` of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: For changes requiring multiple steps to validate, prefer a video for clarity.

| Before  | After   |
| ------- | ------- |
|<img width="3434" height="1700" alt="image" src="https://github.com/user-attachments/assets/d8edad12-f5e8-47a8-ac44-721ffceac0c2" />|<img width="3434" height="1838" alt="image" src="https://github.com/user-attachments/assets/17779e86-41c7-4c87-860b-6fa027904c0a" />|

## How to test 🧪

### Verification steps

(How to verify changes)

- [ ] Checkout the branch and run the app in local.
- [ ] Enable the `iamRbacPrimaryNavChanges` flag → navigating to /account/quotas should redirect to /quotas.
- [ ] Verify all the links and sublinks in the quotas page. 
- [ ] Disable the flag → /account/quotas should show the legacy quotas page (/account/quotas).
- [ ] Confirm that back/forward navigation works without loops.
- [ ] Verify no regression in legacy (account/quotas) billing page when flag is off.
- [ ] Verify all the functionality and links in the new route /quotas.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

