### PR TITLE
test: [M3-10369] - Add tests to linode alerts edit page on when "Save Changes?" dialog should appear

### DIFF
--- a/packages/manager/src/features/CloudPulse/Alerts/ContextualView/AlertInformationActionTable.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/ContextualView/AlertInformationActionTable.tsx
@@ -12,6 +12,7 @@ import { TableCell } from 'src/components/TableCell';
 import { TableContentWrapper } from 'src/components/TableContentWrapper/TableContentWrapper';
 import { TableRow } from 'src/components/TableRow';
 import { TableSortCell } from 'src/components/TableSortCell';
+import { ALERTS_BETA_PROMPT } from 'src/features/Linodes/constants';
 import { useServiceAlertsMutation } from 'src/queries/cloudpulse/alerts';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
@@ -347,12 +348,12 @@ export const AlertInformationActionTable = (
         isOpen={isDialogOpen}
         message={
           <>
-            Are you sure you want to save (Beta) Alerts? <b>Legacy</b> settings
-            will be disabled and replaced by (Beta) Alerts settings.
+            {ALERTS_BETA_PROMPT} <b>Legacy</b> settings will be disabled and
+            replaced by (Beta) Alerts settings.
           </>
         }
         primaryButtonLabel="Confirm"
-        title="Are you sure you want to save (Beta) Alerts? "
+        title={ALERTS_BETA_PROMPT}
       />
     </>
   );

--- a/packages/manager/src/features/Linodes/constants.ts
+++ b/packages/manager/src/features/Linodes/constants.ts
@@ -29,3 +29,6 @@ export const ALERTS_BETA_MODE_BUTTON_TEXT = 'Switch to legacy Alerts';
 
 export const ALERTS_LEGACY_PROMPT =
   'Are you sure you want to save legacy Alerts?';
+
+export const ALERTS_BETA_PROMPT =
+  'Are you sure you want to save (Beta) Alerts?';


### PR DESCRIPTION
## Description 📝

Add tests to linode alerts edit page (/linodes/<linode id>/alerts) on when "Save Changes?" dialog should appear. @pmakode-akamai documented in https://jira.linode.com/browse/M3-10369 the conditions on when the dialog should and should not appear. 
In a region that supports alerts, the user will see the dialog if:

1. the UI defaults to legacy alerts (based on the 'alerts' attribute of the linode)
2. the user switches to beta mode
3. the user makes edits to the beta alerts
4. saves the changes

The user will NOT see the dialog if:
1. the UI defaults to beta alerts (based on the 'alerts' attribute of the linode)
2. the user switches to legacy mode
3. the user makes edits to the legacy alerts
4. saves the changes

## Changes  🔄

Added tests. Also replaced a string in one of the react components. This string was problematic bc it was padded w/ an extra space at the end, which made test assertions difficult.   

## How to test 🧪

pnpm run cy:run -s cypress/e2e/core/linodes/alerts-edit.spec.ts
 
<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

-->