### PR TITLE
fix: [DI-26674] - Update the capitalization logic in Show-Details 

### DIFF
--- a/packages/manager/.changeset/pr-12724-fixed-1755617276166.md
+++ b/packages/manager/.changeset/pr-12724-fixed-1755617276166.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+ACLP-Alerting: capitalization logic for Dimension Values in Show-details ([#12724](https://github.com/linode/manager/pull/12724))

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/RenderAlertsMetricsAndDimensions.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/RenderAlertsMetricsAndDimensions.tsx
@@ -10,7 +10,7 @@ import {
   metricOperatorTypeMap,
 } from '../constants';
 import { DisplayAlertDetailChips } from './DisplayAlertDetailChips';
-import { handleDimensionValue } from './utils';
+import { transformCommaSeperatedDimensionValues } from './utils';
 
 import type {
   AlertDefinitionMetricCriteria,
@@ -81,7 +81,7 @@ export const RenderAlertMetricsAndDimensions = React.memo(
                     dimensionLabel,
                     dimensionOperatorTypeMap[dimensionOperator],
                     transformationAllowedOperators.includes(dimensionOperator)
-                      ? handleDimensionValue(
+                      ? transformCommaSeperatedDimensionValues(
                           value,
                           serviceType,
                           dimensionFilterKey

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/RenderAlertsMetricsAndDimensions.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/RenderAlertsMetricsAndDimensions.tsx
@@ -3,7 +3,6 @@ import { GridLegacy } from '@mui/material';
 import React from 'react';
 
 import NullComponent from 'src/components/NullComponent';
-import { transformDimensionValue } from 'src/features/CloudPulse/Alerts/Utils/utils';
 
 import {
   aggregationTypeMap,
@@ -11,6 +10,7 @@ import {
   metricOperatorTypeMap,
 } from '../constants';
 import { DisplayAlertDetailChips } from './DisplayAlertDetailChips';
+import { handleDimensionValue } from './utils';
 
 import type {
   AlertDefinitionMetricCriteria,
@@ -30,6 +30,7 @@ interface AlertMetricAndDimensionsProp {
   serviceType: CloudPulseServiceType;
 }
 
+const transformationAllowedOperators = ['eq', 'neq', 'in'];
 export const RenderAlertMetricsAndDimensions = React.memo(
   (props: AlertMetricAndDimensionsProp) => {
     const { ruleCriteria, serviceType } = props;
@@ -79,11 +80,13 @@ export const RenderAlertMetricsAndDimensions = React.memo(
                   }) => [
                     dimensionLabel,
                     dimensionOperatorTypeMap[dimensionOperator],
-                    transformDimensionValue(
-                      serviceType,
-                      dimensionFilterKey,
-                      value
-                    ),
+                    transformationAllowedOperators.includes(dimensionOperator)
+                      ? handleDimensionValue(
+                          value,
+                          serviceType,
+                          dimensionFilterKey
+                        )
+                      : value,
                   ]
                 )}
               />

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/utils.test.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/utils.test.ts
@@ -1,31 +1,29 @@
 import { describe, expect, it } from 'vitest';
 
-import { transformDimensionValue } from '../Utils/utils';
-import { handleDimensionValue } from './utils';
-
-import type { CloudPulseServiceType } from '@linode/api-v4';
+import { transformCommaSeperatedDimensionValues } from './utils';
 
 describe('handleDimensionValueCapitalization', () => {
-  const serviceType: CloudPulseServiceType = 'linode';
-
   it('should transform a single value', () => {
-    const value = 'ipv4';
-    const expected = transformDimensionValue(serviceType, 'protocol', value);
+    const value = 'primary';
 
-    const result = handleDimensionValue(value, serviceType, 'protocol');
+    const result = transformCommaSeperatedDimensionValues(
+      value,
+      'dbaas',
+      'protocol'
+    );
 
-    expect(result).toBe(expected);
+    expect(result).toBe('Primary');
   });
 
   it('should transform multiple comma-separated values', () => {
-    const value = 'ipv4,ipv6';
-    const expected = value
-      .split(',')
-      .map((v) => transformDimensionValue(serviceType, 'protocol', v))
-      .join(', ');
+    const value = 'udp,tcp,http';
 
-    const result = handleDimensionValue(value, serviceType, 'protocol');
+    const result = transformCommaSeperatedDimensionValues(
+      value,
+      'nodebalancer',
+      'protocol'
+    );
 
-    expect(result).toBe(expected);
+    expect(result).toBe('UDP, TCP, HTTP');
   });
 });

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/utils.test.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/utils.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { transformDimensionValue } from '../Utils/utils';
+import { handleDimensionValue } from './utils';
+
+import type { CloudPulseServiceType } from '@linode/api-v4';
+
+describe('handleDimensionValueCapitalization', () => {
+  const serviceType: CloudPulseServiceType = 'linode';
+
+  it('should transform a single value', () => {
+    const value = 'ipv4';
+    const expected = transformDimensionValue(serviceType, 'protocol', value);
+
+    const result = handleDimensionValue(value, serviceType, 'protocol');
+
+    expect(result).toBe(expected);
+  });
+
+  it('should transform multiple comma-separated values', () => {
+    const value = 'ipv4,ipv6';
+    const expected = value
+      .split(',')
+      .map((v) => transformDimensionValue(serviceType, 'protocol', v))
+      .join(', ');
+
+    const result = handleDimensionValue(value, serviceType, 'protocol');
+
+    expect(result).toBe(expected);
+  });
+});

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/utils.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/utils.ts
@@ -7,7 +7,7 @@ import type { CloudPulseServiceType } from '@linode/api-v4';
  * @param dimensionLabel The dimnsion label used to determine the transformation logic.
  * @returns string value with proper capitalization based on the service type and dimension label.
  */
-export const handleDimensionValue = (
+export const transformCommaSeperatedDimensionValues = (
   value: string,
   serviceType: CloudPulseServiceType,
   dimensionLabel: string

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/utils.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/utils.ts
@@ -1,0 +1,22 @@
+import { transformDimensionValue } from '../Utils/utils';
+
+import type { CloudPulseServiceType } from '@linode/api-v4';
+/**
+ * @param value The dimension value to be transformed.
+ * @param serviceType The service type of the alert required for the transformation.
+ * @param dimensionLabel The dimnsion label used to determine the transformation logic.
+ * @returns string value with proper capitalization based on the service type and dimension label.
+ */
+export const handleDimensionValue = (
+  value: string,
+  serviceType: CloudPulseServiceType,
+  dimensionLabel: string
+) => {
+  // Split the value by commas and trim whitespace from each part
+  return value
+    .split(',')
+    .map((part) =>
+      transformDimensionValue(serviceType, dimensionLabel, part.trim())
+    )
+    .join(', ');
+};


### PR DESCRIPTION
## Description 📝
Update the capitalization logic in Show-details to handle the comma separated string values. 

## Changes  🔄

- Added a util `handleDimensionValue1 to split comma separated values and transform before joining 
- Unit tests for the util

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [x] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

26th August

## Preview 📷

**Include a screenshot `<img src="" />` or video `<video src="" />` of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: For changes requiring multiple steps to validate, prefer a video for clarity.

| Before  | After   |
| ------- | ------- |
| <img width="1164" height="1348" alt="image" src="https://github.com/user-attachments/assets/66f1fa94-4b1a-4ff1-8cdc-9e54985af4d1" /> |  <img width="1176" height="1392" alt="image" src="https://github.com/user-attachments/assets/4b8624b7-9ead-475f-a8f8-3e3716bcd464" /> |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- In DevCloud env, Under Monitor click on Alerts.
- Create a new alert with a dimension value with in operator selecting multiple values if there aren't any.
- In Alert Listing page, click on Show-details for the selected alert.

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] ...
- [ ] ...

### Verification steps

(How to verify changes)

- [ ] Comma separated Dimension Values are transformed individually as per the Transform Config 
- [ ] No transformation for the Values if the operator is `starts with` or `ends with`

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>