### PR TITLE
fix: [UIE-9111] - DBaaS - Database landing page shows error state after plans column is sorted.

### DIFF
--- a/packages/manager/.changeset/pr-12729-fixed-1755635540451.md
+++ b/packages/manager/.changeset/pr-12729-fixed-1755635540451.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+DBaaS Landing page shows Filter error state after sorting by "Plan" column in table ([#12729](https://github.com/linode/manager/pull/12729))

--- a/packages/manager/.changeset/pr-12729-fixed-1755635540451.md
+++ b/packages/manager/.changeset/pr-12729-fixed-1755635540451.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-DBaaS Landing page shows Filter error state after sorting by "Plan" column in table ([#12729](https://github.com/linode/manager/pull/12729))
+DBaaS Landing page shows filter error state after sorting by "Plan" column in table ([#12729](https://github.com/linode/manager/pull/12729))

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLandingTable.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLandingTable.tsx
@@ -118,10 +118,10 @@ const DatabaseLandingTable = ({
             </TableSortCell>
             {isNewDatabase && (
               <TableSortCell
-                active={orderBy === 'plan'}
+                active={orderBy === 'type'}
                 direction={order}
                 handleClick={handleOrderChange}
-                label="plan"
+                label="type"
               >
                 Plan
               </TableSortCell>


### PR DESCRIPTION
## Description 📝

This pull request fixes in issue in the DBaaS Landing page where the error state is displayed shortly after "Plan" column is sorted.

## Changes  🔄

List any change(s) relevant to the reviewer.

- Sort Cell for "Plan" column has been updated to provide `type` which changes what we provide to `orderBy` for X-Filter in the database instances request and should work with both variations of the call (new and legacy)
- The text displayed for this column header will continue to be "Plan". This is only an update to what what we provide to the backend call for the database list.

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [x] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

8/26/2025

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![legacy-databases-call-fails-after-plan-sort](https://github.com/user-attachments/assets/f8673e76-7e09-4591-ad1b-29320ffdd9f7)  | ![legacy-and-new-dataabase-cluster-calls-successful](https://github.com/user-attachments/assets/74d733d3-d352-497d-bbf6-dbc6e7db9cd1) |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- This has to be tested in an environment with the actual backend calls
- Have access to the Databases tab and landing page
- Have 1 more databases created so you can view the table

### Reproduction steps

(How to reproduce the issue, if applicable)

Note: You can differentiate between the legacy and new database instances calls via the `platform` field in X-Filter.
 * ie. `rdbms-legacy` vs `rdbms-default`

- [ ] Access the Databases tab to view the landing page
- [ ] In the table, click the "Plan" column header cell to sort it, then wait until the legacy call for databases is made (See Screenshots)
- [ ] See that the database instances call fails with a bad request and check X-Filter to see that `"orderBy": "plan"` is provided.
- [ ] See that the error state for the table is displayed with the message `Could not apply filter`

### Verification steps

(How to verify changes)

- [ ] Access the Databases tab to view the landing page
- [ ] In the table, click the "Plan" column header cell to sort it, then wait until the legacy call is made.
- [ ] View the calls and verify that X-Filter has `"orderBy": "type"` provided
- [ ] Verify that both variations of the call (new and legacy) are successful and you don't see the error state display.
- [ ] Verify that "Plan" is still shown as the text in the column header

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

-->