### PR TITLE
feat: [UIE-9120] - IAM RBAC: add the tooltips for linode configuration menu

### DIFF
--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigActionMenu.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigActionMenu.test.tsx
@@ -80,12 +80,12 @@ describe('ConfigActionMenu', () => {
     const deleteBtn = screen.getByTestId('Delete');
     expect(deleteBtn).toHaveAttribute('aria-disabled', 'true');
 
-    const tooltip = screen.getByLabelText(
-      "You don't have permission to perform this action"
+    const tooltips = screen.getAllByLabelText(
+      'You do not have permission to perform this action.'
     );
-    expect(tooltip).toBeInTheDocument();
-    fireEvent.click(tooltip);
-    expect(tooltip).toBeVisible();
+    expect(tooltips).toHaveLength(4);
+    fireEvent.click(tooltips[0]);
+    expect(tooltips[0]).toBeVisible();
   });
 
   it('should enable all actions menu if the user has permissions', async () => {

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigActionMenu.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigActionMenu.tsx
@@ -15,6 +15,8 @@ interface Props {
   onDelete: () => void;
   onEdit: () => void;
 }
+const NO_PERMISSION_TOOLTIP_TEXT =
+  'You do not have permission to perform this action.';
 
 export const ConfigActionMenu = (props: Props) => {
   const { config, linodeId, onBoot, onDelete, onEdit } = props;
@@ -28,20 +30,22 @@ export const ConfigActionMenu = (props: Props) => {
     isOpen
   );
 
-  const tooltip = !permissions.delete_linode
-    ? "You don't have permission to perform this action"
-    : undefined;
-
   const actions: Action[] = [
     {
       disabled: !permissions.reboot_linode,
       onClick: onBoot,
       title: 'Boot',
+      tooltip: !permissions.reboot_linode
+        ? NO_PERMISSION_TOOLTIP_TEXT
+        : undefined,
     },
     {
       disabled: !permissions.update_linode,
       onClick: onEdit,
       title: 'Edit',
+      tooltip: !permissions.update_linode
+        ? NO_PERMISSION_TOOLTIP_TEXT
+        : undefined,
     },
     {
       disabled: !permissions.clone_linode,
@@ -55,12 +59,17 @@ export const ConfigActionMenu = (props: Props) => {
         });
       },
       title: 'Clone',
+      tooltip: !permissions.clone_linode
+        ? NO_PERMISSION_TOOLTIP_TEXT
+        : undefined,
     },
     {
       disabled: !permissions.delete_linode,
       onClick: onDelete,
       title: 'Delete',
-      tooltip,
+      tooltip: !permissions.delete_linode
+        ? NO_PERMISSION_TOOLTIP_TEXT
+        : undefined,
     },
   ];
 


### PR DESCRIPTION
## Description 📝

Add tooltips for the action items in Linode Configuration

## Changes  🔄

List any change(s) relevant to the reviewer.

- Add tooltips for the action items in Linode Configuration.
- Update test

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [x] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

August 26th

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <img width="3024" height="1894" alt="image" src="https://github.com/user-attachments/assets/636b99b9-c2dc-49af-8796-6781164d39f0" /> | <img width="2894" height="1878" alt="image" src="https://github.com/user-attachments/assets/a3f9a429-c918-4884-801d-38dedd9335c1" /> |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- devcloud IAM account or local devenv setup or mock data (use the User Permissions presets)

### Verification steps

(How to verify changes)

- [ ]  Navigate to the Linode -> Configuration Tab
- [ ] All tooltips are visible if user doesn't have permission to perform any actions
- [ ] Tooltips are not visible if user has some permissions

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
