### PR TITLE
test: [M3-10501, M3-10477] - Use a mock region without maintenance policy capability when testing drop-down disabled state

### DIFF
--- a/packages/manager/cypress/e2e/core/linodes/maintenance-policy-region-support.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/maintenance-policy-region-support.spec.ts
@@ -131,8 +131,7 @@ describe('maintenance policy region support - Linode Details > Settings', () => 
     // We'll use a distributed region that doesn't have the 'Maintenance Policy' capability
     const linodeCreatePayload = createLinodeRequestFactory.build({
       label: randomLabel(),
-      region: 'us-den-1', // Denver, CO - distributed region that doesn't support maintenance policies
-      type: 'g6-nanode-edge-1', // Use the correct plan type for distributed regions
+      region: 'us-ord', // A region known not to support maintenance policies as of 8/20/2025.
     });
 
     cy.defer(() => createTestLinode(linodeCreatePayload)).then((linode) => {

--- a/packages/manager/cypress/support/intercepts/linodes.ts
+++ b/packages/manager/cypress/support/intercepts/linodes.ts
@@ -781,6 +781,25 @@ export const mockGetLinodeStats = (
 };
 
 /**
+ * Intercepts GET request to retrieve network stats for a Linode and mocks an error response.
+ *
+ * @param linodeId - ID of Linode for intercepted request.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetLinodeStatsError = (
+  linodeId: number,
+  errorMessage: string,
+  statusCode: number = 400
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'GET',
+    apiMatcher(`linode/instances/${linodeId}/stats`),
+    makeErrorResponse(errorMessage, statusCode)
+  );
+};
+
+/**
  * Intercepts PUT request to edit details of a linode
  *
  * @param linodeId - ID of Linode for intercepted request.


### PR DESCRIPTION
## Description 📝

This is a quick change to one of the tests in `maintenance-policy-region-support.spec.ts` to use a mocked region where the maintenance policy capability is absent. This allows the test to pass in CI (where Gecko regions aren't available) yet should remain stable as Maintenance Policy capabilities continue to roll out to regular regions.

I'm not planning to add a changeset to this as long as we're targeting the 8/26 release, but will add one if it misses it.

## Changes  🔄

- Create a Linode in `us-ord` instead of `us-den-1` when testing maintenance policy negative state

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [x] No customers / Not applicable

## Target release date 🗓️

8/26/2025 if possible, not the end of the world if it doesn't make it (we have a solid understanding of the test failure and can disregard it during release testing if necessary)

## How to test 🧪

```bash
pnpm cy:run -s "cypress/e2e/core/linodes/maintenance-policy-region-support.spec.ts"
```

If your test account already has Gecko enabled, this test will already be passing for you and should continue passing even with this change applied. We can rely on CI to confirm that it works when Gecko is not enabled.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

