### PR TITLE
upcoming: [DI-26793] - Legend row label shown as per group by order

### DIFF
--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.test.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.test.ts
@@ -70,6 +70,7 @@ describe('getLabelName method', () => {
     resources: [{ id: '123', label: 'linode-1' }],
     serviceType: 'linode',
     unit: '%',
+    groupBy: ['entity_id'],
   };
 
   it('returns resource label when all data is valid', () => {
@@ -121,6 +122,7 @@ it('test generateGraphData with metrics data', () => {
     status: 'success',
     unit: '%',
     serviceType: 'linode',
+    groupBy: ['entity_id'],
   });
 
   expect(result.areas[0].dataKey).toBe('linode-1');
@@ -148,6 +150,7 @@ describe('getDimensionName method', () => {
     serviceType: 'linode',
     metric: { entity_id: '123' },
     resources: [{ id: '123', label: 'linode-1' }],
+    groupBy: ['entity_id'],
   };
 
   it('returns resource label when all data is valid', () => {

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
@@ -30,6 +30,11 @@ import type { MetricsDisplayRow } from 'src/components/LineGraph/MetricsDisplay'
 
 export interface LabelNameOptionsProps {
   /**
+   * array of group by fields
+   */
+  groupBy: string[];
+
+  /**
    * Boolean to check if metric name should be hidden
    */
   hideMetricName?: boolean;
@@ -61,6 +66,11 @@ export interface LabelNameOptionsProps {
 }
 
 interface GraphDataOptionsProps {
+  /**
+   * array of group by fields
+   */
+  groupBy: string[];
+
   /**
    * label for the graph title
    */
@@ -121,6 +131,10 @@ interface MetricRequestProps {
 
 export interface DimensionNameProperties {
   /**
+   * array of group by fields
+   */
+  groupBy: string[];
+  /**
    * Boolean to check if metric name should be hidden
    */
   hideMetricName?: boolean;
@@ -168,7 +182,8 @@ interface GraphData {
  * @returns parameters which will be necessary to populate graph & legends
  */
 export const generateGraphData = (props: GraphDataOptionsProps): GraphData => {
-  const { label, metricsList, resources, serviceType, status, unit } = props;
+  const { label, metricsList, resources, serviceType, status, unit, groupBy } =
+    props;
   const legendRowsData: MetricsDisplayRow[] = [];
   const dimension: { [timestamp: number]: { [label: string]: number } } = {};
   const areas: AreaProps[] = [];
@@ -205,6 +220,7 @@ export const generateGraphData = (props: GraphDataOptionsProps): GraphData => {
           unit,
           hideMetricName,
           serviceType,
+          groupBy,
         };
         const labelName = getLabelName(labelOptions);
         const data = seriesDataFormatter(transformedData.values, start, end);
@@ -331,6 +347,7 @@ export const getLabelName = (props: LabelNameOptionsProps): string => {
     unit,
     hideMetricName = false,
     serviceType,
+    groupBy,
   } = props;
   // aggregated metric, where metric keys will be 0
   if (!Object.keys(metric).length) {
@@ -338,7 +355,13 @@ export const getLabelName = (props: LabelNameOptionsProps): string => {
     return `${label} (${unit})`;
   }
 
-  return getDimensionName({ metric, resources, hideMetricName, serviceType });
+  return getDimensionName({
+    metric,
+    resources,
+    hideMetricName,
+    serviceType,
+    groupBy,
+  });
 };
 
 /**
@@ -347,30 +370,53 @@ export const getLabelName = (props: LabelNameOptionsProps): string => {
  */
 // ... existing code ...
 export const getDimensionName = (props: DimensionNameProperties): string => {
-  const { metric, resources, hideMetricName = false, serviceType } = props;
-  return Object.entries(metric)
-    .map(([key, value]) => {
-      if (key === 'entity_id') {
-        return mapResourceIdToName(value, resources);
+  const {
+    metric,
+    resources,
+    hideMetricName = false,
+    serviceType,
+    groupBy,
+  } = props;
+  const labels: string[] = new Array(groupBy.length).fill('');
+  Object.entries(metric).forEach(([key, value]) => {
+    if (key === 'entity_id') {
+      const resourceName = mapResourceIdToName(value, resources);
+      const index = groupBy.indexOf(key);
+      if (index !== -1) {
+        labels[index] = resourceName;
+      } else {
+        labels.push(resourceName);
       }
+      return;
+    }
 
-      if (key === 'linode_id') {
-        return (
-          resources.find((resource) => resource.entities?.[value] !== undefined)
-            ?.entities?.[value] ?? value
-        );
+    if (key === 'linode_id') {
+      const linodeLabel =
+        resources.find((resource) => resource.entities?.[value] !== undefined)
+          ?.entities?.[value] ?? value;
+      const index = groupBy.indexOf('linode_id');
+      if (index !== -1) {
+        labels[index] = linodeLabel;
+      } else {
+        labels.push(linodeLabel);
       }
+      return;
+    }
 
-      if (key === 'metric_name' && hideMetricName) {
-        return '';
-      }
+    if (key === 'metric_name' && hideMetricName) {
+      return;
+    }
 
-      return (
-        DIMENSION_TRANSFORM_CONFIG[serviceType]?.[key]?.(value) ?? value ?? ''
-      );
-    })
-    .filter(Boolean)
-    .join(' | ');
+    const dimensionValue =
+      DIMENSION_TRANSFORM_CONFIG[serviceType]?.[key]?.(value) ?? value ?? '';
+    const index = groupBy.indexOf(key);
+    if (index !== -1) {
+      labels[index] = dimensionValue;
+    } else {
+      labels.push(dimensionValue);
+    }
+  });
+  return labels.filter(Boolean).join(' | ');
 };
 
 /**

--- a/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.tsx
+++ b/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.tsx
@@ -277,6 +277,7 @@ export const CloudPulseWidget = (props: CloudPulseWidgetProperties) => {
       status,
       unit,
       serviceType,
+      groupBy: widgetProp.group_by,
     });
 
     data = generatedData.dimensions;


### PR DESCRIPTION
## Description 📝

Updated the logic in cloudpulse widget utils to show order of legend row label separated by pipe based on the group by order.

## Changes  🔄

List any change(s) relevant to the reviewer.

1. Updated CloudPulseWidgetUtils file to build legend row label based on group by order

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

9th September

## Preview 📷

**Include a screenshot `<img src="" />` or video `<video src="" />` of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: For changes requiring multiple steps to validate, prefer a video for clarity.

| Before  | After   |
| ------- | ------- |
|![Screenshot 2025-08-21 at 11 04 32 AM](https://github.com/user-attachments/assets/5f8650ba-43b5-4856-bae6-845ac0b766b4)|![Screenshot 2025-08-21 at 11 05 19 AM](https://github.com/user-attachments/assets/54d0c79d-c01c-4ff7-b6ea-bd1cf27f48ef)
|
## How to test 🧪

1. Switch to mock user and go to metrics tab
2. Select linode dashboard and all the required filters
3. In CloudPulseWidget.tsx file at line 280, change widgetProp.groupBy with ['linode_id', 'entity_id']
4. You'll see the order or legend row label values is different with this group by value compare to previous group by value

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>