### PR TITLE
[DI-26971] - Add no region info msg for nodebalancer and firewall

### DIFF
--- a/packages/manager/src/features/CloudPulse/Utils/constants.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/constants.ts
@@ -93,6 +93,13 @@ export const PLACEHOLDER_TEXT: Record<string, string> = {
   [INTERFACE_ID]: INTERFACE_IDS_PLACEHOLDER_TEXT,
 };
 
+export const NO_REGION_MESSAGE: Record<string, string> = {
+  dbaas: 'No Database Clusters configured in any Regions.',
+  linode: 'No Linodes configured in any Regions.',
+  nodebalancer: 'No NodeBalancers configured in any Regions.',
+  firewall: 'No Firewalls configured in any Linode Regions.',
+};
+
 export const ORDER_BY_LABLE_ASC = {
   '+order': 'asc',
   '+order_by': 'label',

--- a/packages/manager/src/features/CloudPulse/Utils/constants.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/constants.ts
@@ -94,10 +94,10 @@ export const PLACEHOLDER_TEXT: Record<string, string> = {
 };
 
 export const NO_REGION_MESSAGE: Record<string, string> = {
-  dbaas: 'No Database Clusters configured in any Regions.',
-  linode: 'No Linodes configured in any Regions.',
-  nodebalancer: 'No Nodebalancers configured in any Regions.',
-  firewall: 'No Firewalls configured in any Linode Regions.',
+  dbaas: 'No database clusters configured in any regions.',
+  linode: 'No Linodes configured in any regions.',
+  nodebalancer: 'No NodeBalancers configured in any regions.',
+  firewall: 'No firewalls configured in any Linode regions.',
 };
 
 export const ORDER_BY_LABLE_ASC = {

--- a/packages/manager/src/features/CloudPulse/Utils/constants.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/constants.ts
@@ -96,7 +96,7 @@ export const PLACEHOLDER_TEXT: Record<string, string> = {
 export const NO_REGION_MESSAGE: Record<string, string> = {
   dbaas: 'No Database Clusters configured in any Regions.',
   linode: 'No Linodes configured in any Regions.',
-  nodebalancer: 'No NodeBalancers configured in any Regions.',
+  nodebalancer: 'No Nodebalancers configured in any Regions.',
   firewall: 'No Firewalls configured in any Linode Regions.',
 };
 

--- a/packages/manager/src/features/CloudPulse/Utils/constants.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/constants.ts
@@ -78,9 +78,12 @@ export const INTERFACE_IDS_LIMIT_ERROR_MESSAGE =
   'Enter a maximum of 15 interface ID numbers';
 
 export const INTERFACE_IDS_PLACEHOLDER_TEXT = 'e.g., 1234,5678';
+
 export const NO_REGION_MESSAGE: Record<string, string> = {
   dbaas: 'No database clusters configured in any regions.',
-  linode: 'No linodes configured in any regions.',
+  linode: 'No Linodes configured in any regions.',
+  nodebalancer: 'No NodeBalancers configured in any regions.',
+  firewall: 'No firewalls configured in any Linode regions.',
 };
 
 export const HELPER_TEXT: Record<string, string> = {
@@ -91,13 +94,6 @@ export const HELPER_TEXT: Record<string, string> = {
 export const PLACEHOLDER_TEXT: Record<string, string> = {
   [PORT]: PORTS_PLACEHOLDER_TEXT,
   [INTERFACE_ID]: INTERFACE_IDS_PLACEHOLDER_TEXT,
-};
-
-export const NO_REGION_MESSAGE: Record<string, string> = {
-  dbaas: 'No database clusters configured in any regions.',
-  linode: 'No Linodes configured in any regions.',
-  nodebalancer: 'No NodeBalancers configured in any regions.',
-  firewall: 'No firewalls configured in any Linode regions.',
 };
 
 export const ORDER_BY_LABLE_ASC = {

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.test.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.test.tsx
@@ -1,5 +1,9 @@
 import { capabilityServiceTypeMapping } from '@linode/api-v4';
-import { linodeFactory, regionFactory } from '@linode/utilities';
+import {
+  linodeFactory,
+  nodeBalancerFactory,
+  regionFactory,
+} from '@linode/utilities';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
@@ -7,6 +11,7 @@ import * as React from 'react';
 import { dashboardFactory, databaseInstanceFactory } from 'src/factories';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
+import { NO_REGION_MESSAGE } from '../Utils/constants';
 import { CloudPulseRegionSelect } from './CloudPulseRegionSelect';
 
 import type { CloudPulseRegionSelectProps } from './CloudPulseRegionSelect';
@@ -207,5 +212,77 @@ describe('CloudPulseRegionSelect', () => {
         name: 'US, Miami, FL (us-mia)',
       })
     ).toBeNull();
+  });
+
+  it('should render a Region Select component with correct info message when no regions are available for dbaas service type', async () => {
+    const user = userEvent.setup();
+    queryMocks.useResourcesQuery.mockReturnValue({
+      data: databaseInstanceFactory.buildList(3, {
+        region: 'ap-west',
+      }),
+      isError: false,
+      isLoading: false,
+    });
+    renderWithTheme(
+      <CloudPulseRegionSelect
+        {...props}
+        selectedDashboard={dashboardFactory.build({ service_type: 'dbaas' })}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    expect(screen.getByText(NO_REGION_MESSAGE['dbaas'])).toBeVisible();
+  });
+
+  it('should render a Region Select component with correct info message when no regions are available for linode service type', async () => {
+    const user = userEvent.setup();
+    queryMocks.useResourcesQuery.mockReturnValue({
+      data: linodeFactory.buildList(3, {
+        region: 'ap-west',
+      }),
+      isError: false,
+      isLoading: false,
+    });
+    renderWithTheme(
+      <CloudPulseRegionSelect
+        {...props}
+        selectedDashboard={dashboardFactory.build({ service_type: 'linode' })}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    expect(screen.getByText(NO_REGION_MESSAGE['linode'])).toBeVisible();
+  });
+
+  it('should render a Region Select component with correct info message when no regions are available for nodebalancer service type', async () => {
+    const user = userEvent.setup();
+    queryMocks.useResourcesQuery.mockReturnValue({
+      data: nodeBalancerFactory.buildList(3, {
+        region: 'ap-west',
+      }),
+      isError: false,
+      isLoading: false,
+    });
+    renderWithTheme(
+      <CloudPulseRegionSelect
+        {...props}
+        selectedDashboard={dashboardFactory.build({
+          service_type: 'nodebalancer',
+        })}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    expect(screen.getByText(NO_REGION_MESSAGE['nodebalancer'])).toBeVisible();
+  });
+
+  it('should render a Region Select component with correct info message when no regions are available for firewall service type', async () => {
+    const user = userEvent.setup();
+    // There are no aclp supported regions for firewall service type as returned by useRegionsQuery above
+    renderWithTheme(
+      <CloudPulseRegionSelect
+        {...props}
+        selectedDashboard={dashboardFactory.build({ service_type: 'firewall' })}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    expect(screen.getByText(NO_REGION_MESSAGE['firewall'])).toBeVisible();
   });
 });


### PR DESCRIPTION
## Description 📝
Add no region info msg for nodebalancer and firewall.

## Changes  🔄

- Add 'no region info' message for nodebalancer and firewall service type and update for linode and dbaas service types.
- Add unit tests.

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️
9 Sept 2025

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <img width="2534" height="774" alt="image" src="https://github.com/user-attachments/assets/7db38280-408f-4a84-8ef8-3a7bf4f0f7b3" /> | <img width="2526" height="772" alt="image" src="https://github.com/user-attachments/assets/3f13a96b-aeae-4fe1-bab9-dc8acb39b249" /> |
| <img width="2580" height="674" alt="image" src="https://github.com/user-attachments/assets/8cd83494-689a-4be0-b631-74a10fa05378" /> | <img width="2534" height="576" alt="image" src="https://github.com/user-attachments/assets/482ee0e3-bfe3-47d5-a1d0-d77c7b305579" /> |
| <img width="2550" height="764" alt="image" src="https://github.com/user-attachments/assets/3f743a63-c67a-431b-8b57-11c1ec48985b" /> | <img width="2528" height="734" alt="image" src="https://github.com/user-attachments/assets/0913b774-e2db-4597-b9a4-3dee6e77b855" /> |
| <img width="2536" height="586" alt="image" src="https://github.com/user-attachments/assets/c5182d52-64e8-4934-b499-686d35541dc6" /> | <img width="2534" height="570" alt="image" src="https://github.com/user-attachments/assets/1051f914-c719-447c-944d-3cfc57416282" /> |

refer..
<img width="2104" height="276" alt="image" src="https://github.com/user-attachments/assets/58870eca-e4c6-4a31-a79b-ea9213db5c20" />

## How to test 🧪

### Verification steps

- Navigate to /metrics tab.
- Go to mocks, one by one try to select region for each service type, the region info message will be shown if there are no available regions in region-select dropdown. If there is a service with available regions in mocks, switch to dev env and check the 'no region info' message for that service there.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>