### PR TITLE
tests [M3-10433]: Test for empty string in numeric input validation

### DIFF
--- a/packages/manager/cypress/e2e/core/linodes/alerts-edit.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/alerts-edit.spec.ts
@@ -621,8 +621,14 @@ describe('region disables alerts. beta alerts not available regardless of linode
     cy.get('[data-reach-tab-panels]')
       .should('be.visible')
       .within(() => {
-        // no errors on page load
+        // no errors on page load, and all toggle buttons are enabled
         cy.get('p[data-qa-textfield-error-text]').should('not.exist');
+        ui.toggle.find().each(($toggle) => {
+          cy.wrap($toggle)
+            .should('have.attr', 'data-qa-toggle', 'true')
+            .should('be.visible')
+            .should('be.enabled');
+        });
         cy.get('input[data-testid="textfield-input"]').each(($numericInput) => {
           cy.wrap($numericInput).clear();
           cy.wrap($numericInput).blur();
@@ -632,6 +638,14 @@ describe('region disables alerts. beta alerts not available regardless of linode
             .then(($err) => {
               expect($err).to.contain('is required.');
             });
+          // error message does not disable adjacent toggle button
+          // difficult to find closest toggle btn, so test them all
+          ui.toggle.find().each(($toggle) => {
+            cy.wrap($toggle)
+              .should('have.attr', 'data-qa-toggle', 'true')
+              .should('be.visible')
+              .should('be.enabled');
+          });
           cy.wrap($numericInput).click();
           cy.wrap($numericInput).type('1');
           // error is removed


### PR DESCRIPTION
## Description 📝

Add test for validation workflow in numeric inputs in the /linodes/<linode id>/alerts page. This test is to verify the bugfix for https://jira.linode.com/browse/M3-10286. This jira ticket also contains videos demonstrating how clearing the numeric input value disabled the toggle button and the numeric input. 

## Changes  🔄

Additional test for state of the form when validation error appears when the entire value in the numeric input is selected and deleted (or the characters are individually removed by backspacing). When the numeric input value is empty, a validation error message should appear, but the toggle button should not be disabled.

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [x] No customers / Not applicable

## How to test 🧪

pnpm run cy:run -s cypress/e2e/core/linodes/alerts-edit.spec.ts

### Reproduction steps

Navigate to /linodes/<linode id>/alerts. Select the entire value for one of the numeric inputs. Hit delete. If the bug is properly fixed, then the error msg should appear but both the toggle button and the numeric inputs should remain enabled. 

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

-->