### PR TITLE
fix: [DI-26469] - TextField character limit validations in Alerts and Metrics

### DIFF
--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterValue/ValueSchemas.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterValue/ValueSchemas.ts
@@ -6,7 +6,6 @@ import {
   PORTS_HELPER_TEXT,
   PORTS_LEADING_COMMA_ERROR_MESSAGE,
   PORTS_LEADING_ZERO_ERROR_MESSAGE,
-  PORTS_LIMIT_ERROR_MESSAGE,
   PORTS_RANGE_ERROR_MESSAGE,
 } from 'src/features/CloudPulse/Utils/constants';
 
@@ -19,16 +18,16 @@ import {
   PORTS_TRAILING_COMMA_ERROR_MESSAGE,
 } from '../../../constants';
 
+const LENGTH_ERROR_MESSAGE = 'Value must be 100 characters or less.';
 const fieldErrorMessage = 'This field is required.';
 const DECIMAL_PORT_REGEX = /^[1-9]\d{0,4}$/;
 const LEADING_ZERO_PORT_REGEX = /^0\d+/;
 const CONFIG_NUMBER_REGEX = /^\d+$/;
 
 // Validation schema for a single input port
-const singlePortSchema = string().test(
-  'validate-single-port',
-  PORT_HELPER_TEXT,
-  function (value) {
+const singlePortSchema = string()
+  .max(100, LENGTH_ERROR_MESSAGE)
+  .test('validate-single-port', PORT_HELPER_TEXT, function (value) {
     if (!value || typeof value !== 'string') {
       return this.createError({ message: fieldErrorMessage });
     }
@@ -38,7 +37,6 @@ const singlePortSchema = string().test(
         message: PORTS_LEADING_ZERO_ERROR_MESSAGE,
       });
     }
-
     if (!DECIMAL_PORT_REGEX.test(value)) {
       return this.createError({ message: PORTS_RANGE_ERROR_MESSAGE });
     }
@@ -48,14 +46,12 @@ const singlePortSchema = string().test(
     }
 
     return true;
-  }
-);
+  });
 
 // Validation schema for a multiple comma-separated ports
-const commaSeparatedPortListSchema = string().test(
-  'validate-port-list',
-  PORTS_HELPER_TEXT,
-  function (value) {
+const commaSeparatedPortListSchema = string()
+  .max(100, LENGTH_ERROR_MESSAGE)
+  .test('validate-port-list', PORTS_HELPER_TEXT, function (value) {
     if (!value || typeof value !== 'string') {
       return this.createError({ message: fieldErrorMessage });
     }
@@ -87,11 +83,6 @@ const commaSeparatedPortListSchema = string().test(
 
     const ports = rawSegments.map((p) => p.trim());
 
-    if (ports.length > 15) {
-      return this.createError({
-        message: PORTS_LIMIT_ERROR_MESSAGE,
-      });
-    }
     for (const port of ports) {
       const trimmedPort = port.trim();
 
@@ -111,10 +102,9 @@ const commaSeparatedPortListSchema = string().test(
     }
 
     return true;
-  }
-);
+  });
 const singleConfigSchema = string()
-  .max(100, 'Value must be 100 characters or less.')
+  .max(100, LENGTH_ERROR_MESSAGE)
   .test(
     'validate-single-config-schema',
     CONFIG_ERROR_MESSAGE,
@@ -131,7 +121,7 @@ const singleConfigSchema = string()
   );
 
 const multipleConfigSchema = string()
-  .max(100, 'Value must be 100 characters or less.')
+  .max(100, LENGTH_ERROR_MESSAGE)
   .test(
     'validate-multi-config-schema',
     CONFIGS_ERROR_MESSAGE,
@@ -204,6 +194,8 @@ export const getDimensionFilterValueSchema = ({
       operator === 'in' ? multipleConfigSchema : singleConfigSchema;
     return configSchema.concat(baseValueSchema);
   }
-
+  if (['endswith', 'startswith'].includes(operator)) {
+    return baseValueSchema.concat(string().max(100, LENGTH_ERROR_MESSAGE));
+  }
   return baseValueSchema;
 };

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterValue/constants.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterValue/constants.ts
@@ -148,12 +148,16 @@ export const valueFieldConfig: ValueFieldConfigMap = {
     eq_neq: {
       type: 'textfield',
       inputType: 'number',
+      min: 0,
+      max: Number.MAX_SAFE_INTEGER,
       placeholder: CONFIG_ID_PLACEHOLDER_TEXT,
       helperText: CONFIG_ERROR_MESSAGE,
     },
     startswith_endswith: {
       type: 'textfield',
       inputType: 'number',
+      min: 0,
+      max: Number.MAX_SAFE_INTEGER,
       placeholder: CONFIG_ID_PLACEHOLDER_TEXT,
       helperText: CONFIG_ERROR_MESSAGE,
     },

--- a/packages/manager/src/features/CloudPulse/Utils/constants.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/constants.ts
@@ -58,7 +58,8 @@ export const PORTS_CONSECUTIVE_COMMAS_ERROR_MESSAGE =
 export const PORTS_LEADING_COMMA_ERROR_MESSAGE =
   'First character must be an integer.';
 
-export const PORTS_LIMIT_ERROR_MESSAGE = 'Enter a maximum of 15 port numbers';
+export const PORTS_LIMIT_ERROR_MESSAGE =
+  'Port list must be 100 characters or less.';
 
 export const PORTS_PLACEHOLDER_TEXT = 'e.g., 80,443,3000';
 
@@ -75,7 +76,7 @@ export const INTERFACE_IDS_LEADING_COMMA_ERROR_MESSAGE =
   'First character must be an integer.';
 
 export const INTERFACE_IDS_LIMIT_ERROR_MESSAGE =
-  'Enter a maximum of 15 interface ID numbers';
+  'Interface IDs list must be 100 characters or less.';
 
 export const INTERFACE_IDS_PLACEHOLDER_TEXT = 'e.g., 1234,5678';
 

--- a/packages/manager/src/features/CloudPulse/Utils/utils.test.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/utils.test.ts
@@ -64,10 +64,17 @@ describe('arePortsValid', () => {
     expect(arePortsValid('abc')).toBe(PORTS_ERROR_MESSAGE);
   });
 
-  it('should return invalid for more than 15 ports', () => {
-    const ports = Array.from({ length: 16 }, (_, i) => i + 1).join(',');
-    const result = arePortsValid(ports);
-    expect(result).toBe(PORTS_LIMIT_ERROR_MESSAGE);
+  it('should return invalid for input length more than 100 characters', () => {
+    expect(
+      arePortsValid(
+        '12345,23456,34567,45678,56789,123,456,789,1111,2222,3333,4444,5555,6666,7777,8888,9999,12,34,56,1055'
+      )
+    ).toBe(undefined);
+    expect(
+      arePortsValid(
+        '12345,23456,34567,45678,56789,123,456,789,1111,2222,3333,4444,5555,6666,7777,8888,9999,12,34,56,10455'
+      )
+    ).toBe(PORTS_LIMIT_ERROR_MESSAGE);
   });
 });
 
@@ -93,10 +100,17 @@ describe('areValidInterfaceIds', () => {
     expect(areValidInterfaceIds('abc')).toBe(INTERFACE_IDS_ERROR_MESSAGE);
   });
 
-  it('should return invalid for more than 15 interface ids', () => {
-    const interfaceIds = Array.from({ length: 16 }, (_, i) => i + 1).join(',');
-    const result = areValidInterfaceIds(interfaceIds);
-    expect(result).toBe(INTERFACE_IDS_LIMIT_ERROR_MESSAGE);
+  it('should return invalid for input length more than 100 characters', () => {
+    expect(
+      areValidInterfaceIds(
+        '12345,23456,34567,45678,56789,123,456,789,1111,2222,3333,4444,5555,6666,7777,8888,9999,12,34,56,1455'
+      )
+    ).toBe(undefined);
+    expect(
+      areValidInterfaceIds(
+        '12345,23456,34567,45678,56789,123,456,789,1111,2222,3333,4444,5555,6666,7777,8888,9999,12,34,56,14055'
+      )
+    ).toBe(INTERFACE_IDS_LIMIT_ERROR_MESSAGE);
   });
 });
 

--- a/packages/manager/src/features/CloudPulse/Utils/utils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/utils.ts
@@ -305,6 +305,10 @@ export const arePortsValid = (ports: string): string | undefined => {
     return undefined;
   }
 
+  if (ports.length > 100) {
+    return PORTS_LIMIT_ERROR_MESSAGE;
+  }
+
   if (ports.startsWith(',')) {
     return PORTS_LEADING_COMMA_ERROR_MESSAGE;
   }
@@ -318,18 +322,12 @@ export const arePortsValid = (ports: string): string | undefined => {
   }
 
   const portList = ports.split(',');
-  let portLimitCount = 0;
 
   for (const port of portList) {
     const result = isValidPort(port);
     if (result !== undefined) {
       return result;
     }
-    portLimitCount++;
-  }
-
-  if (portLimitCount > 15) {
-    return PORTS_LIMIT_ERROR_MESSAGE;
   }
 
   return undefined;
@@ -347,6 +345,10 @@ export const areValidInterfaceIds = (
     return undefined;
   }
 
+  if (interfaceIds.length > 100) {
+    return INTERFACE_IDS_LIMIT_ERROR_MESSAGE;
+  }
+
   if (interfaceIds.startsWith(',')) {
     return INTERFACE_IDS_LEADING_COMMA_ERROR_MESSAGE;
   }
@@ -356,13 +358,6 @@ export const areValidInterfaceIds = (
   }
   if (!/^[\d,]+$/.test(interfaceIds)) {
     return INTERFACE_IDS_ERROR_MESSAGE;
-  }
-
-  const interfaceIdList = interfaceIds.split(',');
-  const interfaceIdLimitCount = interfaceIdList.length;
-
-  if (interfaceIdLimitCount > 15) {
-    return INTERFACE_IDS_LIMIT_ERROR_MESSAGE;
   }
 
   return undefined;


### PR DESCRIPTION
## Description 📝
Enforcing validation on Textfield components to have a 100 characters limit

## Changes  🔄
- Add `max` validation test for Port and Config filter schemas in Alerts
- Add `max` validation test when operators are `starts_with` and `ends_with` in Alerts
- Replace the 15 ports/interface IDs  limit with 100 characters limit in Metrics
- Replace the Ports/Interface IDs limit error message in Metrics
- Relevant UT changes

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [x] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️
9th Sept

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <img width="2382" height="1052" alt="image" src="https://github.com/user-attachments/assets/cb5b0274-0050-4a06-a128-18e9b191c67e" />| <img width="2374" height="1066" alt="image" src="https://github.com/user-attachments/assets/52aa7fa8-13d9-4142-a1b2-dbc9b7cc8f84" />|
|<img width="2514" height="542" alt="image" src="https://github.com/user-attachments/assets/591581d2-ef11-46f4-8d31-5762e1718087" />|<img width="2480" height="756" alt="image" src="https://github.com/user-attachments/assets/befe8830-8af9-4aa1-9777-9651283becb2" />|
|<img width="2510" height="540" alt="image" src="https://github.com/user-attachments/assets/035664df-bafd-4afd-84ce-dca091d64e63" />|<img width="2508" height="548" alt="image" src="https://github.com/user-attachments/assets/dfab8ec8-c4cb-4413-9995-8a06978d4791" />|
## How to test 🧪

### Prerequisites

(How to setup test environment)

#### Metrics
- Under Monitor, choose Metrics
- Choose Cloud Firewall Dashboard to test the Interface ID limit changes
- Choose Nodebalancer Dashboard to test the Ports limit changes

#### Alerts
- Under Monitor, choose Alerts. Click on Create Alert or choose to Edit any existing alert
- Choose Firewall service 
    -  After choosing Metric Data Field and click on `Add Dimension Filter`
    - Choose Interface ID as the Dimension Filter 
    - For any operator the Value component should be a textfield and should validate the 100 character limit
- Choose Nodebalancer service
    - After choosing Metric Data Field and click on `Add Dimension Filter`
    - Choose Port as the Dimension Filter 
    - For any operator the Value component should be a textfield and should validate the 100 character limit
- Choose any service
    - After choosing Metric Data Field and click on `Add Dimension Filter`
    - Choose any Dimension Filter
    - For `Starts with` and `Ends with` operator the Value component should be a textfield and should validate the 100 character limit

### Verification steps

Verify that the 100 character limit validation is enforced in:
- [ ] Port Optional Filter in Metrics(Nodebalancer service)
- [ ] Interface ID Optional Filter in Metrics (Cloud Firewall service)
- [ ] Port Dimension Filter in Alerts(Nodebalancer service)
- [ ] Interface ID Dimension Filter in Alerts(Firewall service)
- [ ] Any Dimension Filter in Alerts with `Starts with`, `Ends with` operator (any service)

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>