### PR TITLE
feat: [UIE-9150] - IAM RBAC: add a notification banner for Account Settings if user doesn't have permission

### DIFF
--- a/packages/manager/.changeset/pr-12774-added-1756288318362.md
+++ b/packages/manager/.changeset/pr-12774-added-1756288318362.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Add a notification banner for Account Settings if user doesn't have permission to see ([#12774](https://github.com/linode/manager/pull/12774))

--- a/packages/manager/cypress/e2e/core/account/account-cancellation.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/account-cancellation.spec.ts
@@ -178,50 +178,14 @@ describe('Account cancellation', () => {
     mockGetAccount(mockAccount).as('getAccount');
     mockGetProfile(mockProfile).as('getProfile');
     mockGetProfileGrants(mockGrants).as('getGrants');
-    mockCancelAccountError('Unauthorized', 403).as('cancelAccount');
 
-    // Navigate to Account Settings page, click "Close Account" button.
     cy.visitWithLogin('/account/settings');
     cy.wait(['@getAccount', '@getProfile', '@getGrants']);
 
-    cy.findByTestId('close-account')
-      .should('be.visible')
-      .within(() => {
-        cy.findByTestId('close-account-button')
-          .should('be.visible')
-          .should('be.enabled')
-          .click();
-      });
-
-    // Fill out cancellation dialog and attempt submission.
-    ui.dialog
-      .findByTitle(cancellationDialogTitle)
-      .should('be.visible')
-      .within(() => {
-        // Check both boxes but verify submit remains disabled without email
-        cy.get('[data-qa-checkbox="deleteAccountServices"]').click();
-        cy.get('[data-qa-checkbox="deleteAccountUsers"]').click();
-
-        ui.button
-          .findByTitle('Close Account')
-          .should('be.visible')
-          .should('be.disabled');
-
-        cy.findByLabelText(`Enter your email address (${mockProfile.email})`)
-          .should('be.visible')
-          .should('be.enabled')
-          .type(mockProfile.email);
-
-        ui.button
-          .findByTitle('Close Account')
-          .should('be.visible')
-          .should('be.enabled')
-          .click();
-
-        // Confirm that API unauthorized error message is displayed.
-        cy.wait('@cancelAccount');
-        cy.findByText('Unauthorized').should('be.visible');
-      });
+    cy.findByText(
+      "You don't have permissions to edit this Account. Please contact your account administrator to request the necessary permissions.",
+      { exact: false }
+    ).should('be.visible');
   });
 });
 

--- a/packages/manager/cypress/e2e/core/account/account-linode-managed.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/account-linode-managed.spec.ts
@@ -120,31 +120,10 @@ describe('Account Linode Managed', () => {
     visitUrlWithManagedDisabled('/account/settings');
     cy.wait(['@getAccount', '@getProfile', '@getGrants']);
 
-    ui.button
-      .findByTitle('Add Linode Managed')
-      .should('be.visible')
-      .should('be.enabled')
-      .click();
-
-    ui.dialog
-      .findByTitle('Just to confirm...')
-      .should('be.visible')
-      .within(() => {
-        cy.get('h6')
-          .invoke('text')
-          .then((text) => {
-            expect(text.trim()).to.equal(linodeEnabledMessageText(0));
-          });
-        // Confirm that submit button is enabled.
-        ui.button
-          .findByTitle('Add Linode Managed')
-          .should('be.visible')
-          .should('be.enabled')
-          .click();
-        cy.wait('@enableLinodeManaged');
-        // Confirm that Cloud Manager displays a notice about Linode managed is unauthorized.
-        cy.findByText(errorMessage, { exact: false }).should('be.visible');
-      });
+    cy.findByText(
+      "You don't have permissions to edit this Account. Please contact your account administrator to request the necessary permissions.",
+      { exact: false }
+    ).should('be.visible');
   });
 
   /*


### PR DESCRIPTION
## Description 📝

Add a notification banner if user doesn't have a permission to view this page

## Changes  🔄

List any change(s) relevant to the reviewer.

- Show Account Settings if user has view_account_settings permission.

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [x] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

9/9

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <img width="3292" height="1288" alt="image" src="https://github.com/user-attachments/assets/853237dc-56cb-4492-a0f6-7824e2e4a014" /> | <img width="3320" height="1404" alt="image" src="https://github.com/user-attachments/assets/27344ca8-79cd-4a6f-8729-91c56052a814" /> |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- devcloud IAM account or local devenv setup or mock data (use the User Permissions presets)

- Permission to check: `view_account_settings`

### Verification steps

(How to verify changes)

- [ ] Confirm that the Settings is visible when user has view_account_settings permission.


<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>