### PR TITLE
feat: [M3-10378] - Show Node Pool firewalls in Node Pool footers

### DIFF
--- a/packages/manager/.changeset/pr-12779-added-1756330614474.md
+++ b/packages/manager/.changeset/pr-12779-added-1756330614474.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Linked Node Pool firewall in Node Pool footer for LKE-E clusters ([#12779](https://github.com/linode/manager/pull/12779))

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeEntityDetailFooter.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeEntityDetailFooter.tsx
@@ -158,7 +158,9 @@ export const KubeEntityDetailFooter = React.memo((props: FooterProps) => {
                 </Link>
                 &nbsp;
                 {vpcId && vpc?.label && (
-                  <CopyTooltip copyableText text={`(ID: ${String(vpcId)})`} />
+                  <span>
+                    (ID: <CopyTooltip copyableText text={String(vpcId)} />)
+                  </span>
                 )}
               </StyledListItem>
             )}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeEntityDetailFooter.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeEntityDetailFooter.tsx
@@ -157,11 +157,8 @@ export const KubeEntityDetailFooter = React.memo((props: FooterProps) => {
                   {vpc?.label ?? `${vpcId}`}
                 </Link>
                 &nbsp;
-                {vpcId && (
-                  <CopyTooltip
-                    copyableText
-                    text={vpc?.label ? `(ID: ${String(vpcId)})` : String(vpcId)}
-                  />
+                {vpcId && vpc?.label && (
+                  <CopyTooltip copyableText text={`(ID: ${String(vpcId)})`} />
                 )}
               </StyledListItem>
             )}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeEntityDetailFooter.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeEntityDetailFooter.tsx
@@ -6,6 +6,7 @@ import { useTheme } from '@mui/material/styles';
 import { enqueueSnackbar } from 'notistack';
 import * as React from 'react';
 
+import { CopyTooltip } from 'src/components/CopyTooltip/CopyTooltip';
 import { Link } from 'src/components/Link';
 import { TagCell } from 'src/components/TagCell/TagCell';
 import {
@@ -140,7 +141,7 @@ export const KubeEntityDetailFooter = React.memo((props: FooterProps) => {
           >
             <StyledListItem sx={{ ...sxListItemFirstChild }}>
               <StyledLabelBox component="span">Cluster ID:</StyledLabelBox>{' '}
-              {clusterId}
+              <CopyTooltip copyableText text={String(clusterId)} />
             </StyledListItem>
             {isLkeEnterprisePhase2FeatureEnabled && vpc && (
               <StyledListItem
@@ -156,7 +157,12 @@ export const KubeEntityDetailFooter = React.memo((props: FooterProps) => {
                   {vpc?.label ?? `${vpcId}`}
                 </Link>
                 &nbsp;
-                {vpcId && vpc?.label ? `(ID: ${vpcId})` : undefined}
+                {vpcId && (
+                  <CopyTooltip
+                    copyableText
+                    text={vpc?.label ? `(ID: ${String(vpcId)})` : String(vpcId)}
+                  />
+                )}
               </StyledListItem>
             )}
             <StyledListItem>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
@@ -34,6 +34,7 @@ interface Props {
   openDeletePoolDialog: (poolId: number) => void;
   openRecycleAllNodesDialog: (poolId: number) => void;
   openRecycleNodeDialog: (nodeID: string, linodeLabel: string) => void;
+  poolFirewallId: KubeNodePoolResponse['firewall_id'];
   poolId: number;
   poolVersion: KubeNodePoolResponse['k8s_version'];
   statusFilter: StatusFilter;
@@ -61,6 +62,7 @@ export const NodePool = (props: Props) => {
     openRecycleAllNodesDialog,
     openRecycleNodeDialog,
     poolId,
+    poolFirewallId,
     poolVersion,
     statusFilter,
     tags,
@@ -162,6 +164,7 @@ export const NodePool = (props: Props) => {
         clusterTier={clusterTier}
         encryptionStatus={encryptionStatus}
         isLkeClusterRestricted={isLkeClusterRestricted}
+        poolFirewallId={poolFirewallId}
         poolId={poolId}
         poolVersion={poolVersion}
         tags={tags}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolFooter.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolFooter.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { accountFactory } from 'src/factories';
+import { accountFactory, firewallFactory } from 'src/factories';
 import { http, HttpResponse, server } from 'src/mocks/testServer';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
@@ -16,14 +16,14 @@ describe('Node Pool Footer', () => {
     tags: [],
     poolId: 1,
     poolVersion: undefined,
-    poolFirewallId: 123,
+    poolFirewallId: undefined,
     isLkeClusterRestricted: false,
   };
 
   it('shows the Pool ID', async () => {
     const { getByText } = renderWithTheme(<NodePoolFooter {...props} />);
 
-    expect(getByText('Pool ID')).toBeVisible();
+    expect(getByText('Pool ID:')).toBeVisible();
     expect(getByText(props.poolId)).toBeVisible();
   });
 
@@ -48,7 +48,7 @@ describe('Node Pool Footer', () => {
       />
     );
 
-    expect(getByText('Version')).toBeVisible();
+    expect(getByText('Version:')).toBeVisible();
     expect(getByText('v1.31.8+lke5')).toBeVisible();
   });
 
@@ -61,8 +61,56 @@ describe('Node Pool Footer', () => {
       />
     );
 
-    expect(queryByText('Version')).not.toBeInTheDocument();
+    expect(queryByText('Version:')).not.toBeInTheDocument();
     expect(queryByText('v1.31.8+lke5')).not.toBeInTheDocument();
+  });
+
+  it("shows the node pool's firewall for an LKE Enterprise cluster", async () => {
+    server.use(
+      http.get('*/firewalls/*', () => {
+        return HttpResponse.json(
+          firewallFactory.build({ id: 123, label: 'my-lke-e-firewall' })
+        );
+      })
+    );
+    const { getByText, findByText } = renderWithTheme(
+      <NodePoolFooter
+        {...props}
+        clusterTier="enterprise"
+        poolFirewallId={123}
+      />
+    );
+
+    expect(getByText('Firewall:')).toBeVisible();
+    expect(
+      await findByText('my-lke-e-firewall', { exact: false })
+    ).toBeVisible();
+    expect(getByText('(ID: 123)')).toBeVisible();
+  });
+
+  it("does not show the node pool's firewall when undefined for a LKE Enterprise cluster ", async () => {
+    const { queryByText } = renderWithTheme(
+      <NodePoolFooter {...props} clusterTier="enterprise" />
+    );
+
+    expect(queryByText('Firewall:')).not.toBeInTheDocument();
+  });
+
+  it("does not show the node pool's firewall for a standard LKE cluster", async () => {
+    server.use(
+      http.get('*/firewalls/*', () => {
+        return HttpResponse.json(
+          firewallFactory.build({ id: 123, label: 'my-lke-e-firewall' })
+        );
+      })
+    );
+    const { queryByText } = renderWithTheme(
+      <NodePoolFooter {...props} clusterTier="standard" poolFirewallId={123} />
+    );
+
+    expect(queryByText('Firewall:')).not.toBeInTheDocument();
+    expect(queryByText('my-lke-e-firewall')).not.toBeInTheDocument();
+    expect(queryByText('123')).not.toBeInTheDocument();
   });
 
   it('does not display the encryption status of the pool if the account lacks the capability or the feature flag is off', async () => {

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolFooter.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolFooter.test.tsx
@@ -96,6 +96,15 @@ describe('Node Pool Footer', () => {
     expect(queryByText('Firewall:')).not.toBeInTheDocument();
   });
 
+  // This check handles the current API behavior for a default firewall (0). TODO: remove this once LKE-7686 is fixed.
+  it("does not show the node pool's firewall when 0 for a LKE Enterprise cluster ", async () => {
+    const { queryByText } = renderWithTheme(
+      <NodePoolFooter {...props} clusterTier="enterprise" poolFirewallId={0} />
+    );
+
+    expect(queryByText('Firewall:')).not.toBeInTheDocument();
+  });
+
   it("does not show the node pool's firewall for a standard LKE cluster", async () => {
     server.use(
       http.get('*/firewalls/*', () => {

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolFooter.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolFooter.test.tsx
@@ -85,7 +85,7 @@ describe('Node Pool Footer', () => {
     expect(
       await findByText('my-lke-e-firewall', { exact: false })
     ).toBeVisible();
-    expect(getByText('(ID: 123)')).toBeVisible();
+    expect(getByText('123')).toBeVisible();
   });
 
   it("does not show the node pool's firewall when undefined for a LKE Enterprise cluster ", async () => {

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolFooter.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolFooter.test.tsx
@@ -16,6 +16,7 @@ describe('Node Pool Footer', () => {
     tags: [],
     poolId: 1,
     poolVersion: undefined,
+    poolFirewallId: 123,
     isLkeClusterRestricted: false,
   };
 

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolFooter.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolFooter.tsx
@@ -85,22 +85,24 @@ export const NodePoolFooter = (props: Props) => {
               <b>Version:</b> {poolVersion}
             </Typography>
           )}
-          {clusterTier === 'enterprise' && poolFirewallId && (
-            <Typography sx={{ textWrap: 'nowrap' }}>
-              <b>Firewall:</b>{' '}
-              <Link to={`/firewalls/${poolFirewallId}/rules`}>
-                {firewall?.label}
-              </Link>{' '}
-              <CopyTooltip
-                copyableText
-                text={
-                  firewall?.label
-                    ? `(ID: ${String(poolFirewallId)})`
-                    : String(poolFirewallId)
-                }
-              />
-            </Typography>
-          )}
+          {clusterTier === 'enterprise' &&
+            poolFirewallId &&
+            poolFirewallId > 0 && ( // This check handles the current API behavior for a default firewall (0). TODO: remove this once LKE-7686 is fixed.
+              <Typography sx={{ textWrap: 'nowrap' }}>
+                <b>Firewall:</b>{' '}
+                <Link to={`/firewalls/${poolFirewallId}/rules`}>
+                  {firewall?.label}
+                </Link>{' '}
+                <CopyTooltip
+                  copyableText
+                  text={
+                    firewall?.label
+                      ? `(ID: ${String(poolFirewallId)})`
+                      : String(poolFirewallId)
+                  }
+                />
+              </Typography>
+            )}
           {isDiskEncryptionFeatureEnabled && (
             <NodePoolEncryptionStatus encryptionStatus={encryptionStatus} />
           )}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolFooter.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolFooter.tsx
@@ -94,10 +94,10 @@ export const NodePoolFooter = (props: Props) => {
                   {firewall?.label ?? poolFirewallId}
                 </Link>{' '}
                 {firewall?.label && (
-                  <CopyTooltip
-                    copyableText
-                    text={`(ID: ${String(poolFirewallId)})`}
-                  />
+                  <span>
+                    (ID:{' '}
+                    <CopyTooltip copyableText text={String(poolFirewallId)} />)
+                  </span>
                 )}
               </Typography>
             )}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolFooter.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolFooter.tsx
@@ -91,16 +91,14 @@ export const NodePoolFooter = (props: Props) => {
               <Typography sx={{ textWrap: 'nowrap' }}>
                 <b>Firewall:</b>{' '}
                 <Link to={`/firewalls/${poolFirewallId}/rules`}>
-                  {firewall?.label}
+                  {firewall?.label ?? poolFirewallId}
                 </Link>{' '}
-                <CopyTooltip
-                  copyableText
-                  text={
-                    firewall?.label
-                      ? `(ID: ${String(poolFirewallId)})`
-                      : String(poolFirewallId)
-                  }
-                />
+                {firewall?.label && (
+                  <CopyTooltip
+                    copyableText
+                    text={`(ID: ${String(poolFirewallId)})`}
+                  />
+                )}
               </Typography>
             )}
           {isDiskEncryptionFeatureEnabled && (

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolFooter.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolFooter.tsx
@@ -90,7 +90,15 @@ export const NodePoolFooter = (props: Props) => {
               <b>Firewall:</b>{' '}
               <Link to={`/firewalls/${poolFirewallId}/rules`}>
                 {firewall?.label}
-              </Link>
+              </Link>{' '}
+              <CopyTooltip
+                copyableText
+                text={
+                  firewall?.label
+                    ? `(ID: ${String(poolFirewallId)})`
+                    : String(poolFirewallId)
+                }
+              />
             </Typography>
           )}
           {isDiskEncryptionFeatureEnabled && (

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolFooter.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolFooter.tsx
@@ -1,9 +1,11 @@
+import { useFirewallQuery } from '@linode/queries';
 import { Box, Divider, Stack, Typography } from '@linode/ui';
 import { useSnackbar } from 'notistack';
 import * as React from 'react';
 
 import { CopyTooltip } from 'src/components/CopyTooltip/CopyTooltip';
 import { useIsDiskEncryptionFeatureEnabled } from 'src/components/Encryption/utils';
+import { Link } from 'src/components/Link';
 import { TagCell } from 'src/components/TagCell/TagCell';
 import { useUpdateNodePoolMutation } from 'src/queries/kubernetes';
 
@@ -21,6 +23,7 @@ export interface Props {
   clusterTier: KubernetesTier;
   encryptionStatus: EncryptionStatus;
   isLkeClusterRestricted: boolean;
+  poolFirewallId: KubeNodePoolResponse['firewall_id'];
   poolId: number;
   poolVersion: KubeNodePoolResponse['k8s_version'];
   tags: string[];
@@ -33,6 +36,7 @@ export const NodePoolFooter = (props: Props) => {
     encryptionStatus,
     isLkeClusterRestricted,
     poolId,
+    poolFirewallId,
     tags,
     clusterId,
   } = props;
@@ -42,6 +46,11 @@ export const NodePoolFooter = (props: Props) => {
   const { mutateAsync: updateNodePool } = useUpdateNodePoolMutation(
     clusterId,
     poolId
+  );
+
+  const { data: firewall } = useFirewallQuery(
+    poolFirewallId ?? -1,
+    Boolean(poolFirewallId)
   );
 
   const { isDiskEncryptionFeatureEnabled } =
@@ -69,11 +78,19 @@ export const NodePoolFooter = (props: Props) => {
           rowGap={1}
         >
           <Typography sx={{ textWrap: 'nowrap' }}>
-            <b>Pool ID</b> <CopyTooltip copyableText text={String(poolId)} />
+            <b>Pool ID:</b> <CopyTooltip copyableText text={String(poolId)} />
           </Typography>
           {clusterTier === 'enterprise' && poolVersion && (
             <Typography sx={{ textWrap: 'nowrap' }}>
-              <b>Version</b> {poolVersion}
+              <b>Version:</b> {poolVersion}
+            </Typography>
+          )}
+          {poolFirewallId && (
+            <Typography sx={{ textWrap: 'nowrap' }}>
+              <b>Firewall:</b>{' '}
+              <Link to={`/firewalls/${poolFirewallId}/rules`}>
+                {firewall?.label}
+              </Link>
             </Typography>
           )}
           {isDiskEncryptionFeatureEnabled && (

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolFooter.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolFooter.tsx
@@ -85,7 +85,7 @@ export const NodePoolFooter = (props: Props) => {
               <b>Version:</b> {poolVersion}
             </Typography>
           )}
-          {poolFirewallId && (
+          {clusterTier === 'enterprise' && poolFirewallId && (
             <Typography sx={{ textWrap: 'nowrap' }}>
               <b>Firewall:</b>{' '}
               <Link to={`/firewalls/${poolFirewallId}/rules`}>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -308,6 +308,7 @@ export const NodePoolsDisplay = (props: Props) => {
                 setSelectedNodeId(nodeId);
                 setIsRecycleNodeOpen(true);
               }}
+              poolFirewallId={thisPool.firewall_id}
               poolId={thisPool.id}
               poolVersion={thisPool.k8s_version}
               statusFilter={statusFilter}


### PR DESCRIPTION
## Description 📝

For LKE-E clusters, users should be able to see and easily link to the firewall associated with their node pool(s).

We now show this at the bottom of the Node Pool paper.

## Changes  🔄
- Adds a linked firewall to the Node Pool Footer
- Adds test coverage
- Provides consistency across styling, specifically:
   - Adds colons after each label in the footer to match the summary (e.g. `Cluster ID:`)
   - Adds a copy tooltip to the Cluster ID, since it is the only ID that doesn't have copyable text

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [x] All customers - Cluster ID will be copyable, Node Pool footer labels will have colons
- [x] Some customers (e.g. in Beta or Limited Availability) - all LKE-E LA customers will see the linked firewall (did not feature flag with postLa)
- [x] No customers / Not applicable - VPC changes will not be visible until the VPC is shown with the Phase 2 MTC flag flipped

## Target release date 🗓️

9/9

## Preview 📷

| Firewall changes | Consistent UX |
|--------| ----- |
| <video src="https://github.com/user-attachments/assets/738ab0c0-2cf0-4c2d-a3b1-77827240e544"/> |  <video src="https://github.com/user-attachments/assets/bd08437a-1b7e-4781-af2e-2e5de6d26e06"/> |
| LKE, firewall, and linode are all linked up now via navigation | Copy tooltip behavior is standard where IDs are visible |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Have the LKE-Enterprise customer tag on your account (see project tracker)
- Have the correct feature flags flipped on (LKE-Enterprise: enabled, la, postLa)
- At least one existing firewall on your account

### Verification steps

(How to verify changes)

- [ ] Create a new LKE-E cluster with two node pools: one with a default firewall and one with a user-selected firewall (if you don't already have a firewall on your account to select, create one)
- [ ] When redirected to the LKE details page after cluster submission, observe that the node pool with the user-selected firewall displays the linked firewall label and the firewall id consistent with the firewall_id in the GET pools request
- [ ] Confirm that you're routed to the correct page
- [ ] Confirm that the copy button copies the ID correctly
- [ ] Observe that all visible ID fields now have consistent copy behavior (cluster id, vpc id)
   - [ ] (Optional: you can toggle on the phase2Mtc feature flag and use CRUD mode, or point to devcloud, to test the linked VPC part)
- [ ] Confirm all LKE-related tests pass

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

-->