### PR TITLE
hotfix: [M3-10558] - broken entity link on Linodes list card view

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2025-08-28] - v1.149.1
+
+### Fixed:
+
+- Broken entity link on Linodes list card view
+
 ## [2025-08-26] - v1.149.0
 
 ### Added:

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.149.0",
+  "version": "1.149.1",
   "private": true,
   "type": "module",
   "bugs": {

--- a/packages/manager/src/features/Linodes/LinodeEntityDetailHeader.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetailHeader.tsx
@@ -121,7 +121,11 @@ export const LinodeEntityDetailHeader = (
   return (
     <EntityHeader
       isSummaryView={isSummaryView}
-      title={<StyledLink to={`linodes/${linodeId}`}>{linodeLabel}</StyledLink>}
+      title={
+        <StyledLink params={{ linodeId }} to="/linodes/$linodeId">
+          {linodeLabel}
+        </StyledLink>
+      }
       variant={variant}
     >
       <Box

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailNavigation.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailNavigation.tsx
@@ -112,7 +112,11 @@ const LinodesDetailNavigation = () => {
   ]);
 
   if (location.pathname === `/linodes/${linodeId}`) {
-    navigate({ to: '/linodes/$linodeId/metrics', params: { linodeId } });
+    navigate({
+      to: '/linodes/$linodeId/metrics',
+      params: { linodeId },
+      replace: true,
+    });
   }
 
   if (error) {


### PR DESCRIPTION
## Description 📝
Not sure if this was a result of the rerouting, but the link was missing a leading slash, resulting in appending an extra "linodes" in the URL.

I also noticed the browser `history -1` behavior wasn't working properly so i added a replace as well for good measure

## Changes  🔄
- Fix broken entity link in Linodes list (card view)
- Fix `history -1` behavior

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [x] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️
8/28/2025

## Preview 📷
![Screenshot 2025-08-28 at 12 27 58](https://github.com/user-attachments/assets/61ca453d-fc74-4e89-95ac-503b9d799aa9)


## How to test 🧪

### Reproduction steps
- Navigate to /linodes
- Toggle to card view
- Click on any of the linodes title to access its details
  - 🚫 notice wrong url and page not found

### Verification steps
- Navigate to /linodes
- Toggle to card view
- Click on any of the linodes title to access its details
  - ✅ confirm proper URL and getting to the linode details
- Click on the browser back button
  - ✅ confirm back to the linode list

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support
</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules