### PR TITLE
feat: [UIE-9142] - IAM RBAC: perm check nodebalancer summary tab

### DIFF
--- a/packages/manager/.changeset/pr-12790-added-1756817237984.md
+++ b/packages/manager/.changeset/pr-12790-added-1756817237984.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+IAM RBAC: Implements IAM RBAC permissions for NodeBalancer summary tab ([#12790](https://github.com/linode/manager/pull/12790))

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
@@ -13,7 +13,7 @@ import { TabPanels } from 'src/components/Tabs/TabPanels';
 import { Tabs } from 'src/components/Tabs/Tabs';
 import { TanStackTabLinkList } from 'src/components/Tabs/TanStackTabLinkList';
 import { getRestrictedResourceText } from 'src/features/Account/utils';
-import { useIsResourceRestricted } from 'src/hooks/useIsResourceRestricted';
+import { usePermissions } from 'src/features/IAM/hooks/usePermissions';
 import { useTabs } from 'src/hooks/useTabs';
 import { getErrorMap } from 'src/utilities/errorUtils';
 
@@ -38,11 +38,11 @@ export const NodeBalancerDetail = () => {
     isLoading,
   } = useNodeBalancerQuery(Number(id), Boolean(id));
 
-  const isNodeBalancerReadOnly = useIsResourceRestricted({
-    grantLevel: 'read_only',
-    grantType: 'nodebalancer',
-    id: nodebalancer?.id,
-  });
+  const { data: permissions } = usePermissions(
+    'nodebalancer',
+    ['update_nodebalancer'],
+    nodebalancer?.id
+  );
 
   const { handleTabChange, tabIndex, tabs } = useTabs([
     {
@@ -90,13 +90,14 @@ export const NodeBalancerDetail = () => {
           },
           pathname: `/nodebalancers/${nodebalancer.label}`,
         }}
+        disabledBreadcrumbEditButton={!permissions.update_nodebalancer}
         docsLabel="Docs"
         docsLink="https://techdocs.akamai.com/cloud-computing/docs/getting-started-with-nodebalancers"
         spacingBottom={4}
         title={nodebalancer.label}
       />
       {errorMap.none && <Notice text={errorMap.none} variant="error" />}
-      {isNodeBalancerReadOnly && (
+      {!permissions.update_nodebalancer && (
         <Notice
           text={getRestrictedResourceText({
             resourceType: 'NodeBalancers',

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.test.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.test.tsx
@@ -20,6 +20,15 @@ const queryMocks = vi.hoisted(() => ({
     .fn()
     .mockReturnValue({ data: undefined }),
   useParams: vi.fn().mockReturnValue({}),
+  userPermissions: vi.fn(() => ({
+    data: {
+      update_nodebalancer: false,
+    },
+  })),
+}));
+
+vi.mock('src/features/IAM/hooks/usePermissions', () => ({
+  usePermissions: queryMocks.userPermissions,
 }));
 
 vi.mock('@tanstack/react-router', async () => {
@@ -187,5 +196,32 @@ describe('SummaryPanel', () => {
         '/kubernetes/clusters/1/summary'
       );
     });
+  });
+
+  it('should disable "Add a tag" if user does not have permission', () => {
+    const { getByText } = renderWithTheme(<SummaryPanel />, {
+      flags: { nodebalancerVpc: true },
+    });
+
+    // Tags panel
+    expect(getByText('Tags')).toBeVisible();
+    expect(getByText('Add a tag')).toBeVisible();
+    expect(getByText('Add a tag')).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('should enable "Add a tag" if user has permission', () => {
+    queryMocks.userPermissions.mockReturnValue({
+      data: {
+        update_nodebalancer: true,
+      },
+    });
+    const { getByText } = renderWithTheme(<SummaryPanel />, {
+      flags: { nodebalancerVpc: true },
+    });
+
+    // Tags panel
+    expect(getByText('Tags')).toBeVisible();
+    expect(getByText('Add a tag')).toBeVisible();
+    expect(getByText('Add a tag')).not.toHaveAttribute('aria-disabled', 'true');
   });
 });

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
@@ -15,9 +15,9 @@ import * as React from 'react';
 
 import { Link } from 'src/components/Link';
 import { TagCell } from 'src/components/TagCell/TagCell';
+import { usePermissions } from 'src/features/IAM/hooks/usePermissions';
 import { useKubernetesBetaEndpoint } from 'src/features/Kubernetes/kubeUtils';
 import { IPAddress } from 'src/features/Linodes/LinodesLanding/IPAddress';
-import { useIsResourceRestricted } from 'src/hooks/useIsResourceRestricted';
 import { useKubernetesClusterQuery } from 'src/queries/kubernetes';
 
 import { useIsNodebalancerVPCEnabled } from '../../utils';
@@ -42,11 +42,11 @@ export const SummaryPanel = () => {
   );
   const displayFirewallLink = !!attachedFirewallData?.data?.length;
 
-  const isNodeBalancerReadOnly = useIsResourceRestricted({
-    grantLevel: 'read_only',
-    grantType: 'nodebalancer',
-    id: nodebalancer?.id,
-  });
+  const { data: permissions } = usePermissions(
+    'nodebalancer',
+    ['update_nodebalancer'],
+    nodebalancer?.id
+  );
 
   const flags = useIsNodebalancerVPCEnabled();
 
@@ -265,7 +265,7 @@ export const SummaryPanel = () => {
           Tags
         </StyledTitle>
         <TagCell
-          disabled={isNodeBalancerReadOnly}
+          disabled={!permissions.update_nodebalancer}
           entity="NodeBalancer"
           tags={nodebalancer?.tags}
           updateTags={(tags) => updateNodeBalancer({ tags })}


### PR DESCRIPTION
## Description 📝

This PR implements IAM RBAC permissions for NodeBalancer summary tab

## Changes  🔄

List any change(s) relevant to the reviewer.

- Implement permissions in the /nodebalancers/${nodebalancersId}/summary flow (Edit label + Add tags)
- Update unit tests

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [x] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

9/9

## How to test 🧪

### Prerequisites

(How to setup test environment)

- MSW or iam (restricted) + regular account to compare
- Permissions to check:
     Custom User Entity Permissions preset:
    ```
    [
        "update_nodebalancer"
    ]
    ```

### Verification steps

(How to verify changes)

- [ ]  Confirm the buttons/inputs are disabled according the grant model with IAM is off, and according to the RBAC model when IAM is on.


<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
