### PR TITLE
upcoming: [M3-10379] - Allow Firewall to be configured in the Add Node Pool Drawer

### DIFF
--- a/packages/api-v4/.changeset/pr-12793-changed-1756835875675.md
+++ b/packages/api-v4/.changeset/pr-12793-changed-1756835875675.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Changed
+---
+
+Update `CreateNodePoolData` to satisfy @linode/validation's `CreateNodePoolSchema`'s type ([#12793](https://github.com/linode/manager/pull/12793))

--- a/packages/api-v4/src/kubernetes/nodePools.ts
+++ b/packages/api-v4/src/kubernetes/nodePools.ts
@@ -1,4 +1,4 @@
-import { nodePoolSchema } from '@linode/validation/lib/kubernetes.schema';
+import { CreateNodePoolSchema, EditNodePoolSchema } from '@linode/validation';
 
 import { API_ROOT, BETA_API_ROOT } from '../constants';
 import Request, {
@@ -61,7 +61,7 @@ export const createNodePool = (clusterID: number, data: CreateNodePoolData) =>
     setURL(
       `${BETA_API_ROOT}/lke/clusters/${encodeURIComponent(clusterID)}/pools`,
     ),
-    setData(data, nodePoolSchema),
+    setData(data, CreateNodePoolSchema),
   );
 
 /**
@@ -81,7 +81,7 @@ export const updateNodePool = (
         clusterID,
       )}/pools/${encodeURIComponent(nodePoolID)}`,
     ),
-    setData(data, nodePoolSchema),
+    setData(data, EditNodePoolSchema),
   );
 
 /**

--- a/packages/api-v4/src/kubernetes/types.ts
+++ b/packages/api-v4/src/kubernetes/types.ts
@@ -110,7 +110,7 @@ export interface CreateNodePoolData {
    *
    * @note Only supported on LKE Enterprise clusters
    */
-  firewall_id?: number;
+  firewall_id?: null | number;
   /**
    * The LKE version that the node pool should use.
    *
@@ -127,12 +127,12 @@ export interface CreateNodePoolData {
   /**
    * Key-value pairs added as labels to nodes in the node pool.
    */
-  labels?: Label;
-  tags?: string[];
+  labels?: Label | null;
+  tags?: null | string[];
   /**
    * Kubernetes taints to add to node pool nodes.
    */
-  taints?: Taint[];
+  taints?: null | Taint[];
   /**
    * The Linode Type for all of the nodes in the Node Pool.
    */
@@ -144,7 +144,7 @@ export interface CreateNodePoolData {
    * @note Only supported on LKE Enterprise clusters
    * @default on_recycle
    */
-  update_strategy?: NodePoolUpdateStrategy;
+  update_strategy?: NodePoolUpdateStrategy | null;
 }
 
 export type UpdateNodePoolData = Partial<CreateNodePoolData>;

--- a/packages/manager/.changeset/pr-12793-upcoming-features-1756835231450.md
+++ b/packages/manager/.changeset/pr-12793-upcoming-features-1756835231450.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Add Firewall option to the Add Node Pool Drawer for LKE Enterprise Kubernetes Clusters ([#12793](https://github.com/linode/manager/pull/12793))

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.test.tsx
@@ -1,6 +1,10 @@
+import { linodeTypeFactory } from '@linode/utilities';
+import { waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
-import { accountFactory } from 'src/factories';
+import { accountFactory, firewallFactory } from 'src/factories';
+import { makeResourcePage } from 'src/mocks/serverHandlers';
 import { http, HttpResponse, server } from 'src/mocks/testServer';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
@@ -18,69 +22,145 @@ const props: Props = {
 };
 
 describe('AddNodePoolDrawer', () => {
-  it('should render plan heading', async () => {
-    const { findByText } = renderWithTheme(<AddNodePoolDrawer {...props} />);
+  describe('Plans', () => {
+    it('should render plan heading', async () => {
+      const { findByText } = renderWithTheme(<AddNodePoolDrawer {...props} />);
 
-    await findByText('Dedicated CPU');
-  });
-
-  it('should display the GPU tab for standard clusters', async () => {
-    const { findByText } = renderWithTheme(<AddNodePoolDrawer {...props} />);
-
-    expect(await findByText('GPU')).toBeInTheDocument();
-  });
-
-  it('should not display the GPU tab for enterprise clusters', async () => {
-    const { queryByText } = renderWithTheme(
-      <AddNodePoolDrawer {...props} clusterTier="enterprise" />
-    );
-
-    expect(queryByText('GPU')).toBeNull();
-  });
-
-  it('should not display "Firewall" as an option by default', async () => {
-    const { queryByText } = renderWithTheme(
-      <AddNodePoolDrawer {...props} clusterTier="standard" />
-    );
-
-    expect(queryByText('Firewall')).toBeNull();
-  });
-
-  it('should display "Firewall" as an option for enterprise clusters if the postLA flag is on and the account has the capability', async () => {
-    const account = accountFactory.build({
-      capabilities: ['Kubernetes Enterprise'],
+      await findByText('Dedicated CPU');
     });
 
-    server.use(
-      http.get('*/v4*/account', () => {
-        return HttpResponse.json(account);
-      })
-    );
+    it('should display the GPU tab for standard clusters', async () => {
+      const { findByText } = renderWithTheme(<AddNodePoolDrawer {...props} />);
 
-    const { findByText, getByLabelText } = renderWithTheme(
-      <AddNodePoolDrawer {...props} clusterTier="enterprise" />,
-      {
-        flags: {
-          lkeEnterprise: {
-            enabled: true,
-            ga: false,
-            la: true,
-            postLa: true,
-            phase2Mtc: false,
-          },
-        },
-      }
-    );
+      expect(await findByText('GPU')).toBeInTheDocument();
+    });
 
-    expect(await findByText('Firewall')).toBeVisible();
+    it('should not display the GPU tab for enterprise clusters', async () => {
+      const { queryByText } = renderWithTheme(
+        <AddNodePoolDrawer {...props} clusterTier="enterprise" />
+      );
 
-    const defaultOption = getByLabelText('Use default firewall');
-    const existingFirewallOption = getByLabelText('Select existing firewall');
+      expect(queryByText('GPU')).toBeNull();
+    });
+  });
 
-    expect(defaultOption).toBeInTheDocument();
-    expect(existingFirewallOption).toBeInTheDocument();
+  describe('Firewall', () => {
+    // LKE-E Post LA must be enabled for the Firewall option to show up
+    const flags = {
+      lkeEnterprise: {
+        enabled: true,
+        ga: false,
+        la: true,
+        postLa: true,
+        phase2Mtc: false,
+      },
+    };
 
-    expect(defaultOption).toBeEnabled();
-    expect(existingFirewallOption).toBeEnabled();
+    it('should not display "Firewall" as an option by default', async () => {
+      const { queryByText } = renderWithTheme(
+        <AddNodePoolDrawer {...props} clusterTier="standard" />
+      );
+
+      expect(queryByText('Firewall')).toBeNull();
+    });
+
+    it('should display "Firewall" as an option for enterprise clusters if the postLA flag is on and the account has the capability', async () => {
+      const account = accountFactory.build({
+        capabilities: ['Kubernetes Enterprise'],
+      });
+
+      server.use(
+        http.get('*/v4*/account', () => {
+          return HttpResponse.json(account);
+        }),
+        http.get('*/v4*/linode/types', () => {
+          return HttpResponse.json(makeResourcePage([]));
+        })
+      );
+
+      const { findByText, getByLabelText } = renderWithTheme(
+        <AddNodePoolDrawer {...props} clusterTier="enterprise" />,
+        { flags }
+      );
+
+      expect(await findByText('Firewall')).toBeVisible();
+
+      const defaultOption = getByLabelText('Use default firewall');
+      const existingFirewallOption = getByLabelText('Select existing firewall');
+
+      expect(defaultOption).toBeInTheDocument();
+      expect(existingFirewallOption).toBeInTheDocument();
+
+      expect(defaultOption).toBeEnabled();
+      expect(existingFirewallOption).toBeEnabled();
+    });
+
+    it('should allow the user to pick an existing firewall for enterprise clusters if the postLA flag is on and the account has the capability', async () => {
+      const account = accountFactory.build({
+        capabilities: ['Kubernetes Enterprise'],
+      });
+      const firewall = firewallFactory.build({ id: 12 });
+      const type = linodeTypeFactory.build({
+        label: 'Linode 4GB',
+        class: 'dedicated',
+      });
+
+      const onCreatePool = vi.fn();
+
+      server.use(
+        http.get('*/v4*/account', () => {
+          return HttpResponse.json(account);
+        }),
+        http.get('*/v4*/linode/types', () => {
+          return HttpResponse.json(makeResourcePage([type]));
+        }),
+        http.get('*/v4*/networking/firewalls', () => {
+          return HttpResponse.json(makeResourcePage([firewall]));
+        }),
+        http.post(
+          '*/v4*/lke/clusters/:clusterId/pools',
+          async ({ request }) => {
+            const data = await request.json();
+            onCreatePool(data);
+            return HttpResponse.json(data);
+          }
+        )
+      );
+
+      const { findByText, findByLabelText, getByRole, getByPlaceholderText } =
+        renderWithTheme(
+          <AddNodePoolDrawer {...props} clusterTier="enterprise" />,
+          { flags }
+        );
+
+      expect(await findByText('Linode 4 GB')).toBeVisible();
+
+      await userEvent.click(getByRole('button', { name: 'Add 1' }));
+      await userEvent.click(getByRole('button', { name: 'Add 1' }));
+      await userEvent.click(getByRole('button', { name: 'Add 1' }));
+
+      const existingFirewallOption = await findByLabelText(
+        'Select existing firewall'
+      );
+
+      await userEvent.click(existingFirewallOption);
+
+      const firewallSelect = getByPlaceholderText('Select firewall');
+
+      await userEvent.click(firewallSelect);
+
+      await userEvent.click(await findByText(firewall.label));
+
+      await userEvent.click(getByRole('button', { name: 'Add pool' }));
+
+      await waitFor(() => {
+        expect(onCreatePool).toHaveBeenCalledWith({
+          firewall_id: 12,
+          count: 3,
+          type: type.id,
+          update_strategy: 'on_recycle',
+        });
+      });
+    });
   });
 });

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.tsx
@@ -1,3 +1,9 @@
+import {
+  type CreateNodePoolData,
+  isEmpty,
+  type KubernetesTier,
+  type Region,
+} from '@linode/api-v4';
 import { useAllTypes, useRegionsQuery } from '@linode/queries';
 import { Box, Button, Drawer, Notice, Stack, Typography } from '@linode/ui';
 import {
@@ -7,10 +13,9 @@ import {
   scrollErrorIntoView,
 } from '@linode/utilities';
 import React from 'react';
-import { Controller, useForm, useWatch } from 'react-hook-form';
+import { FormProvider, useForm, useWatch } from 'react-hook-form';
 
 import { ErrorMessage } from 'src/components/ErrorMessage';
-// import { FirewallSelect } from 'src/features/Firewalls/components/FirewallSelect';
 import {
   ADD_NODE_POOLS_DESCRIPTION,
   ADD_NODE_POOLS_ENTERPRISE_DESCRIPTION,
@@ -25,15 +30,8 @@ import { getLinodeRegionPrice } from 'src/utilities/pricing/linodes';
 
 import { PremiumCPUPlanNotice } from '../../CreateCluster/PremiumCPUPlanNotice';
 import { KubernetesPlansPanel } from '../../KubernetesPlansPanel/KubernetesPlansPanel';
-import { useIsLkeEnterpriseEnabled } from '../../kubeUtils';
-import { NodePoolUpdateStrategySelect } from '../../NodePoolUpdateStrategySelect';
+import { NodePoolConfigOptions } from '../../KubernetesPlansPanel/NodePoolConfigOptions';
 import { hasInvalidNodePoolPrice } from './utils';
-
-import type {
-  CreateNodePoolData,
-  KubernetesTier,
-  Region,
-} from '@linode/api-v4';
 
 export interface Props {
   clusterId: number;
@@ -54,15 +52,11 @@ export const AddNodePoolDrawer = (props: Props) => {
     open,
   } = props;
 
-  const { isLkeEnterprisePostLAFeatureEnabled } = useIsLkeEnterpriseEnabled();
   const { data: regions, isLoading: isRegionsLoading } = useRegionsQuery();
   const { data: types, isLoading: isTypesLoading } = useAllTypes(open);
 
-  const {
-    error,
-    isPending,
-    mutateAsync: createPool,
-  } = useCreateNodePoolMutation(clusterId);
+  const { isPending, mutateAsync: createPool } =
+    useCreateNodePoolMutation(clusterId);
 
   // Only want to use current types here and filter out nanodes
   const extendedTypes = filterCurrentTypes(types?.map(extendType)).filter(
@@ -73,6 +67,7 @@ export const AddNodePoolDrawer = (props: Props) => {
     defaultValues: {
       update_strategy: clusterTier === 'enterprise' ? 'on_recycle' : undefined,
     },
+    shouldFocusError: false,
   });
 
   const [type, count] = useWatch({
@@ -93,7 +88,7 @@ export const AddNodePoolDrawer = (props: Props) => {
     type && count && isNumber(pricePerNode) ? count * pricePerNode : undefined;
 
   const hasInvalidPrice = hasInvalidNodePoolPrice(pricePerNode, totalPrice);
-  const shouldShowPricingInfo = type && count > 0;
+  const shouldShowPricingInfo = Boolean(type) && count > 0;
 
   React.useEffect(() => {
     if (open) {
@@ -101,11 +96,17 @@ export const AddNodePoolDrawer = (props: Props) => {
     }
   }, [open]);
 
+  const previousSubmitCount = React.useRef<number>(0);
+
   React.useEffect(() => {
-    if (error) {
-      scrollErrorIntoView(undefined, { behavior: 'smooth' });
+    if (
+      !isEmpty(form.formState.errors) &&
+      form.formState.submitCount > previousSubmitCount.current
+    ) {
+      scrollErrorIntoView();
     }
-  }, [error]);
+    previousSubmitCount.current = form.formState.submitCount;
+  }, [form.formState]);
 
   const updatePlanCount = (planId: string, newCount: number) => {
     form.setValue('type', newCount === 0 ? '' : planId);
@@ -145,119 +146,97 @@ export const AddNodePoolDrawer = (props: Props) => {
       open={open}
       slotProps={{
         paper: {
-          sx: { maxWidth: '790px !important' },
+          sx: { maxWidth: '810px !important' },
         },
       }}
       title={`Add a Node Pool: ${clusterLabel}`}
       wide
     >
-      {form.formState.errors.root?.message && (
-        <Notice spacingBottom={0} spacingTop={12} variant="error">
-          <ErrorMessage
-            entity={{ id: clusterId, type: 'lkecluster_id' }}
-            message={form.formState.errors.root?.message}
-          />
-        </Notice>
-      )}
-      <form onSubmit={form.handleSubmit(onSubmit)}>
-        <KubernetesPlansPanel
-          copy={getPlansPanelCopy()}
-          getTypeCount={(plan) => {
-            if (plan === type) {
-              return count;
-            }
-            return 0;
-          }}
-          hasSelectedRegion={hasSelectedRegion}
-          isPlanPanelDisabled={isPlanPanelDisabled}
-          isSelectedRegionEligibleForPlan={isSelectedRegionEligibleForPlan}
-          isSubmitting={isPending}
-          notice={<PremiumCPUPlanNotice spacingBottom={16} spacingTop={16} />}
-          onSelect={(type) => form.setValue('type', type)}
-          regionsData={regions ?? []}
-          resetValues={() => form.reset()}
-          selectedId={type}
-          selectedRegionId={clusterRegionId}
-          selectedTier={clusterTier}
-          types={extendedTypes}
-          updatePlanCount={updatePlanCount}
-        />
-        {count > 0 && count < 3 && (
-          <Notice
-            spacingBottom={16}
-            spacingTop={8}
-            text={nodeWarning}
-            variant="warning"
-          />
-        )}
-        {hasInvalidPrice && shouldShowPricingInfo && (
-          <Notice
-            spacingBottom={16}
-            spacingTop={8}
-            text={PRICES_RELOAD_ERROR_NOTICE_TEXT}
-            variant="error"
-          />
-        )}
-        {isLkeEnterprisePostLAFeatureEnabled &&
-          clusterTier === 'enterprise' && (
-            <Stack spacing={2}>
-              <Typography variant="h3">Configuration</Typography>
-              <Controller
-                control={form.control}
-                name="update_strategy"
-                render={({ field }) => (
-                  <NodePoolUpdateStrategySelect
-                    onChange={field.onChange}
-                    value={field.value!}
-                  />
-                )}
+      <FormProvider {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)}>
+          <Stack spacing={2}>
+            {form.formState.errors.root?.message && (
+              <Notice variant="error">
+                <ErrorMessage
+                  entity={{ id: clusterId, type: 'lkecluster_id' }}
+                  message={form.formState.errors.root?.message}
+                />
+              </Notice>
+            )}
+            <KubernetesPlansPanel
+              copy={getPlansPanelCopy()}
+              error={form.formState.errors.type?.message}
+              getTypeCount={(plan) => {
+                if (plan === type) {
+                  return count;
+                }
+                return 0;
+              }}
+              hasSelectedRegion={hasSelectedRegion}
+              isPlanPanelDisabled={isPlanPanelDisabled}
+              isSelectedRegionEligibleForPlan={isSelectedRegionEligibleForPlan}
+              isSubmitting={isPending}
+              notice={
+                <PremiumCPUPlanNotice spacingBottom={16} spacingTop={16} />
+              }
+              onSelect={(type) => form.setValue('type', type)}
+              regionsData={regions ?? []}
+              resetValues={() => form.resetField('type')}
+              selectedId={type}
+              selectedRegionId={clusterRegionId}
+              selectedTier={clusterTier}
+              types={extendedTypes}
+              updatePlanCount={updatePlanCount}
+            />
+            {count > 0 && count < 3 && (
+              <Notice
+                spacingBottom={0}
+                spacingTop={0}
+                text={nodeWarning}
+                variant="warning"
               />
-              {/*
-              <Controller
-                control={form.control}
-                name="firewall_id"
-                render={({ field, fieldState }) => (
-                  <FirewallSelect
-                    errorText={fieldState.error?.message}
-                    onChange={(e, firewall) =>
-                      field.onChange(firewall?.id ?? null)
-                    }
-                    value={field.value ?? null}
-                  />
-                )}
+            )}
+            {hasInvalidPrice && shouldShowPricingInfo && (
+              <Notice
+                spacingBottom={0}
+                spacingTop={0}
+                text={PRICES_RELOAD_ERROR_NOTICE_TEXT}
+                variant="error"
               />
-              */}
-            </Stack>
-          )}
-        <Box
-          alignItems="center"
-          display="flex"
-          flexDirection="row"
-          justifyContent={shouldShowPricingInfo ? 'space-between' : 'flex-end'}
-          mt={3}
-        >
-          {shouldShowPricingInfo && (
-            <Typography>
-              This pool will add{' '}
-              <strong>
-                ${renderMonthlyPriceToCorrectDecimalPlace(totalPrice)}/month (
-                {pluralize('node', 'nodes', count)} at $
-                {renderMonthlyPriceToCorrectDecimalPlace(pricePerNode)}
-                /month)
-              </strong>{' '}
-              to this cluster.
-            </Typography>
-          )}
-          <Button
-            buttonType="primary"
-            disabled={!type || hasInvalidPrice}
-            loading={form.formState.isSubmitting}
-            type="submit"
-          >
-            Add pool
-          </Button>
-        </Box>
-      </form>
+            )}
+            <NodePoolConfigOptions clusterTier={clusterTier} />
+            <Box
+              alignItems="center"
+              display="flex"
+              flexDirection="row"
+              justifyContent={
+                shouldShowPricingInfo ? 'space-between' : 'flex-end'
+              }
+            >
+              {shouldShowPricingInfo && (
+                <Typography>
+                  This pool will add{' '}
+                  <strong>
+                    ${renderMonthlyPriceToCorrectDecimalPlace(totalPrice)}/month
+                    ({pluralize('node', 'nodes', count)} at $
+                    {renderMonthlyPriceToCorrectDecimalPlace(pricePerNode)}
+                    /month)
+                  </strong>{' '}
+                  to this cluster.
+                </Typography>
+              )}
+              <Button
+                buttonType="primary"
+                disabled={shouldShowPricingInfo && hasInvalidPrice}
+                loading={form.formState.isSubmitting}
+                type="submit"
+              >
+                Add pool
+              </Button>
+            </Box>
+          </Stack>
+        </form>
+      </FormProvider>
     </Drawer>
   );
 };

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AddNodePoolDrawer.tsx
@@ -69,7 +69,6 @@ export const AddNodePoolDrawer = (props: Props) => {
     defaultValues: {
       update_strategy: clusterTier === 'enterprise' ? 'on_recycle' : undefined,
     },
-    shouldFocusError: false,
   });
 
   const [type, count] = useWatch({

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelectionTable.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlanSelectionTable.tsx
@@ -38,10 +38,7 @@ export const KubernetesPlanSelectionTable = (
   } = props;
 
   return (
-    <Table
-      aria-label={`List of ${filterOptions?.header ?? 'Linode'} Plans`}
-      spacingBottom={16}
-    >
+    <Table aria-label={`List of ${filterOptions?.header ?? 'Linode'} Plans`}>
       <TableHead>
         <TableRow>
           {tableCells.map(({ cellName, center, noWrap, testId }) => {

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/NodePoolConfigOptions.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/NodePoolConfigOptions.tsx
@@ -79,7 +79,7 @@ export const NodePoolConfigOptions = (props: Props) => {
             render={({ field }) => (
               <NodePoolUpdateStrategySelect
                 onChange={field.onChange}
-                value={field.value}
+                value={field.value ?? undefined}
               />
             )}
           />

--- a/packages/validation/.changeset/pr-12793-added-1756835813761.md
+++ b/packages/validation/.changeset/pr-12793-added-1756835813761.md
@@ -1,0 +1,5 @@
+---
+"@linode/validation": Added
+---
+
+Node Pool schemas `CreateNodePoolSchema` and `EditNodePoolSchema` ([#12793](https://github.com/linode/manager/pull/12793))

--- a/packages/validation/.changeset/pr-12793-removed-1756835773560.md
+++ b/packages/validation/.changeset/pr-12793-removed-1756835773560.md
@@ -1,0 +1,5 @@
+---
+"@linode/validation": Removed
+---
+
+General Node Pool schema `nodePoolSchema` ([#12793](https://github.com/linode/manager/pull/12793))

--- a/packages/validation/src/kubernetes.schema.ts
+++ b/packages/validation/src/kubernetes.schema.ts
@@ -2,10 +2,70 @@ import { array, boolean, number, object, string } from 'yup';
 
 import { validateIP } from './firewalls.schema';
 
-export const nodePoolSchema = object({
+// Starts and ends with a letter or number and contains letters, numbers, hyphens, dots, and underscores
+const alphaNumericValidCharactersRegex =
+  /^[a-zA-Z0-9]([a-zA-Z0-9-._]*[a-zA-Z0-9])?$/;
+
+export const kubernetesTaintSchema = object({
+  key: string()
+    .required('Key is required.')
+    .test(
+      'valid-key',
+      'Key must start with a letter or number and may contain letters, numbers, hyphens, dots, and underscores, up to 253 characters.',
+      (value) => {
+        return (
+          alphaNumericValidCharactersRegex.test(value) ||
+          dnsKeyRegex.test(value)
+        );
+      },
+    )
+    .max(253, 'Key must be between 1 and 253 characters.')
+    .min(1, 'Key must be between 1 and 253 characters.'),
+  value: string()
+    .matches(
+      alphaNumericValidCharactersRegex,
+      'Value must start with a letter or number and may contain letters, numbers, hyphens, dots, and underscores, up to 63 characters.',
+    )
+    .max(63, 'Value must be between 0 and 63 characters.')
+    .notOneOf(
+      ['kubernetes.io', 'linode.com'],
+      'Value cannot be "kubernetes.io" or "linode.com".',
+    )
+    .notRequired(),
+});
+
+const NodePoolDiskSchema = object({
+  size: number().required(),
+  type: string()
+    .oneOf(['raw', 'ext4'] as const)
+    .required(),
+});
+
+const AutoscaleSettingsSchema = object({
+  enabled: boolean().required(),
+  max: number().required(),
+  min: number().required(),
+});
+
+export const CreateNodePoolSchema = object({
+  autoscaler: AutoscaleSettingsSchema.notRequired().default(undefined),
+  type: string().required('Type is required.'),
+  count: number().required(),
+  tags: array(string().defined()).notRequired(),
+  disks: array(NodePoolDiskSchema).notRequired(),
+  update_strategy: string()
+    .oneOf(['rolling_update', 'on_recycle'] as const)
+    .notRequired(),
+  k8_version: string().notRequired(),
+  firewall_id: number().notRequired(),
+  labels: object().notRequired(),
+  taints: array(kubernetesTaintSchema).notRequired(),
+});
+
+export const EditNodePoolSchema = object({
   type: string(),
   count: number(),
-  upgrade_strategy: string(),
+  update_strategy: string(),
   k8_version: string(),
   firewall_id: number(),
 });
@@ -58,7 +118,7 @@ export const createKubeClusterSchema = object({
   region: string().required('Region is required.'),
   k8s_version: string().required('Kubernetes version is required.'),
   node_pools: array()
-    .of(nodePoolSchema)
+    .of(CreateNodePoolSchema)
     .min(1, 'Please add at least one node pool.'),
 });
 
@@ -104,10 +164,6 @@ export const kubernetesEnterpriseControlPlaneACLPayloadSchema = object({
     },
   ),
 });
-
-// Starts and ends with a letter or number and contains letters, numbers, hyphens, dots, and underscores
-const alphaNumericValidCharactersRegex =
-  /^[a-zA-Z0-9]([a-zA-Z0-9-._]*[a-zA-Z0-9])?$/;
 
 // DNS subdomain key (example.com/my-app)
 const dnsKeyRegex =
@@ -169,32 +225,4 @@ export const kubernetesLabelSchema = object().test({
   name: 'validateLabels',
   message: 'Labels must be valid key-value pairs.',
   test: validateKubernetesLabel,
-});
-
-export const kubernetesTaintSchema = object({
-  key: string()
-    .required('Key is required.')
-    .test(
-      'valid-key',
-      'Key must start with a letter or number and may contain letters, numbers, hyphens, dots, and underscores, up to 253 characters.',
-      (value) => {
-        return (
-          alphaNumericValidCharactersRegex.test(value) ||
-          dnsKeyRegex.test(value)
-        );
-      },
-    )
-    .max(253, 'Key must be between 1 and 253 characters.')
-    .min(1, 'Key must be between 1 and 253 characters.'),
-  value: string()
-    .matches(
-      alphaNumericValidCharactersRegex,
-      'Value must start with a letter or number and may contain letters, numbers, hyphens, dots, and underscores, up to 63 characters.',
-    )
-    .max(63, 'Value must be between 0 and 63 characters.')
-    .notOneOf(
-      ['kubernetes.io', 'linode.com'],
-      'Value cannot be "kubernetes.io" or "linode.com".',
-    )
-    .notRequired(),
 });


### PR DESCRIPTION
## Description 📝

- This PR allows users to configure a Node Pool's Firewall in the "Add Node Pool Drawer" for  LKE Enterprise Clusters only
- Also updates some validation schemas that are very out of date

## Target release date 🗓️

Hoping for this to be included in the **September 9th release** 🤞  (release branch cut on September 3rd)

## Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [x] No customers / Not applicable (flag is not enabled yet but will likely be enabled in early/mid September)

## Preview 📷

![Screenshot 2025-09-02 at 1 37 41 PM](https://github.com/user-attachments/assets/6351620e-fbfb-493b-bb4b-dc28ef32f54d)


## How to test 🧪

> [!note]
> Have a standard LKE cluster and an Enterprise cluster on your account for testing. If you need customer tags for enterprise, let me know.

- Ensure the correct LKE-E feature flags are on locally (LKE Enterprise: `enabled`, `la`, `postLa`)
- Verify you can set a Node Pool's firewall in the "Add Node Pool Drawer" 
- Verify other flows still work and are unaffected by this change
  - Verify this drawer still works for standard LKE clusters

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

-->