### PR TITLE
fix: [M3-10570] - Profile preferences across sessions

### DIFF
--- a/packages/manager/.changeset/pr-12795-fixed-1756842256177.md
+++ b/packages/manager/.changeset/pr-12795-fixed-1756842256177.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Profile preferences across sessions ([#12795](https://github.com/linode/manager/pull/12795))

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -121,7 +121,9 @@ export const PrimaryNav = (props: PrimaryNavProps) => {
     (preferences) => preferences?.collapsedSideNavProductFamilies
   );
 
-  const collapsedAccordions = collapsedSideNavPreference ?? [1, 2, 3, 4, 5, 6]; // by default, we collapse all categories if no preference is set;
+  const collapsedAccordions = collapsedSideNavPreference ?? [
+    1, 2, 3, 4, 5, 6, 7,
+  ]; // by default, we collapse all categories if no preference is set;
 
   const { mutateAsync: updatePreferences } = useMutatePreferences();
 
@@ -336,7 +338,7 @@ export const PrimaryNav = (props: PrimaryNavProps) => {
     );
 
   const accordionClicked = (index: number) => {
-    let updatedCollapsedAccordions: number[] = [0, 1, 2, 3, 4, 5];
+    let updatedCollapsedAccordions: number[] = [1, 2, 3, 4, 5, 6, 7];
     if (collapsedAccordions.includes(index)) {
       updatedCollapsedAccordions = collapsedAccordions.filter(
         (accIndex) => accIndex !== index

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -113,7 +113,11 @@ export const PrimaryNav = (props: PrimaryNavProps) => {
 
   const { isIAMBeta, isIAMEnabled } = useIsIAMEnabled();
 
-  const { data: collapsedSideNavPreference } = usePreferences(
+  const {
+    data: collapsedSideNavPreference,
+    error: preferencesError,
+    isLoading: preferencesLoading,
+  } = usePreferences(
     (preferences) => preferences?.collapsedSideNavProductFamilies
   );
 
@@ -398,6 +402,10 @@ export const PrimaryNav = (props: PrimaryNavProps) => {
   // When a user lands on a page and does not have any preference set,
   // we want to expand the accordion that contains the active link for convenience and discoverability
   React.useEffect(() => {
+    if (preferencesLoading || preferencesError) {
+      return;
+    }
+
     if (collapsedSideNavPreference) {
       return;
     }
@@ -421,6 +429,8 @@ export const PrimaryNav = (props: PrimaryNavProps) => {
     location.search,
     productFamilyLinkGroups,
     collapsedSideNavPreference,
+    preferencesLoading,
+    preferencesError,
   ]);
 
   let activeProductFamily = '';

--- a/packages/queries/src/profile/preferences.ts
+++ b/packages/queries/src/profile/preferences.ts
@@ -38,12 +38,7 @@ export const useMutatePreferences = (replace = false) => {
         );
       return updateUserPreferences({ ...existingPreferences, ...data });
     },
-    onSuccess: (data) => {
-      queryClient.setQueryData<ManagerPreferences>(
-        profileQueries.preferences.queryKey,
-        data,
-      );
-    },
+    onMutate: (data) => updatePreferenceData(data, replace, queryClient),
   });
 };
 

--- a/packages/queries/src/profile/preferences.ts
+++ b/packages/queries/src/profile/preferences.ts
@@ -38,7 +38,12 @@ export const useMutatePreferences = (replace = false) => {
         );
       return updateUserPreferences({ ...existingPreferences, ...data });
     },
-    onMutate: (data) => updatePreferenceData(data, replace, queryClient),
+    onSuccess: (data) => {
+      queryClient.setQueryData<ManagerPreferences>(
+        profileQueries.preferences.queryKey,
+        data,
+      );
+    },
   });
 };
 


### PR DESCRIPTION
## Description 📝
Although it seems not to have been noticed so far, preferences are broken from a session to another.

Bad bug: 🐛 - The `useMutatePreferences` assumes data is available when the `PrimaryNav` component (kinda top of the tree) makes its preference mutation for the opened/collapsed sections of the menu. Somehow, along the many refactors to the component, routing and the rendering tree, this broke **any** preference persistence other than the primary nav ones from one session to the next.

## Changes  🔄
- Prevent `PrimaryNav` from overriding older set preferences settings
- Fix "more" section not being set in preferences

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [x] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️
⚠️ **09/09/2025**

## Preview 📷
nothin' visual here, except your theme choice now will actually persist (among other profile prefs)

## How to test 🧪

### Prerequisites

### Reproduction steps
- login as {USER}
- navigate to /profile/settings
- change a profile setting (theme or type-to-confirm or both)
- collapse the "more" section
- log-out
- log back in as as same user
  - 🚫 notice previous profile settings wiped out
  - 🚫 "more" section preference not respected (still expanded)

### Verification steps
- login as {USER}
- navigate to /profile/settings
- change a profile setting (theme or type-to-confirm or both)
- collapse or open the "more" section depending on its current state
- log-out
- log back in as as same user
  - ✅  confirm settings persisted across sessions
  - ✅ "more" section preference is stored in preferences

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support
</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules