### PR TITLE
fix: [M3-10573] - Improve node pool footer layout, fixing overflow due to added Firewall entity

### DIFF
--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolFooter.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolFooter.tsx
@@ -72,7 +72,13 @@ export const NodePoolFooter = (props: Props) => {
           columnGap={{ sm: 2, xs: 1.5 }}
           direction="row"
           divider={
-            <Divider flexItem orientation="vertical" sx={{ height: '20px' }} />
+            <Divider
+              flexItem
+              orientation="vertical"
+              spacingBottom={0}
+              spacingTop={0}
+              sx={{ height: '20px' }}
+            />
           }
           flexWrap={{ sm: 'unset', xs: 'wrap' }}
           rowGap={1}
@@ -88,7 +94,7 @@ export const NodePoolFooter = (props: Props) => {
           {clusterTier === 'enterprise' &&
             poolFirewallId &&
             poolFirewallId > 0 && ( // This check handles the current API behavior for a default firewall (0). TODO: remove this once LKE-7686 is fixed.
-              <Typography sx={{ textWrap: 'nowrap' }}>
+              <Typography>
                 <b>Firewall:</b>{' '}
                 <Link to={`/firewalls/${poolFirewallId}/rules`}>
                   {firewall?.label ?? poolFirewallId}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolFooter.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolFooter.tsx
@@ -1,5 +1,5 @@
 import { useFirewallQuery } from '@linode/queries';
-import { Box, Divider, Stack, Typography } from '@linode/ui';
+import { Divider, Stack, Typography } from '@linode/ui';
 import { useSnackbar } from 'notistack';
 import * as React from 'react';
 
@@ -66,19 +66,13 @@ export const NodePoolFooter = (props: Props) => {
 
   return (
     <NodePoolTableFooter>
-      <Box>
+      <Stack direction="column" width="100%">
         <Stack
           alignItems="center"
           columnGap={{ sm: 2, xs: 1.5 }}
           direction="row"
           divider={
-            <Divider
-              flexItem
-              orientation="vertical"
-              spacingBottom={0}
-              spacingTop={0}
-              sx={{ height: '20px' }}
-            />
+            <Divider flexItem orientation="vertical" sx={{ height: '20px' }} />
           }
           flexWrap={{ sm: 'unset', xs: 'wrap' }}
           rowGap={1}
@@ -111,13 +105,14 @@ export const NodePoolFooter = (props: Props) => {
             <NodePoolEncryptionStatus encryptionStatus={encryptionStatus} />
           )}
         </Stack>
-      </Box>
-      <TagCell
-        disabled={isLkeClusterRestricted}
-        tags={tags}
-        updateTags={updateTags}
-        view="inline"
-      />
+        <TagCell
+          disabled={isLkeClusterRestricted}
+          sx={{ justifyContent: 'flex-end' }}
+          tags={tags}
+          updateTags={updateTags}
+          view="inline"
+        />
+      </Stack>
     </NodePoolTableFooter>
   );
 };


### PR DESCRIPTION
## Description 📝

When the user views the LKE details page at breakpoints between ~528 and ~729 with an LKE-E cluster that has a user-selected (aka non-default) firewall, the amount of items in the Node Pool footer (pool id, version, firewall, and tags button) are now causing overflow.

This regression was introduced in #12779.

## Changes  🔄
- ...
- ...

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

Please specify a release date (and environment, if applicable) to guarantee timely review of this PR. If exact date is not known, please approximate and update it as needed.

## Preview 📷

**Include a screenshot `<img src="" />` or video `<video src="" />` of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: For changes requiring multiple steps to validate, prefer a video for clarity.

| Before  | After   |
| ------- | ------- |
| 📷 | LKE-E: ![Screenshot 2025-09-02 at 2 50 37 PM](https://github.com/user-attachments/assets/f77fb95c-3ec3-4a83-9f4d-c128bda80200) ![Screenshot 2025-09-02 at 2 51 14 PM](https://github.com/user-attachments/assets/fee7e4ee-052d-4c55-b767-fa830dfa8f7a) | 
| x | LKE Standard: ![Screenshot 2025-09-02 at 2 51 55 PM](https://github.com/user-attachments/assets/480ca512-8b44-49a6-b2a4-01a4cc621558)  ![Screenshot 2025-09-02 at 2 51 47 PM](https://github.com/user-attachments/assets/8def4a84-b0ef-49b3-bcb1-b19e6f4defa0) |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- ...
- ...

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] ...
- [ ] ...

### Verification steps

(How to verify changes)

- [ ] ...
- [ ] ...

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

-->