### PR TITLE
new: [STORIF-82] Volume tag editing feature added to the volume details page.

### DIFF
--- a/packages/api-v4/.changeset/pr-12800-changed-1756894123495.md
+++ b/packages/api-v4/.changeset/pr-12800-changed-1756894123495.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Changed
+---
+
+UpdateVolumeRequest updated ([#12800](https://github.com/linode/manager/pull/12800))

--- a/packages/api-v4/src/volumes/volumes.ts
+++ b/packages/api-v4/src/volumes/volumes.ts
@@ -152,7 +152,7 @@ export const resizeVolume = (volumeId: number, data: ResizeVolumePayload) =>
   );
 
 export interface UpdateVolumeRequest {
-  label: string;
+  label?: string;
   tags?: string[];
 }
 

--- a/packages/manager/.changeset/pr-12800-added-1756893991385.md
+++ b/packages/manager/.changeset/pr-12800-added-1756893991385.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Ability to edit tags on volume details page ([#12800](https://github.com/linode/manager/pull/12800))

--- a/packages/manager/src/features/Volumes/Drawers/EditVolumeDrawer.tsx
+++ b/packages/manager/src/features/Volumes/Drawers/EditVolumeDrawer.tsx
@@ -1,4 +1,4 @@
-import { useUpdateVolumeMutation } from '@linode/queries';
+import { useVolumeUpdateMutation } from '@linode/queries';
 import {
   ActionsPanel,
   Box,
@@ -39,7 +39,9 @@ export const EditVolumeDrawer = (props: Props) => {
   );
   const canUpdateVolume = permissions?.update_volume;
 
-  const { mutateAsync: updateVolume } = useUpdateVolumeMutation();
+  const { mutateAsync: updateVolume } = useVolumeUpdateMutation(
+    volume?.id ?? -1
+  );
 
   const { isBlockStorageEncryptionFeatureEnabled } =
     useIsBlockStorageEncryptionFeatureEnabled();
@@ -62,7 +64,6 @@ export const EditVolumeDrawer = (props: Props) => {
         await updateVolume({
           label: values.label,
           tags: values.tags,
-          volumeId: volume?.id ?? -1,
         });
 
         onClose();

--- a/packages/manager/src/features/Volumes/Drawers/ManageTagsDrawer.tsx
+++ b/packages/manager/src/features/Volumes/Drawers/ManageTagsDrawer.tsx
@@ -1,4 +1,4 @@
-import { useUpdateVolumeMutation } from '@linode/queries';
+import { useVolumeUpdateMutation } from '@linode/queries';
 import { ActionsPanel, Drawer, Notice } from '@linode/ui';
 import React from 'react';
 import { Controller, useForm } from 'react-hook-form';
@@ -26,7 +26,9 @@ export const ManageTagsDrawer = (props: Props) => {
   );
   const canUpdateVolume = permissions?.update_volume;
 
-  const { mutateAsync: updateVolume } = useUpdateVolumeMutation();
+  const { mutateAsync: updateVolume } = useVolumeUpdateMutation(
+    volume?.id ?? -1
+  );
 
   const {
     control,
@@ -40,16 +42,12 @@ export const ManageTagsDrawer = (props: Props) => {
 
   const onSubmit = handleSubmit(async (values) => {
     try {
-      await updateVolume({
-        label: volume?.label ?? '',
-        tags: values.tags,
-        volumeId: volume?.id ?? -1,
-      });
+      await updateVolume({ tags: values.tags });
 
       onClose();
     } catch (errors) {
       errors.forEach((error: APIError) => {
-        if (error.field == 'tags') {
+        if (error.field === 'tags') {
           setError('tags', {
             message: error.reason,
           });

--- a/packages/manager/src/features/Volumes/VolumeDetails/VolumeEntityDetails/VolumeEntityDetail.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDetails/VolumeEntityDetails/VolumeEntityDetail.tsx
@@ -16,7 +16,7 @@ export const VolumeEntityDetail = ({ volume }: Props) => {
   return (
     <EntityDetail
       body={<VolumeEntityDetailBody volume={volume} />}
-      footer={<VolumeEntityDetailFooter tags={volume.tags} />}
+      footer={<VolumeEntityDetailFooter volume={volume} />}
       header={<VolumeEntityDetailHeader volume={volume} />}
     />
   );

--- a/packages/queries/src/volumes/volumes.ts
+++ b/packages/queries/src/volumes/volumes.ts
@@ -228,14 +228,10 @@ export const useVolumesMigrateMutation = () => {
   });
 };
 
-interface UpdateVolumePayloadWithId extends UpdateVolumeRequest {
-  volumeId: number;
-}
-
-export const useUpdateVolumeMutation = () => {
+export const useVolumeUpdateMutation = (id: number) => {
   const queryClient = useQueryClient();
-  return useMutation<Volume, APIError[], UpdateVolumePayloadWithId>({
-    mutationFn: ({ volumeId, ...data }) => updateVolume(volumeId, data),
+  return useMutation<Volume, APIError[], UpdateVolumeRequest>({
+    mutationFn: (data) => updateVolume(id, data),
     onSuccess(volume) {
       // Update the specific volume
       queryClient.setQueryData<Volume>(


### PR DESCRIPTION
## Description 📝

Volume tag editing feature added to the volume details page.

## Changes  🔄

Added ability to add and remove tags from the volume details page.

## Preview 📷

<img width="2496" height="555" alt="image" src="https://github.com/user-attachments/assets/08532611-c55b-45ac-b13c-59df1b49c2b3" />


## How to test 🧪

- Run cloud manager locally.
- Enable VolumeSummaryPage feature flag.
- Open `/volumes/$volumeId` page.
- Open developer tools -> Network tab.
- Add/Remove tag.
- Observe the PUT request.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>