### PR TITLE
fix: [DI-26792] - Alerting UI inconsistencies

### DIFF
--- a/packages/manager/cypress/e2e/core/cloudpulse/alert-show-details.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/alert-show-details.spec.ts
@@ -284,22 +284,22 @@ describe('Integration Tests for Alert Show Detail Page', () => {
       cy.get('[data-qa-item="Polling Interval"]')
         .find('[data-qa-chip]')
         .should('be.visible')
-        .should('have.text', '10 minutes');
+        .should('have.text', '10 min');
 
       // Validating contents of Evaluation Periods
       cy.get('[data-qa-item="Evaluation Period"]')
         .find('[data-qa-chip]')
         .should('be.visible')
-        .should('have.text', '5 minutes');
+        .should('have.text', '5 min');
 
       // Validating contents of Trigger Alert
       cy.get('[data-qa-chip="All"]')
         .should('be.visible')
         .should('have.text', 'All');
 
-      cy.get('[data-qa-chip="5 minutes"]')
+      cy.get('[data-qa-chip="5 min"]')
         .should('be.visible')
-        .should('have.text', '5 minutes');
+        .should('have.text', '5 min');
 
       cy.get('[data-qa-item="criteria are met for"]')
         .should('be.visible')

--- a/packages/manager/cypress/support/constants/alert.ts
+++ b/packages/manager/cypress/support/constants/alert.ts
@@ -11,8 +11,8 @@ export const dimensionOperatorTypeMap: Record<
   string
 > = {
   endswith: 'ends with',
-  eq: 'equals',
-  neq: 'not equals',
+  eq: 'equal',
+  neq: 'not equal',
   startswith: 'starts with',
   in: 'in',
 };

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetailCriteria.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetailCriteria.test.tsx
@@ -8,7 +8,7 @@ import {
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { metricOperatorTypeMap } from '../constants';
-import { convertSecondsToMinutes } from '../Utils/utils';
+import { convertSecondsToOptions } from '../Utils/utils';
 import { AlertDetailCriteria } from './AlertDetailCriteria';
 
 describe('AlertDetailCriteria component tests', () => {
@@ -39,10 +39,10 @@ describe('AlertDetailCriteria component tests', () => {
     const { evaluation_period_seconds, polling_interval_seconds } =
       alertDetails.trigger_conditions;
     expect(
-      getByText(convertSecondsToMinutes(polling_interval_seconds))
+      getByText(convertSecondsToOptions(polling_interval_seconds))
     ).toBeInTheDocument();
     expect(
-      getByText(convertSecondsToMinutes(evaluation_period_seconds))
+      getByText(convertSecondsToOptions(evaluation_period_seconds))
     ).toBeInTheDocument();
   });
 

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetailCriteria.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetailCriteria.tsx
@@ -2,7 +2,7 @@ import { Typography } from '@linode/ui';
 import { GridLegacy, useTheme } from '@mui/material';
 import React from 'react';
 
-import { convertSecondsToMinutes } from '../Utils/utils';
+import { convertSecondsToOptions } from '../Utils/utils';
 import { StyledAlertChip, StyledAlertTypography } from './AlertDetail';
 import { DisplayAlertDetailChips } from './DisplayAlertDetailChips';
 import { RenderAlertMetricsAndDimensions } from './RenderAlertsMetricsAndDimensions';
@@ -96,12 +96,12 @@ export const AlertDetailCriteria = React.memo((props: CriteriaProps) => {
         <DisplayAlertDetailChips // label chip for polling interval
           label="Polling Interval"
           mergeChips
-          values={[convertSecondsToMinutes(pollingIntervalSeconds)]}
+          values={[convertSecondsToOptions(pollingIntervalSeconds)]}
         />
         <DisplayAlertDetailChips // label chip for evaluation period
           label="Evaluation Period"
           mergeChips
-          values={[convertSecondsToMinutes(evaluationPeriod)]}
+          values={[convertSecondsToOptions(evaluationPeriod)]}
         />
         {renderTriggerCriteria} {/** Render the trigger criteria */}
       </GridLegacy>

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/CreateAlertDefinition.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/CreateAlertDefinition.test.tsx
@@ -165,7 +165,7 @@ describe('AlertDefinition Create', () => {
 
       await user.click(submitButton);
 
-      expect(container.getAllByText('Enter a positive value.').length).toBe(2);
+      expect(container.getAllByText('Enter a positive value.').length).toBe(1);
 
       const thresholdInput = container.getByLabelText('Threshold');
       const triggerOccurrences = container.getByTestId('trigger-occurences');

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/NotificationChannels/AddNotificationChannelDrawer.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/NotificationChannels/AddNotificationChannelDrawer.tsx
@@ -129,12 +129,7 @@ export const AddNotificationChannelDrawer = (
                     isNotificationChannelsLoading &&
                     !isNotificationChannelsError
                   }
-                  errorText={
-                    fieldState.error?.message ??
-                    (isNotificationChannelsError
-                      ? 'Error in fetching the data.'
-                      : '')
-                  }
+                  errorText={fieldState.error?.message}
                   label="Type"
                   onBlur={field.onBlur}
                   onChange={(
@@ -167,7 +162,12 @@ export const AddNotificationChannelDrawer = (
                   <Autocomplete
                     data-testid="channel-label"
                     disabled={!selectedChannelTypeTemplate}
-                    errorText={fieldState.error?.message}
+                    errorText={
+                      fieldState.error?.message ??
+                      (isNotificationChannelsError
+                        ? 'Error in fetching the data.'
+                        : '')
+                    }
                     key={channelTypeWatcher}
                     label="Channel"
                     onBlur={field.onBlur}

--- a/packages/validation/src/cloudpulse.schema.ts
+++ b/packages/validation/src/cloudpulse.schema.ts
@@ -20,7 +20,7 @@ export const metricCriteria = object({
     .required(fieldErrorMessage),
   threshold: number()
     .required(fieldErrorMessage)
-    .positive('Enter a positive value.')
+    .min(0, 'Enter a positive value.')
     .typeError('The value should be a number.'),
   dimension_filters: array().of(dimensionFilters.defined()).optional(),
 });


### PR DESCRIPTION
## Description 📝
Fixing UI inconsistencies across Alerting service

## Changes  🔄

List any change(s) relevant to the reviewer.

- Displaying `equal`, `not equal` instead of `equals`, in `not equals` in Show-details
- Using `min` for Evaluation Period and Polling Interval in Show-details
- Fixed validation to allow `0` for Metric Threshold in Create and Edit Alert
- Fixed the error-message display from Type to Channel in Notification Channel Drawer

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [x] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

Please specify a release date (and environment, if applicable) to guarantee timely review of this PR. If exact date is not known, please approximate and update it as needed.

## Preview 📷

**Include a screenshot `<img src="" />` or video `<video src="" />` of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: For changes requiring multiple steps to validate, prefer a video for clarity.

| Component | Before  | After   |
| ------- | ------- | ------- |
| Allowing zero for the Metric Threshold Value (Create/ Edit Alert) | <img width="2374" height="480" alt="image" src="https://github.com/user-attachments/assets/b6ea823b-2897-4ff4-a2c2-c6dde811aa29" /> | <img width="2368" height="430" alt="image" src="https://github.com/user-attachments/assets/7fdb3ea0-2d3d-4767-87d6-e36a6f701678" /> |
| Displaying API  error message at the proper component (Create/ Edit Alert) | <img width="842" height="446" alt="image" src="https://github.com/user-attachments/assets/6a0c3b00-3a24-4c55-ae9c-06a444f2589a" /> | <img width="830" height="464" alt="image" src="https://github.com/user-attachments/assets/519b94be-97a7-4ed2-8ebe-f808343de9ae" /> |
| Using consistent terms (equal, not equal) across Alerting pages (Show Details) | <img width="1114" height="554" alt="image" src="https://github.com/user-attachments/assets/cee1cb95-e4cb-49f8-9424-b2e3a66c7da2" /> | <img width="1122" height="542" alt="image" src="https://github.com/user-attachments/assets/890a15cd-4f4a-4b74-ac2f-d188e18f2284" /> |
| Using consistent terms (min) across Alerting pages (Show Details) | <img width="1138" height="266" alt="image" src="https://github.com/user-attachments/assets/4e240515-179d-4425-af4c-7923c0b43590" /> | <img width="1122" height="330" alt="image" src="https://github.com/user-attachments/assets/5225bddc-ab7a-4d03-86ae-1e4107f330a2" /> |

## How to test 🧪

### Prerequisites

(How to setup test environment)
- In any environment, Under Monitor click on Alerts.
- For Create Alert page:
  - Click on the Create Alert button in Alert Listing page. 
  - Then fill in the values or click on submit directly to verify the error messages
- For Edit Alert page: 
  - Choose an Alert and click on the Action Menu of that Alert. Click on Edit
  - Then fill in the values or click on submit directly to verify the error messages
 - For Show Detail page:
   - Choose an Alert and click on the Action Menu of that Alert. Click on Show Details

For verifying the Alert Channel API Error change
  - In Create/Edit Alert.
  - Click on the Add Notification Channel button to verify the Notification Channel Drawer related changes. The changes are to test if error messages are displayed at proper component or not. In DevTools, in the network tab please disable the URL for the `alert-channel` by click on `Block request URL` .
<img width="3454" height="834" alt="image" src="https://github.com/user-attachments/assets/fb6c3f8e-47b5-417b-99f9-567f1ac7c694" />

### Verification steps

(How to verify changes)

- [ ] Displaying `equal`, `not equal` instead of `equals`, in `not equals` in Show-details
- [ ] Using `min` for Evaluation Period and Polling Interval in Show-details
- [ ] Allow the value 0 for the Metric Threshold Value
- [ ] The API Error message for `alert-channels` API is displayed at the Channel component

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>