### PR TITLE
[DI-26876] - Select default region in firewalls contextual view

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
@@ -49,14 +49,6 @@ const FirewallDeviceLanding = React.lazy(() =>
   }))
 );
 
-const FirewallMetricsLanding = React.lazy(() =>
-  import('../../CloudPulse/Dashboard/CloudPulseDashboardWithFilters').then(
-    (module) => ({
-      default: module.CloudPulseDashboardWithFilters,
-    })
-  )
-);
-
 export const FirewallDetail = () => {
   const { id } = useParams({
     strict: false,
@@ -130,10 +122,6 @@ export const FirewallDetail = () => {
     {
       title: `NodeBalancers (${nodebalancerCount})`,
       to: `/firewalls/$id/nodebalancers`,
-    },
-    {
-      title: 'Metrics',
-      to: `/firewalls/$id/metrics`,
     },
   ]);
 
@@ -258,9 +246,6 @@ export const FirewallDetail = () => {
                 firewallLabel={firewall.label}
                 type="nodebalancer"
               />
-            </SafeTabPanel>
-            <SafeTabPanel index={3}>
-              <FirewallMetricsLanding dashboardId={4} resource={firewall.id} />
             </SafeTabPanel>
           </TabPanels>
         </React.Suspense>

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -739,10 +739,6 @@ export const handlers = [
   }),
   http.get('*/linode/instances', async ({ request }) => {
     linodeFactory.resetSequenceNumber();
-    const linodeWithFirewall = linodeFactory.build({
-      id: 1,
-      region: 'ap-west',
-    });
     const metadataLinodeWithCompatibleImage = linodeFactory.build({
       image: 'metadata-test-image',
       label: 'metadata-test-image',
@@ -824,7 +820,6 @@ export const handlers = [
       }),
     ];
     const linodes = [
-      linodeWithFirewall,
       ...mtcLinodes,
       ...aclpSupportedRegionLinodes,
       nonMTCPlanInMTCSupportedRegionsLinode,
@@ -887,63 +882,19 @@ export const handlers = [
 
       let filteredLinodes = linodes; // Default to the original linodes in case no filters are applied
 
-      // Handle combined filter structure with +and containing id and region filters (for CloudPulse)
+      // filter the linodes based on id or region
       if (andFilters?.length) {
-        // Check if this is a combined filter structure (multiple filter groups with +or arrays)
-        const hasCombinedFilter = andFilters.some(
-          (filterGroup: any) =>
-            filterGroup['+or'] && Array.isArray(filterGroup['+or'])
-        );
+        filteredLinodes = filteredLinodes.filter((linode) => {
+          const filteredById = andFilters.every(
+            (filter: { id: number }) => filter.id === linode.id
+          );
+          const filteredByRegion = andFilters.every(
+            (filter: { region: string }) => filter.region === linode.region
+          );
 
-        if (hasCombinedFilter) {
-          // Handle combined filter structure for CloudPulse alerts
-          filteredLinodes = filteredLinodes.filter((linode) => {
-            return andFilters.every((filterGroup: any) => {
-              // Handle id filter group
-              if (filterGroup['+or'] && Array.isArray(filterGroup['+or'])) {
-                const idFilters = filterGroup['+or'].filter(
-                  (f) => f.id !== undefined
-                );
-                const regionFilters = filterGroup['+or'].filter(
-                  (f) => f.region !== undefined
-                );
-
-                // Check if linode matches any id in the id filter group
-                const matchesId =
-                  idFilters.length === 0 ||
-                  idFilters.some((f) => Number(f.id) === linode.id);
-
-                // Check if linode matches any region in the region filter group
-                const matchesRegion =
-                  regionFilters.length === 0 ||
-                  regionFilters.some((f) => f.region === linode.region);
-
-                return matchesId && matchesRegion;
-              }
-
-              return false;
-            });
-          });
-        } else {
-          // Handle legacy andFilters for other use cases
-          filteredLinodes = filteredLinodes.filter((linode) => {
-            const filteredById = andFilters.every(
-              (filter: { id: number }) => filter.id === linode.id
-            );
-            const filteredByRegion = andFilters.every(
-              (filter: { region: string }) => filter.region === linode.region
-            );
-
-            return filteredById || filteredByRegion;
-          });
-        }
+          return filteredById || filteredByRegion;
+        });
       }
-
-      // The legacy id/region filtering logic has been removed here because it
-      // duplicated the work done above and incorrectly trimmed results when a
-      // newer "combined" filter structure (an array of "+or" groups inside
-      // "+and") was supplied. For legacy consumers the filtering is handled
-      // in the `else` branch above (lines ~922–934).
 
       // after the linodes are filtered based on region, filter the region-filtered linodes based on selected tags if any
       if (orFilters?.length) {

--- a/packages/manager/src/routes/firewalls/index.ts
+++ b/packages/manager/src/routes/firewalls/index.ts
@@ -167,15 +167,6 @@ const firewallDetailNodebalancersRemoveNodebalancerRoute = createRoute({
   )
 );
 
-const firewallDetailMetricsRoute = createRoute({
-  getParentRoute: () => firewallsRoute,
-  path: '$id/metrics',
-}).lazy(() =>
-  import('src/features/Firewalls/FirewallDetail/firewallDetailLazyRoute').then(
-    (m) => m.firewallDetailLazyRoute
-  )
-);
-
 export const firewallsRouteTree = firewallsRoute.addChildren([
   firewallsIndexRoute,
   firewallDetailRoute.addChildren([
@@ -194,7 +185,6 @@ export const firewallsRouteTree = firewallsRoute.addChildren([
       firewallDetailNodebalancersAddNodebalancerRoute,
       firewallDetailNodebalancersRemoveNodebalancerRoute,
     ]),
-    firewallDetailMetricsRoute,
   ]),
   firewallCreateRoute,
 ]);

--- a/packages/utilities/src/__data__/regionsData.ts
+++ b/packages/utilities/src/__data__/regionsData.ts
@@ -27,7 +27,7 @@ export const regions: Region[] = [
     },
     site_type: 'core',
     status: 'ok',
-    monitors: { alerts: [], metrics: ['Cloud Firewall'] },
+    monitors: { alerts: [], metrics: [] },
   },
   {
     capabilities: [


### PR DESCRIPTION
## Description 📝

Default `linode region` gets selected in firewalls contextual view.

## Changes  🔄

- Update `CloudPulseRegionSelect.tsx` to handle default linode region selection in firewalls contextual view. 
- Update unit tests.

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️
9 Sept 2025

## Preview 📷
| Before  | After   |
| ------- | ------- |
| <img width="1876" height="1538" alt="image" src="https://github.com/user-attachments/assets/518f95e7-f910-48a1-b935-fc9a24ed65a3" /> | <img width="3022" height="1622" alt="image" src="https://github.com/user-attachments/assets/fbeb1683-6144-4567-a862-071552bf93a0" /> |

## How to test 🧪

> [!note]
Firewalls integration and serverhandler update is temporary and would be removed after reviewer testing/verification. Don't review these files in changed files - index.tsx(firewalls/firewallDetail), index.tsx(/routes), serverHandler.ts, regionsData.ts. These are just for testing, will be removed after the pr is reviewed.

### Verification steps
- Navigate to metrics tab in /firewalls page.
- See if default `linode region` is selected. Verify in network tab that `/metrics` call gets fired automatically when you switch to `/metrics` tab under firewalls set of tabs.
- Navigate to `/metrics` under `monitor` tab in primary navigation, check if `linode region` filter is working fine, i.e. there is no impact due to contextual view changes(/changes in /firewalls page). 
         - **Expected behaviour** - It should be enabled only after firewall filter selection. On selection of `linode region`, `/metrics` api call should go, payload should have this prop - `associated_entity_region`: `selected region id`.
- Check the `region` filter of all the services as we touched a common component - `CloudPulseRegionSelect.tsx`.
- Play around with filters and report any unusual behaviour.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

-->