### PR TITLE
change: [M3-10586] - Remove update strategy from node pool summary item in LKE checkout bar

### DIFF
--- a/packages/manager/.changeset/pr-12814-removed-1757010425024.md
+++ b/packages/manager/.changeset/pr-12814-removed-1757010425024.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Removed
+---
+
+Update strategy from the Node Pool summary item in LKE checkout bar ([#12814](https://github.com/linode/manager/pull/12814))

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/NodePoolSummaryItem.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/NodePoolSummaryItem.tsx
@@ -8,7 +8,6 @@ import {
 } from '@linode/ui';
 import { pluralize } from '@linode/utilities';
 import * as React from 'react';
-import { useFormContext, useWatch } from 'react-hook-form';
 
 import { DisplayPrice } from 'src/components/DisplayPrice';
 import { EnhancedNumberInput } from 'src/components/EnhancedNumberInput/EnhancedNumberInput';
@@ -16,15 +15,11 @@ import { StyledLinkButtonBox } from 'src/components/SelectFirewallPanel/SelectFi
 import {
   MAX_NODES_PER_POOL_ENTERPRISE_TIER,
   MAX_NODES_PER_POOL_STANDARD_TIER,
-  UPDATE_STRATEGY_OPTIONS,
 } from 'src/features/Kubernetes/constants';
 
 import { useIsLkeEnterpriseEnabled } from '../kubeUtils';
 
-import type {
-  CreateClusterFormValues,
-  NodePoolConfigDrawerHandlerParams,
-} from '../CreateCluster/CreateCluster';
+import type { NodePoolConfigDrawerHandlerParams } from '../CreateCluster/CreateCluster';
 import type { KubernetesTier } from '@linode/api-v4';
 import type { ExtendedType } from 'src/utilities/extendType';
 
@@ -53,13 +48,6 @@ export const NodePoolSummaryItem = React.memo((props: Props) => {
 
   const { isLkeEnterprisePostLAFeatureEnabled } = useIsLkeEnterpriseEnabled();
 
-  const { control } = useFormContext<CreateClusterFormValues>();
-  const nodePoolsWatcher = useWatch({
-    control,
-    name: 'nodePools',
-  });
-  const thisPool = nodePoolsWatcher[poolIndex];
-
   // This should never happen but TS wants us to account for the situation
   // where we fail to match a selected type against our types list.
   if (poolType === null) {
@@ -77,13 +65,6 @@ export const NodePoolSummaryItem = React.memo((props: Props) => {
           <Typography>
             {pluralize('CPU', 'CPUs', poolType.vcpus)}, {poolType.disk / 1024}{' '}
             GB Storage
-          </Typography>
-          <Typography>
-            {isLkeEnterprisePostLAFeatureEnabled && thisPool
-              ? UPDATE_STRATEGY_OPTIONS.find(
-                  (option) => option.value === thisPool?.update_strategy
-                )?.label
-              : ''}
           </Typography>
         </Stack>
         <IconButton


### PR DESCRIPTION
## Description 📝

Currently, with Post LA changes, the kube checkout bar was updated to show the node pool's update strategy for each pool (for LKE-E clusters, where this selection is available).

After UX feedback, we've decided to keep the information in the checkout bar simple to avoid overwhelming the user with too many details and focus on pricing. Update strategy and firewall will not be listed. 

Firewall was not added to begin with, I just forgot to remove update strategy earlier - since this is only a display change  and has no functional impact, I don't think it's priority to squeeze this into the already cut 9/9 release, even if we flip the post LA flag before 9/23.
 
## Changes  🔄

- Remove the displayed update strategy from the UI and clean up related RHF logic no longer needed

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [X] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

9/23

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-09-04 at 11 05 02 AM](https://github.com/user-attachments/assets/e79a3758-9c40-4b85-8391-72189f752f19) | ![Screenshot 2025-09-04 at 11 03 40 AM](https://github.com/user-attachments/assets/06934e3a-8796-4a89-be4e-4231bf1b1c0b) |

## How to test 🧪

###  Prerequisites

- Have LKE-Enterprise enabled (feature flags: enabled, la, postLa) + customer tag

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] Check out `develop` and go to http://localhost:3000/kubernetes/create
- [ ] Select an LKE-E tier, go through the create flow, and add at least one node pool to the cluster
- [ ] Observe the checkout bar and note the update strategy is listed

### Verification steps

(How to verify changes)

- [ ] Check out this branch
- [ ] Select an LKE-E tier, go through the create flow, and add at least one node pool to the cluster
- [ ] Observe the checkout bar and note the update strategy is not listed

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

-->