### PR TITLE
new: [STORIF-81] Added ability to edit volume label.

### DIFF
--- a/packages/manager/.changeset/pr-12820-added-1757082532771.md
+++ b/packages/manager/.changeset/pr-12820-added-1757082532771.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Ability to edit volume label on the Volume Details page ([#12820](https://github.com/linode/manager/pull/12820))

--- a/packages/manager/src/features/Volumes/VolumeDetails/VolumeDetails.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDetails/VolumeDetails.tsx
@@ -3,7 +3,6 @@ import { CircleProgress, ErrorState } from '@linode/ui';
 import { useNavigate, useParams } from '@tanstack/react-router';
 import * as React from 'react';
 
-import { LandingHeader } from 'src/components/LandingHeader';
 import { SuspenseLoader } from 'src/components/SuspenseLoader';
 import { SafeTabPanel } from 'src/components/Tabs/SafeTabPanel';
 import { TabPanels } from 'src/components/Tabs/TabPanels';
@@ -12,6 +11,7 @@ import { TanStackTabLinkList } from 'src/components/Tabs/TanStackTabLinkList';
 import { useFlags } from 'src/hooks/useFlags';
 import { useTabs } from 'src/hooks/useTabs';
 
+import { VolumeDetailsHeader } from './VolumeDetailsHeader';
 import { VolumeEntityDetail } from './VolumeEntityDetails/VolumeEntityDetail';
 
 export const VolumeDetails = () => {
@@ -40,14 +40,7 @@ export const VolumeDetails = () => {
 
   return (
     <>
-      <LandingHeader
-        breadcrumbProps={{
-          pathname: `/volumes/${volume.label}`,
-        }}
-        docsLink="https://techdocs.akamai.com/cloud-computing/docs/faqs-for-compute-instances"
-        entity="Volume"
-        spacingBottom={16}
-      />
+      <VolumeDetailsHeader volume={volume} />
 
       <Tabs index={tabIndex} onChange={handleTabChange}>
         <TanStackTabLinkList tabs={tabs} />

--- a/packages/manager/src/features/Volumes/VolumeDetails/VolumeDetailsHeader.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDetails/VolumeDetailsHeader.tsx
@@ -1,0 +1,36 @@
+import { useVolumeUpdateMutation } from '@linode/queries';
+import * as React from 'react';
+
+import { LandingHeader } from 'src/components/LandingHeader';
+
+import type { Volume } from '@linode/api-v4';
+
+interface Props {
+  volume: Volume;
+}
+
+export const VolumeDetailsHeader = ({ volume }: Props) => {
+  const {
+    mutateAsync: updateVolume,
+    error,
+    reset,
+  } = useVolumeUpdateMutation(volume.id);
+
+  return (
+    <LandingHeader
+      breadcrumbProps={{
+        onEditHandlers: {
+          editableTextTitle: volume.label,
+          errorText: error?.[0].reason,
+          onCancel: reset,
+          onEdit: (label) => updateVolume({ label }),
+        },
+        pathname: `/volumes/${volume.label}`,
+      }}
+      docsLabel="Getting Started"
+      docsLink="https://techdocs.akamai.com/cloud-computing/docs/faqs-for-compute-instances"
+      entity="Volume"
+      spacingBottom={16}
+    />
+  );
+};


### PR DESCRIPTION
## Description 📝

 Added ability to edit volume label.

## Changes  🔄

- Created VolumeDetailsHeader component.
- Added label editing logic.

## Preview 📷

<img width="1035" height="136" alt="image" src="https://github.com/user-attachments/assets/774d5d75-3d85-48c5-8d55-ff159e60d774" />

## How to test 🧪

- Run cloud manager locally.
- Enable VolumeSummaryPage feature flag.
- Open /volumes/$volumeId page.
- Open developer tools -> Network tab.
- Press "Pencil" icon on the breadcrumb and edit label. 
- Observe the PUT request.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>