### PR TITLE
feat: [UIE-9166] - IAM RBAC: add a delay to Linodes menu

### DIFF
--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/LinodeBackupActionMenu.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/LinodeBackupActionMenu.tsx
@@ -15,14 +15,16 @@ interface Props {
 
 export const LinodeBackupActionMenu = (props: Props) => {
   const { backup, linodeId, onDeploy, onRestore } = props;
+  const [isOpen, setIsOpen] = React.useState<boolean>(false);
 
   const { data: accountPermissions } = usePermissions('account', [
     'create_linode',
   ]);
-  const { data: linodePermissions } = usePermissions(
+  const { data: linodePermissions, isLoading } = usePermissions(
     'linode',
     ['update_linode'],
-    linodeId
+    linodeId,
+    isOpen
   );
 
   const disabledPropsForRestore = {
@@ -60,6 +62,8 @@ export const LinodeBackupActionMenu = (props: Props) => {
     <ActionMenu
       actionsList={actions}
       ariaLabel={`Action menu for Backup ${backup.label}`}
+      loading={isLoading}
+      onOpen={() => setIsOpen(true)}
     />
   );
 };

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigActionMenu.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigActionMenu.tsx
@@ -22,7 +22,7 @@ export const ConfigActionMenu = (props: Props) => {
   const [isOpen, setIsOpen] = React.useState<boolean>(false);
   const navigate = useNavigate();
 
-  const { data: permissions } = usePermissions(
+  const { data: permissions, isLoading } = usePermissions(
     'linode',
     ['reboot_linode', 'update_linode', 'clone_linode', 'delete_linode'],
     linodeId,
@@ -76,6 +76,7 @@ export const ConfigActionMenu = (props: Props) => {
     <ActionMenu
       actionsList={actions}
       ariaLabel={`Action menu for Linode Config ${props.label}`}
+      loading={isLoading}
       onOpen={() => setIsOpen(true)}
     />
   );

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddresses.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddresses.tsx
@@ -59,6 +59,7 @@ export const LinodeIPAddresses = (props: LinodeIPAddressesProps) => {
   const { data: linode } = useLinodeQuery(linodeID);
   const { data: regions } = useRegionsQuery();
   const { isLinodeInterfacesEnabled } = useIsLinodeInterfacesEnabled();
+  const [isOpen, setIsOpen] = React.useState<boolean>(false);
 
   const linodeIsInDistributedRegion = getIsDistributedRegion(
     regions ?? [],
@@ -66,10 +67,11 @@ export const LinodeIPAddresses = (props: LinodeIPAddressesProps) => {
   );
 
   // TODO: Update to check share_ips, assign_ips, update_ip_rdns, and allocate_linode_ip_address permissions once available
-  const { data: permissions } = usePermissions(
+  const { data: permissions, isLoading: isPermissionsLoading } = usePermissions(
     'linode',
     ['update_linode'],
-    linodeID
+    linodeID,
+    isOpen
   );
   const isLinodeInterface = linode?.interface_generation === 'linode';
 
@@ -212,6 +214,8 @@ export const LinodeIPAddresses = (props: LinodeIPAddressesProps) => {
               },
             ]}
             ariaLabel="Linode IP Address Actions"
+            loading={isPermissionsLoading}
+            onOpen={() => setIsOpen(true)}
           />
         ) : (
           <Stack direction="row" spacing={1}>

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeStorage/LinodeDiskActionMenu.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeStorage/LinodeDiskActionMenu.tsx
@@ -31,7 +31,7 @@ export const LinodeDiskActionMenu = (props: Props) => {
     readOnly,
   } = props;
 
-  const { data: permissions } = usePermissions(
+  const { data: permissions, isLoading } = usePermissions(
     'linode',
     ['update_linode', 'resize_linode', 'delete_linode', 'clone_linode'],
     linodeId,
@@ -106,6 +106,7 @@ export const LinodeDiskActionMenu = (props: Props) => {
     <ActionMenu
       actionsList={actions}
       ariaLabel={`Action menu for Disk ${disk.label}`}
+      loading={isLoading}
       onOpen={() => setIsOpen(true)}
     />
   );

--- a/packages/manager/src/features/Linodes/LinodesLanding/LinodeActionMenu/LinodeActionMenu.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/LinodeActionMenu/LinodeActionMenu.tsx
@@ -55,12 +55,13 @@ export const LinodeActionMenu = (props: LinodeActionMenuProps) => {
   const regions = useRegionsQuery().data ?? [];
   const isBareMetalInstance = linodeType?.class === 'metal';
   const hasHostMaintenance = linodeStatus === 'stopped';
+  const [isOpen, setIsOpen] = React.useState<boolean>(false);
 
   const { data: accountPermissions } = usePermissions('account', [
     'create_linode',
   ]);
 
-  const { data: permissions } = usePermissions(
+  const { data: permissions, isLoading } = usePermissions(
     'linode',
     [
       'shutdown_linode',
@@ -74,7 +75,8 @@ export const LinodeActionMenu = (props: LinodeActionMenuProps) => {
       'delete_linode',
       'generate_linode_lish_token',
     ],
-    linodeId
+    linodeId,
+    isOpen
   );
 
   const handlePowerAction = () => {
@@ -256,7 +258,11 @@ export const LinodeActionMenu = (props: LinodeActionMenuProps) => {
     <ActionMenu
       actionsList={actions}
       ariaLabel={`Action menu for Linode ${props.linodeLabel}`}
-      onOpen={sendLinodeActionEvent}
+      loading={isLoading}
+      onOpen={() => {
+        sendLinodeActionEvent();
+        setIsOpen(true);
+      }}
     />
   );
 };


### PR DESCRIPTION
## Description 📝

We are requesting all permissions for every row on linodes landing. We should wait until the user clicks the action menu to fetch the permissions. 

## Changes  🔄

List any change(s) relevant to the reviewer.

- Add a delay for an action menu for checking permissions in Linodes

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [x] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

09/23

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <img width="3206" height="1742" alt="image" src="https://github.com/user-attachments/assets/d23180dd-1ddc-446c-919d-c578e5fc10fa" /> | <img width="3234" height="1858" alt="image" src="https://github.com/user-attachments/assets/2aee680f-0fe2-4728-9916-6d25a96b60cd" /> |
| 📷 | <img width="3270" height="1638" alt="image" src="https://github.com/user-attachments/assets/bfee15a1-3280-4fe7-8288-537eb0f8228c" /> |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- MSW or iam (restricted) + regular account to compare
- navigate to /linodes


### Verification steps

(How to verify changes)

- [ ] Confirm that permissions are only requested once the user clicks the action menu

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>