### PR TITLE
fix: [M3-10606] - Redirects /settings to /account-settings

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Profile preferences not retained across sessions ([#12795](https://github.com/linode/manager/pull/12795))
 - Make a Payment and Add Payment drawers not closing when browser back button is clicked ([#12796](https://github.com/linode/manager/pull/12796))
 - Node Pool footer layout ([#12798](https://github.com/linode/manager/pull/12798))
+- Redirects /settings to /account-settings ([#12841](https://github.com/linode/manager/pull/12841))
 
 ### Removed:
 

--- a/packages/manager/src/routes/accountSettings/index.ts
+++ b/packages/manager/src/routes/accountSettings/index.ts
@@ -41,8 +41,7 @@ export const accountSettingsRouteTree = accountSettingsRoute.addChildren([
   accountSettingsCatchAllRoute,
 ]);
 
-// This supports redirecting from /settings, which was initially used to redirect to /account/settings,
-// and has now been changed to /account-settings.
+// This supports redirecting from /settings to /account-settings(which renamed from 'settings' to 'account-settings' ).
 export const settingsRouteTree = createRoute({
   getParentRoute: () => rootRoute,
   path: 'settings',

--- a/packages/manager/src/routes/accountSettings/index.ts
+++ b/packages/manager/src/routes/accountSettings/index.ts
@@ -40,3 +40,13 @@ export const accountSettingsRouteTree = accountSettingsRoute.addChildren([
   accountSettingsIndexRoute,
   accountSettingsCatchAllRoute,
 ]);
+
+// This supports redirecting from /settings, which was initially used to redirect to /account/settings,
+// and has now been changed to /account-settings.
+export const settingsRouteTree = createRoute({
+  getParentRoute: () => rootRoute,
+  path: 'settings',
+  beforeLoad: () => {
+    throw redirect({ to: '/account-settings' });
+  },
+});

--- a/packages/manager/src/routes/index.tsx
+++ b/packages/manager/src/routes/index.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { ErrorComponent } from 'src/features/ErrorBoundary/ErrorComponent';
 
 import { accountRouteTree } from './account';
-import { accountSettingsRouteTree } from './accountSettings';
+import { accountSettingsRouteTree, settingsRouteTree } from './accountSettings';
 import { cloudPulseAlertsRouteTree } from './alerts';
 import {
   cancelLandingRoute,
@@ -86,6 +86,7 @@ export const routeTree = rootRoute.addChildren([
   quotasRouteTree,
   searchRouteTree,
   serviceTransfersRouteTree,
+  settingsRouteTree,
   stackScriptsRouteTree,
   supportRouteTree,
   usersAndGrantsRouteTree,


### PR DESCRIPTION
## Description 📝

This PR redirects /settings route to /account-settings. 


### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [x] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

9/9

## Preview 📷

https://github.com/user-attachments/assets/7ed45cd4-882f-45c3-96bf-443b7fbde773


## How to test 🧪

### Verification steps

(How to verify changes)

- [ ] Checkout, run the app locally and navigate to localhost:3000/settings 
- [ ] Verify it should re-route to account-settings 
- [ ] verify no regression in routing to /account-settings, /settings, /account/settings page. 

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

