### PR TITLE
M3-10512 Cypress test flake in events-fetching

### DIFF
--- a/packages/manager/.changeset/pr-12875-tests-1757702639982.md
+++ b/packages/manager/.changeset/pr-12875-tests-1757702639982.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Cypress test flake in "events-fetching.spec.ts" ([#12875](https://github.com/linode/manager/pull/12875))


### PR DESCRIPTION
## Description 📝

Fix Cypress test flake in events-fetching.spec.ts

## Changes  🔄

List any change(s) relevant to the reviewer.
- Change code to ignore the delay within 1 second.

## How to test 🧪
```
pnpm cy:run -s "cypress/e2e/core/notificationsAndEvents/events-fetching.spec.ts"
```