### PR TITLE
upcoming: [DI-26794] - Scope support for Cloud Firewall dimension filters

### DIFF
--- a/packages/manager/.changeset/pr-12879-upcoming-features-1757953229656.md
+++ b/packages/manager/.changeset/pr-12879-upcoming-features-1757953229656.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Account scope support for ACLP-Alerting firewall dimension filters ([#12879](https://github.com/linode/manager/pull/12879))

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterField.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterField.tsx
@@ -80,6 +80,11 @@ export const DimensionFilterField = (props: DimensionFilterFieldProps) => {
     control,
     name: 'serviceType',
   });
+  const scopeWatcher = useWatch({
+    control,
+    name: 'scope',
+  });
+  const selectedRegionsWatcher = useWatch({ control, name: 'regions' });
   const selectedDimension =
     dimensionOptions && dimensionFieldWatcher
       ? (dimensionOptions.find(
@@ -171,6 +176,8 @@ export const DimensionFilterField = (props: DimensionFilterFieldProps) => {
               onBlur={field.onBlur}
               onChange={field.onChange}
               operator={dimensionOperatorWatcher}
+              scope={scopeWatcher}
+              selectedRegions={selectedRegionsWatcher}
               serviceType={serviceType}
               value={field.value}
               values={selectedDimension?.values ?? []}

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterValue/ValueFieldRenderer.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterValue/ValueFieldRenderer.tsx
@@ -63,6 +63,10 @@ interface ValueFieldRendererProps {
    */
   scope?: AlertDefinitionScope | null;
   /**
+   * List of selected regions under the region scope
+   */
+  selectedRegions?: string[];
+  /**
    * Service type of the alert
    */
   serviceType?: CloudPulseServiceType | null;

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterValue/useFetchOptions.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterValue/useFetchOptions.ts
@@ -5,7 +5,7 @@ import { useResourcesQuery } from 'src/queries/cloudpulse/resources';
 
 import { filterRegionByServiceType } from '../../../Utils/utils';
 import {
-  getFilteredFirewallResources,
+  getFilteredFirewallParentEntities,
   getFirewallLinodes,
   getLinodeRegions,
   getVPCSubnets,
@@ -87,16 +87,20 @@ export function useFetchOptions(props: FetchOptionsProps): FetchOptions {
   );
 
   // Decide firewall resource IDs based on scope
-  const filteredFirewallResourcesIds = useMemo(() => {
-    if (scope === 'account') {
-      return (firewallResources ?? []).map((r) => r.id);
-    }
-    return getFilteredFirewallResources(firewallResources, entities);
+  const filteredFirewallParentEntityIds = useMemo(() => {
+    const selectedEntities =
+      scope && scope === 'account'
+        ? firewallResources?.map((r) => r.id)
+        : entities;
+    return getFilteredFirewallParentEntities(
+      firewallResources,
+      selectedEntities
+    );
   }, [scope, firewallResources, entities]);
 
   const idFilter = {
-    '+or': filteredFirewallResourcesIds.length
-      ? filteredFirewallResourcesIds.map((id) => ({ id }))
+    '+or': filteredFirewallParentEntityIds.length
+      ? filteredFirewallParentEntityIds.map((id) => ({ id }))
       : [{ id: '' }],
   };
 
@@ -113,7 +117,7 @@ export function useFetchOptions(props: FetchOptionsProps): FetchOptions {
     {},
     combinedFilter,
     filterLabels.includes(dimensionLabel ?? '') &&
-      filteredFirewallResourcesIds.length > 0 &&
+      filteredFirewallParentEntityIds.length > 0 &&
       supportedRegionIds?.length > 0
   );
 

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterValue/utils.test.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterValue/utils.test.ts
@@ -2,7 +2,7 @@ import { linodeFactory } from '@linode/utilities';
 
 import { transformDimensionValue } from '../../../Utils/utils';
 import {
-  getFilteredFirewallResources,
+  getFilteredFirewallParentEntities,
   getFirewallLinodes,
   getLinodeRegions,
   getOperatorGroup,
@@ -107,7 +107,7 @@ describe('Utils', () => {
     });
   });
 
-  describe('getFilteredFirewallResources', () => {
+  describe('getFilteredFirewallParentEntities', () => {
     const resources: CloudPulseResources[] = [
       {
         id: '1',
@@ -122,16 +122,16 @@ describe('Utils', () => {
     ];
 
     it('should return matched resources by entity IDs', () => {
-      expect(getFilteredFirewallResources(resources, ['1'])).toEqual(['a']);
+      expect(getFilteredFirewallParentEntities(resources, ['1'])).toEqual(['a']);
     });
 
     it('should return empty array if no match', () => {
-      expect(getFilteredFirewallResources(resources, ['3'])).toEqual([]);
+      expect(getFilteredFirewallParentEntities(resources, ['3'])).toEqual([]);
     });
 
     it('should handle undefined inputs', () => {
-      expect(getFilteredFirewallResources(undefined, ['1'])).toEqual([]);
-      expect(getFilteredFirewallResources(resources, undefined)).toEqual([]);
+      expect(getFilteredFirewallParentEntities(undefined, ['1'])).toEqual([]);
+      expect(getFilteredFirewallParentEntities(resources, undefined)).toEqual([]);
     });
   });
 

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterValue/utils.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterValue/utils.ts
@@ -95,7 +95,7 @@ export const getStaticOptions = (
  * @param entities - List of target firewall entity IDs.
  * @returns - Flattened array of matching entity IDs.
  */
-export const getFilteredFirewallResources = (
+export const getFilteredFirewallParentEntities = (
   firewallResources: CloudPulseResources[] | undefined,
   entities: string[] | undefined
 ): string[] => {

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -2928,6 +2928,7 @@ export const handlers = [
         label: 'Firewall - testing',
         service_type: 'firewall',
         type: 'user',
+        scope: 'account',
         created_by: 'user1',
         rule_criteria: {
           rules: [firewallMetricRulesFactory.build()],
@@ -2946,6 +2947,7 @@ export const handlers = [
             label: 'Firewall - testing',
             service_type: 'firewall',
             type: 'user',
+            scope: 'account',
             rule_criteria: {
               rules: [firewallMetricRulesFactory.build()],
             },
@@ -2983,6 +2985,7 @@ export const handlers = [
             label: 'Firewall - testing',
             service_type: 'firewall',
             type: 'user',
+            scope: 'account',
             rule_criteria: {
               rules: [firewallMetricRulesFactory.build()],
             },


### PR DESCRIPTION
## Description 📝

Support for fetching linode, linode region options for account scope in Alerting.

## Changes  🔄

- Passing scope as a parameter from the DimensionFilterField component to ValueFieldRenderer, useFetchOptions
- Handling region and account scope for firewall filtering in useFetchOptions

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [x] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️
September 23rd.

## Preview 📷
### Create Alert Account scope
https://github.com/user-attachments/assets/f3ac314a-c1ed-4167-9b4f-2feaeeb41755

### Edit Alert Account scope 
![Screenshot 2025-09-08 at 11 45 59](https://github.com/user-attachments/assets/f3ce0f35-6647-41cc-a5e4-80767ce08aab)

### Show-details Account scope
![Screenshot 2025-09-08 at 11 46 10](https://github.com/user-attachments/assets/05ee3dc5-1d0b-4cb6-ab33-083b84d9ad98)


## How to test 🧪

### Prerequisites

(How to setup test environment)

In Mock environment , please choose Legacy MSW Handlers for Base Preset
Under Monitor, click on Alerts
For Create : Click on Create Alert button, choose the Firewall service. Please select Account scope . And for Linode, Linode Region dimension filter there should be some values present which should be the same if you select Entity scope and select all the Firewalls and then check the Linode, Linode Region options
For Show-Details: In the Alerts Page, Find 'Firewall - testing' alert and in action menu click on Show Details
For Edit: In the Alerts Page, Find 'Firewall - testing' alert and in action menu click on Edit. The account scope will be the default and similar to Create some values for the Linode and Linode Region dimension filters will be be available.

(How to reproduce the issue, if applicable)

- [ ] ...
- [ ] ...

### Verification steps

(How to verify changes)

- [ ] For account scope, the Linode, Linode Region dimension filters are working properly.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>