### PR TITLE
test: [M3-10628] - Fix Cypress test failures after LKE-E Post LA flag was toggled on

### DIFF
--- a/packages/manager/.changeset/pr-12883-tests-1758049052198.md
+++ b/packages/manager/.changeset/pr-12883-tests-1758049052198.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tests
+---
+
+Update Cypress tests following LKE-E postLa feature flag enablement ([#12883](https://github.com/linode/manager/pull/12883))

--- a/packages/manager/cypress/e2e/core/kubernetes/smoke-lke-standard-create.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/smoke-lke-standard-create.spec.ts
@@ -13,7 +13,7 @@ import {
   mockGetProfileGrants,
 } from 'support/intercepts/profile';
 import { ui } from 'support/ui';
-import { addNodes } from 'support/util/lke';
+import { lkeClusterCreatePage } from 'support/ui/pages/lke-cluster-create-page';
 import { randomLabel, randomNumber } from 'support/util/random';
 import { chooseRegion } from 'support/util/regions';
 
@@ -25,6 +25,7 @@ describe('LKE Create Cluster', () => {
         enabled: true,
         la: true,
         phase2Mtc: { byoVPC: true, dualStack: true },
+        postLa: true,
       },
     }).as('getFeatureFlags');
   });
@@ -36,34 +37,59 @@ describe('LKE Create Cluster', () => {
     });
     mockCreateCluster(mockCluster).as('createCluster');
     cy.visitWithLogin('/kubernetes/create');
-    cy.findByText('Add Node Pools').should('be.visible');
 
-    cy.findByLabelText('Cluster Label').click();
-    cy.focused().type(mockCluster.label);
-
+    const mockPlanName = 'Linode 2 GB';
     const lkeRegion = chooseRegion({
       capabilities: ['Kubernetes'],
     });
 
-    ui.regionSelect.find().click().type(`${lkeRegion.label}`);
-    ui.regionSelect.findItemByRegionId(lkeRegion.id).click();
+    // Configure an LKE cluster.
+    lkeClusterCreatePage.setLabel(mockCluster.label);
+    lkeClusterCreatePage.selectRegionById(lkeRegion.id);
+    lkeClusterCreatePage.setEnableHighAvailability(true);
+    lkeClusterCreatePage.selectPlanTab('Shared CPU');
+    lkeClusterCreatePage.selectNodePoolPlan(mockPlanName);
 
-    cy.findByLabelText('Kubernetes Version').should('be.visible').click();
-    cy.findByText('1.32').should('be.visible').click();
+    // Create a node pool then confirm the order summary UI updates to reflect node pool selection.
+    cy.findByText('Add Node Pools').should('be.visible');
 
-    cy.get('[data-testid="ha-radio-button-yes"]').should('be.visible').click();
+    lkeClusterCreatePage.withinNodePoolDrawer(mockPlanName, () => {
+      ui.button
+        .findByTitle('Add Pool')
+        .should('be.visible')
+        .should('be.enabled')
+        .click();
+    });
 
-    cy.findByText('Shared CPU').should('be.visible').click();
-    addNodes('Linode 2 GB');
+    lkeClusterCreatePage.withinOrderSummary(() => {
+      cy.contains(mockPlanName)
+        .closest('[data-testid="node-pool-summary"]')
+        .within(() => {
+          cy.findByText('Linode 2 GB Plan').should('be.visible');
+          cy.findByTitle('Remove Linode 2GB Node Pool').should('exist');
+          cy.findByText('3 Nodes').should('be.visible');
+          cy.findByText('Edit Configuration').should('be.visible').click();
+        });
+    });
 
-    // Confirm change is reflected in checkout bar.
-    cy.get('[data-testid="kube-checkout-bar"]').within(() => {
-      cy.findByText('Linode 2 GB Plan').should('be.visible');
-      cy.findByTitle('Remove Linode 2GB Node Pool').should('be.visible');
-
+    // Update the node pool's count and confirm warning exists in drawer.
+    lkeClusterCreatePage.withinNodePoolDrawer(mockPlanName, () => {
+      cy.get('[data-testid="decrement-button"]').click();
+      cy.get('[data-testid="decrement-button"]').click();
       cy.get('[data-qa-notice="true"]').within(() => {
-        cy.findByText(minimumNodeNotice).should('be.visible');
+        cy.findByText(minimumNodeNotice).should('exist');
       });
+
+      ui.button
+        .findByTitle('Update Pool')
+        .should('be.visible')
+        .should('be.enabled')
+        .click();
+    });
+
+    // Confirm warning exists in checkout and submit.
+    lkeClusterCreatePage.withinOrderSummary(() => {
+      cy.findByText(minimumNodeNotice).should('exist');
 
       ui.button
         .findByTitle('Create Cluster')

--- a/packages/manager/cypress/e2e/core/linodes/plan-selection.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/plan-selection.spec.ts
@@ -285,8 +285,6 @@ describe('displays kubernetes plans panel based on availability', () => {
           'disabled'
         );
         cy.get('[data-qa-plan-row="dedicated-3"]').within(() => {
-          cy.get('[data-testid="decrement-button"]').should('be.disabled');
-          cy.get('[data-testid="increment-button"]').should('be.disabled');
           cy.get('[data-testid="button"]')
             .should(
               'have.attr',


### PR DESCRIPTION
## Description 📝

We started seeing test failures since we turned the LKE-Enterprise `postLa` flag on in prod yesterday. Based on the screenshot, a couple of current tests haven't accounted for the change to the Node Pool plans table, which no longer has an enhanced number input increment/decrement button. That has been moved inside the Configure Pool drawer.

## Changes  🔄

- Update `plan-selection.spec.ts` to remove the check for the disabled increment/decrement buttons. Just a disabled Configure Pool button is visible now.
- Update `smoke-lke-standard-create.spec.ts` to use the new LKE helper functions and correctly reference the Configure Pool button, rather than attempt to click the enhanced number input buttons in the plan row.

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [x] No customers / Not applicable

## Target release date 🗓️

9/23 - let's please get this in so that we don't have to deal with these test failures in the release

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <img width="1841" height="574" alt="image (29)" src="https://github.com/user-attachments/assets/571cc827-248b-4bea-9213-01350a969495" /> | <img width="855" height="322" alt="image" src="https://github.com/user-attachments/assets/3ebde26a-cdce-4b61-9506-011910180753" /> |

## How to test 🧪

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] Check out develop and run these tests, or check the notifications Slack channel and observe the recent test failures

### Verification steps

(How to verify changes)

- [ ] Watch CI or check out this branch locally and:
```
pnpm cy:run -s "cypress/e2e/core/linodes/plan-selection.spec.ts,cypress/e2e/core/kubernetes/smoke-lke-standard-create.spec.ts"
```

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

-->