### PR TITLE
upcoming: [DI-27338] - Added group by on metrics global and widget filter

### DIFF
--- a/packages/api-v4/src/cloudpulse/types.ts
+++ b/packages/api-v4/src/cloudpulse/types.ts
@@ -72,7 +72,7 @@ export interface Widgets {
   color: string;
   entity_ids: string[];
   filters: Filters[];
-  group_by: string[];
+  group_by?: string[];
   label: string;
   metric: string;
   namespace_id: number;
@@ -150,7 +150,7 @@ export interface CloudPulseMetricsRequest {
   associated_entity_region?: string;
   entity_ids: number[];
   filters?: Filters[];
-  group_by: string[];
+  group_by?: string[];
   metrics: Metric[];
   relative_time_duration: TimeDuration | undefined;
   time_granularity: TimeGranularity | undefined;

--- a/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboard.tsx
+++ b/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboard.tsx
@@ -36,6 +36,11 @@ export interface DashboardProperties {
   duration: DateTimeWithPreset;
 
   /**
+   * list of fields to group the metrics data by
+   */
+  groupBy: string[];
+
+  /**
    * Selected linode region for the dashboard
    */
   linodeRegion?: string;
@@ -74,11 +79,11 @@ export const CloudPulseDashboard = (props: DashboardProperties) => {
     manualRefreshTimeStamp,
     resources,
     savePref,
+    groupBy,
     linodeRegion,
   } = props;
 
   const { preferences } = useAclpPreference();
-
   const getJweTokenPayload = (): JWETokenPayLoad => {
     return {
       entity_ids: resources?.map((resource) => Number(resource)) ?? [],
@@ -152,12 +157,12 @@ export const CloudPulseDashboard = (props: DashboardProperties) => {
       'No visualizations are available at this moment. Create Dashboards to list here.'
     );
   }
-
   return (
     <RenderWidgets
       additionalFilters={additionalFilters}
       dashboard={dashboard}
       duration={duration}
+      groupBy={groupBy}
       isJweTokenFetching={isJweTokenFetching}
       jweToken={jweToken}
       linodeRegion={linodeRegion}

--- a/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardLanding.tsx
+++ b/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardLanding.tsx
@@ -24,6 +24,7 @@ export interface CloudPulseMetricsFilter {
 export interface DashboardProp {
   dashboard?: Dashboard;
   filterValue: CloudPulseMetricsFilter;
+  groupBy: string[];
   timeDuration?: DateTimeWithPreset;
 }
 
@@ -32,6 +33,8 @@ export const CloudPulseDashboardLanding = () => {
     id: {},
     label: {},
   });
+
+  const [groupBy, setGroupBy] = React.useState<string[]>([]);
 
   const [timeDuration, setTimeDuration] = React.useState<
     DateTimeWithPreset | undefined
@@ -45,6 +48,10 @@ export const CloudPulseDashboardLanding = () => {
   const toggleAppliedFilter = (isVisible: boolean) => {
     setShowAppliedFilters(isVisible);
   };
+
+  const onGroupByChange = React.useCallback((selectedValues: string[]) => {
+    setGroupBy(selectedValues);
+  }, []);
 
   const onFilterChange = React.useCallback(
     (filterKey: string, filterValue: FilterValueType, labels: string[]) => {
@@ -92,6 +99,7 @@ export const CloudPulseDashboardLanding = () => {
               <GlobalFilters
                 handleAnyFilterChange={onFilterChange}
                 handleDashboardChange={onDashboardChange}
+                handleGroupByChange={onGroupByChange}
                 handleTimeDurationChange={onTimeDurationChange}
                 handleToggleAppliedFilter={toggleAppliedFilter}
               />
@@ -107,6 +115,7 @@ export const CloudPulseDashboardLanding = () => {
         <CloudPulseDashboardRenderer
           dashboard={dashboard}
           filterValue={filterData.id}
+          groupBy={groupBy}
           timeDuration={timeDuration}
         />
       </GridLegacy>

--- a/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardRenderer.tsx
+++ b/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardRenderer.tsx
@@ -19,8 +19,7 @@ import type { DashboardProp } from './CloudPulseDashboardLanding';
 
 export const CloudPulseDashboardRenderer = React.memo(
   (props: DashboardProp) => {
-    const { dashboard, filterValue, timeDuration } = props;
-
+    const { dashboard, filterValue, timeDuration, groupBy } = props;
     const selectDashboardAndFilterMessage =
       'Select a dashboard and apply filters to visualize metrics.';
 
@@ -63,6 +62,7 @@ export const CloudPulseDashboardRenderer = React.memo(
         additionalFilters={getMetricsCall}
         dashboardId={dashboard.id}
         duration={timeDuration}
+        groupBy={groupBy}
         linodeRegion={
           filterValue[LINODE_REGION] &&
           typeof filterValue[LINODE_REGION] === 'string'

--- a/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardWithFilters.tsx
+++ b/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardWithFilters.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 import { useCloudPulseDashboardByIdQuery } from 'src/queries/cloudpulse/dashboards';
 
+import { GlobalFilterGroupByRenderer } from '../GroupBy/GlobalFilterGroupByRenderer';
 import { CloudPulseAppliedFilterRenderer } from '../shared/CloudPulseAppliedFilterRenderer';
 import { CloudPulseDashboardFilterBuilder } from '../shared/CloudPulseDashboardFilterBuilder';
 import { CloudPulseDashboardSelect } from '../shared/CloudPulseDashboardSelect';
@@ -43,6 +44,8 @@ export const CloudPulseDashboardWithFilters = React.memo(
       label: {},
     });
 
+    const [groupBy, setGroupBy] = React.useState<string[]>([]);
+
     const [timeDuration, setTimeDuration] =
       React.useState<DateTimeWithPreset>();
 
@@ -70,6 +73,10 @@ export const CloudPulseDashboardWithFilters = React.memo(
       },
       []
     );
+
+    const handleGroupByChange = React.useCallback((groupBy: string[]) => {
+      setGroupBy(groupBy);
+    }, []);
 
     const handleTimeRangeChange = React.useCallback(
       (timeDuration: DateTimeWithPreset) => {
@@ -116,6 +123,7 @@ export const CloudPulseDashboardWithFilters = React.memo(
       filterValue: filterData.id,
       resource,
       timeDuration,
+      groupBy,
     });
 
     return (
@@ -139,11 +147,21 @@ export const CloudPulseDashboardWithFilters = React.memo(
                   defaultValue={dashboardId}
                   isServiceIntegration
                 />
-
-                <CloudPulseDateTimeRangePicker
-                  handleStatsChange={handleTimeRangeChange}
-                  savePreferences
-                />
+                <Box
+                  display="flex"
+                  flexDirection={{ md: 'row', xs: 'column' }}
+                  flexWrap="wrap"
+                  gap={2}
+                >
+                  <CloudPulseDateTimeRangePicker
+                    handleStatsChange={handleTimeRangeChange}
+                    savePreferences
+                  />
+                  <GlobalFilterGroupByRenderer
+                    handleChange={handleGroupByChange}
+                    selectedDashboard={dashboard}
+                  />
+                </Box>
               </Box>
             </GridLegacy>
 
@@ -189,6 +207,7 @@ export const CloudPulseDashboardWithFilters = React.memo(
               filterValue: filterData.id,
               resource,
               timeDuration,
+              groupBy,
             })}
             linodeRegion={
               filterData.id[LINODE_REGION]

--- a/packages/manager/src/features/CloudPulse/GroupBy/CloudPulseGroupByDrawer.tsx
+++ b/packages/manager/src/features/CloudPulse/GroupBy/CloudPulseGroupByDrawer.tsx
@@ -76,7 +76,7 @@ export const CloudPulseGroupByDrawer = React.memo(
     const [selectedValue, setSelectedValue] = React.useState<GroupByOption[]>(
       defaultValue.slice(
         0,
-        Math.min(defaultValue.length ?? 0, GROUP_BY_SELECTION_LIMIT)
+        Math.min(defaultValue.length, GROUP_BY_SELECTION_LIMIT)
       )
     );
     const previousValueRef = React.useRef<GroupByOption[]>(
@@ -94,7 +94,7 @@ export const CloudPulseGroupByDrawer = React.memo(
     React.useEffect(() => {
       const value = defaultValue.slice(
         0,
-        Math.min(defaultValue.length ?? 0, GROUP_BY_SELECTION_LIMIT)
+        Math.min(defaultValue.length, GROUP_BY_SELECTION_LIMIT)
       );
       onApply(value);
       setSelectedValue(value);

--- a/packages/manager/src/features/CloudPulse/GroupBy/GlobalFilterGroupByRenderer.tsx
+++ b/packages/manager/src/features/CloudPulse/GroupBy/GlobalFilterGroupByRenderer.tsx
@@ -65,7 +65,9 @@ export const GlobalFilterGroupByRenderer = (
           sx={(theme) => ({
             marginBlockEnd: 'auto',
             marginTop: { md: theme.spacingFunction(28) },
-            color: isSelected ? theme.color.buttonPrimaryHover : 'inherit',
+            color: isSelected
+              ? theme.tokens.component.Button.Primary.Hover.Background
+              : 'inherit',
           })}
         >
           <GroupByIcon height="24px" width="24px" />

--- a/packages/manager/src/features/CloudPulse/Overview/GlobalFilters.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Overview/GlobalFilters.test.tsx
@@ -10,11 +10,13 @@ const mockHandleAnyFilterChange = vi.fn();
 const mockHandleDashboardChange = vi.fn();
 const mockHandleTimeDurationChange = vi.fn();
 const mockHandleToggleAppliedFilter = vi.fn();
+const mockHandleGroupByChange = vi.fn();
 const setup = () => {
   renderWithTheme(
     <GlobalFilters
       handleAnyFilterChange={mockHandleAnyFilterChange}
       handleDashboardChange={mockHandleDashboardChange}
+      handleGroupByChange={mockHandleGroupByChange}
       handleTimeDurationChange={mockHandleTimeDurationChange}
       handleToggleAppliedFilter={mockHandleToggleAppliedFilter}
     />

--- a/packages/manager/src/features/CloudPulse/Overview/GlobalFilters.tsx
+++ b/packages/manager/src/features/CloudPulse/Overview/GlobalFilters.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import Reload from 'src/assets/icons/refresh.svg';
 import { useResourcesQuery } from 'src/queries/cloudpulse/resources';
 
+import { GlobalFilterGroupByRenderer } from '../GroupBy/GlobalFilterGroupByRenderer';
 import { CloudPulseDashboardFilterBuilder } from '../shared/CloudPulseDashboardFilterBuilder';
 import { CloudPulseDashboardSelect } from '../shared/CloudPulseDashboardSelect';
 import { CloudPulseDateTimeRangePicker } from '../shared/CloudPulseDateTimeRangePicker';
@@ -29,6 +30,7 @@ export interface GlobalFilterProperties {
     labels: string[]
   ): void;
   handleDashboardChange(dashboard: Dashboard | undefined): void;
+  handleGroupByChange: (selectedValues: string[]) => void;
   handleTimeDurationChange(timeDuration: DateTimeWithPreset): void;
   handleToggleAppliedFilter(isVisible: boolean): void;
 }
@@ -39,6 +41,7 @@ export const GlobalFilters = React.memo((props: GlobalFilterProperties) => {
     handleDashboardChange,
     handleTimeDurationChange,
     handleToggleAppliedFilter,
+    handleGroupByChange,
   } = props;
 
   const { preferences, updateGlobalFilterPreference: updatePreferences } =
@@ -129,6 +132,7 @@ export const GlobalFilters = React.memo((props: GlobalFilterProperties) => {
               handleStatsChange={handleTimeRangeChange}
               savePreferences
             />
+
             <CloudPulseTooltip placement="bottom-end" title="Refresh">
               <IconButton
                 aria-label="Refresh Dashboard Metrics"
@@ -145,6 +149,10 @@ export const GlobalFilters = React.memo((props: GlobalFilterProperties) => {
                 <Reload height="24px" width="24px" />
               </IconButton>
             </CloudPulseTooltip>
+            <GlobalFilterGroupByRenderer
+              handleChange={handleGroupByChange}
+              selectedDashboard={selectedDashboard}
+            />
           </Box>
         </Box>
       </GridLegacy>

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
@@ -319,7 +319,7 @@ export const getCloudPulseMetricRequest = (
       ? entityIds.map((id) => parseInt(id, 10))
       : widget.entity_ids.map((id) => parseInt(id, 10)),
     filters: undefined,
-    group_by: groupBy,
+    group_by: !groupBy?.length ? undefined : groupBy,
     relative_time_duration: getTimeDurationFromPreset(preset),
     metrics: [
       {

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
@@ -113,6 +113,8 @@ interface MetricRequestProps {
    */
   entityIds: string[];
 
+  groupBy?: string[];
+
   /**
    * selected linode region for the widget
    */
@@ -304,7 +306,7 @@ export const generateMaxUnit = (
 export const getCloudPulseMetricRequest = (
   props: MetricRequestProps
 ): CloudPulseMetricsRequest => {
-  const { duration, entityIds, resources, widget, linodeRegion } = props;
+  const { duration, entityIds, resources, widget, groupBy, linodeRegion } = props;
   const preset = duration.preset;
 
   return {
@@ -316,7 +318,7 @@ export const getCloudPulseMetricRequest = (
       ? entityIds.map((id) => parseInt(id, 10))
       : widget.entity_ids.map((id) => parseInt(id, 10)),
     filters: undefined,
-    group_by: widget.group_by,
+    group_by: groupBy,
     relative_time_duration: getTimeDurationFromPreset(preset),
     metrics: [
       {

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
@@ -419,7 +419,8 @@ export const getDimensionName = (props: DimensionNameProperties): string => {
       labels.push(dimensionValue);
     }
   });
-  return labels.filter(Boolean).join(' | ');
+  const label = labels.filter(Boolean).join(' | ');
+  return label || metric['metric_name'];
 };
 
 /**

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
@@ -32,7 +32,7 @@ export interface LabelNameOptionsProps {
   /**
    * array of group by fields
    */
-  groupBy: string[];
+  groupBy?: string[];
 
   /**
    * Boolean to check if metric name should be hidden
@@ -69,7 +69,7 @@ interface GraphDataOptionsProps {
   /**
    * array of group by fields
    */
-  groupBy: string[];
+  groupBy?: string[];
 
   /**
    * label for the graph title
@@ -135,7 +135,7 @@ export interface DimensionNameProperties {
   /**
    * array of group by fields
    */
-  groupBy: string[];
+  groupBy?: string[];
   /**
    * Boolean to check if metric name should be hidden
    */
@@ -306,7 +306,8 @@ export const generateMaxUnit = (
 export const getCloudPulseMetricRequest = (
   props: MetricRequestProps
 ): CloudPulseMetricsRequest => {
-  const { duration, entityIds, resources, widget, groupBy, linodeRegion } = props;
+  const { duration, entityIds, resources, widget, groupBy, linodeRegion } =
+    props;
   const preset = duration.preset;
 
   return {
@@ -377,7 +378,7 @@ export const getDimensionName = (props: DimensionNameProperties): string => {
     resources,
     hideMetricName = false,
     serviceType,
-    groupBy,
+    groupBy = [],
   } = props;
   const labels: string[] = new Array(groupBy.length).fill('');
   Object.entries(metric).forEach(([key, value]) => {

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
@@ -51,7 +51,7 @@ export interface LabelNameOptionsProps {
   /**
    * label for the current metric
    */
-  metricLabel: string | undefined;
+  metricLabel?: string;
 
   /**
    * list of CloudPulseResources available
@@ -82,7 +82,7 @@ interface GraphDataOptionsProps {
   /**
    * label for the current metric
    */
-  metricLabel: string | undefined;
+  metricLabel?: string;
 
   /**
    * data that will be displayed on graph
@@ -155,7 +155,7 @@ export interface DimensionNameProperties {
   /**
    * label for the current metric
    */
-  metricLabel: string | undefined;
+  metricLabel?: string;
 
   /**
    * resources list of CloudPulseResources available

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
@@ -33,7 +33,6 @@ export interface LabelNameOptionsProps {
    * array of group by fields
    */
   groupBy?: string[];
-
   /**
    * Boolean to check if metric name should be hidden
    */
@@ -48,6 +47,11 @@ export interface LabelNameOptionsProps {
    * key-value to generate dimension name
    */
   metric: { [label: string]: string };
+
+  /**
+   * label for the current metric
+   */
+  metricLabel: string | undefined;
 
   /**
    * list of CloudPulseResources available
@@ -70,11 +74,15 @@ interface GraphDataOptionsProps {
    * array of group by fields
    */
   groupBy?: string[];
-
   /**
    * label for the graph title
    */
   label: string;
+
+  /**
+   * label for the current metric
+   */
+  metricLabel: string | undefined;
 
   /**
    * data that will be displayed on graph
@@ -140,11 +148,14 @@ export interface DimensionNameProperties {
    * Boolean to check if metric name should be hidden
    */
   hideMetricName?: boolean;
-
   /**
    * metric key-value to generate dimension name
    */
   metric: { [label: string]: string };
+  /**
+   * label for the current metric
+   */
+  metricLabel: string | undefined;
 
   /**
    * resources list of CloudPulseResources available
@@ -184,8 +195,16 @@ interface GraphData {
  * @returns parameters which will be necessary to populate graph & legends
  */
 export const generateGraphData = (props: GraphDataOptionsProps): GraphData => {
-  const { label, metricsList, resources, serviceType, status, unit, groupBy } =
-    props;
+  const {
+    label,
+    metricsList,
+    resources,
+    serviceType,
+    status,
+    unit,
+    groupBy,
+    metricLabel,
+  } = props;
   const legendRowsData: MetricsDisplayRow[] = [];
   const dimension: { [timestamp: number]: { [label: string]: number } } = {};
   const areas: AreaProps[] = [];
@@ -223,6 +242,7 @@ export const generateGraphData = (props: GraphDataOptionsProps): GraphData => {
           hideMetricName,
           serviceType,
           groupBy,
+          metricLabel,
         };
         const labelName = getLabelName(labelOptions);
         const data = seriesDataFormatter(transformedData.values, start, end);
@@ -351,6 +371,7 @@ export const getLabelName = (props: LabelNameOptionsProps): string => {
     hideMetricName = false,
     serviceType,
     groupBy,
+    metricLabel,
   } = props;
   // aggregated metric, where metric keys will be 0
   if (!Object.keys(metric).length) {
@@ -364,6 +385,7 @@ export const getLabelName = (props: LabelNameOptionsProps): string => {
     hideMetricName,
     serviceType,
     groupBy,
+    metricLabel,
   });
 };
 
@@ -379,6 +401,7 @@ export const getDimensionName = (props: DimensionNameProperties): string => {
     hideMetricName = false,
     serviceType,
     groupBy = [],
+    metricLabel = '',
   } = props;
   const labels: string[] = new Array(groupBy.length).fill('');
   Object.entries(metric).forEach(([key, value]) => {
@@ -420,7 +443,7 @@ export const getDimensionName = (props: DimensionNameProperties): string => {
     }
   });
   const label = labels.filter(Boolean).join(' | ');
-  return (label || metric['metric_name']) ?? '';
+  return label || metricLabel;
 };
 
 /**

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
@@ -420,7 +420,7 @@ export const getDimensionName = (props: DimensionNameProperties): string => {
     }
   });
   const label = labels.filter(Boolean).join(' | ');
-  return label || metric['metric_name'];
+  return (label || metric['metric_name']) ?? '';
 };
 
 /**

--- a/packages/manager/src/features/CloudPulse/Utils/ReusableDashboardFilterUtils.test.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/ReusableDashboardFilterUtils.test.ts
@@ -19,6 +19,7 @@ it('test getDashboardProperties method', () => {
     dashboardObj: mockDashboard,
     filterValue: { region: 'us-east' },
     resource: 1,
+    groupBy: [],
   });
 
   expect(result).toBeDefined();
@@ -31,6 +32,7 @@ it('test checkMandatoryFiltersSelected method for time duration and resource', (
     dashboardObj: mockDashboard,
     filterValue: { region: 'us-east' },
     resource: 0,
+    groupBy: [],
   });
   expect(result).toBe(false);
   result = checkMandatoryFiltersSelected({
@@ -42,6 +44,7 @@ it('test checkMandatoryFiltersSelected method for time duration and resource', (
       preset,
       start: start.toISO(),
     },
+    groupBy: [],
   });
 
   expect(result).toBe(true);
@@ -51,6 +54,7 @@ it('test checkMandatoryFiltersSelected method for time duration and resource', (
     filterValue: { region: 'us-east' },
     resource: 1,
     timeDuration: undefined, // here time duration is undefined, so it should return false
+    groupBy: [],
   });
 
   expect(result).toBe(false);
@@ -60,6 +64,7 @@ it('test checkMandatoryFiltersSelected method for time duration and resource', (
     filterValue: { region: 'us-east' },
     resource: 0, // here resource is 0, so it should return false
     timeDuration: { end: end.toISO(), preset, start: start.toISO() },
+    groupBy: [],
   });
 
   expect(result).toBe(false);
@@ -72,6 +77,7 @@ it('test checkMandatoryFiltersSelected method for role', () => {
     filterValue: { region: 'us-east' }, // here role is missing
     resource: 1,
     timeDuration: { end: end.toISO(), preset, start: start.toISO() },
+    groupBy: [],
   });
 
   expect(result).toBe(false);
@@ -81,6 +87,7 @@ it('test checkMandatoryFiltersSelected method for role', () => {
     filterValue: { node_type: 'primary', region: 'us-east' },
     resource: 1,
     timeDuration: { end: end.toISO(), preset, start: start.toISO() },
+    groupBy: [],
   });
 
   expect(result).toBe(true);
@@ -92,6 +99,7 @@ it('test constructDimensionFilters method', () => {
     dashboardObj: mockDashboard,
     filterValue: { node_type: 'primary' },
     resource: 1,
+    groupBy: [],
   });
 
   expect(result.length).toEqual(1);

--- a/packages/manager/src/features/CloudPulse/Utils/ReusableDashboardFilterUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/ReusableDashboardFilterUtils.ts
@@ -19,6 +19,7 @@ interface ReusableDashboardFilterUtilProps {
    * The selected filter values
    */
   filterValue: CloudPulseMetricsFilter;
+  groupBy: string[];
   /**
    * The selected resource id
    */
@@ -36,17 +37,19 @@ interface ReusableDashboardFilterUtilProps {
 export const getDashboardProperties = (
   props: ReusableDashboardFilterUtilProps
 ): DashboardProperties => {
-  const { dashboardObj, filterValue, resource, timeDuration } = props;
+  const { dashboardObj, filterValue, resource, timeDuration, groupBy } = props;
   return {
     additionalFilters: constructDimensionFilters({
       dashboardObj,
       filterValue,
       resource,
+      groupBy,
     }),
     dashboardId: dashboardObj.id,
     duration: timeDuration ?? defaultTimeDuration(),
     resources: [String(resource)],
     savePref: false,
+    groupBy,
   };
 };
 

--- a/packages/manager/src/features/CloudPulse/Utils/ReusableDashboardFilterUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/ReusableDashboardFilterUtils.ts
@@ -19,6 +19,9 @@ interface ReusableDashboardFilterUtilProps {
    * The selected filter values
    */
   filterValue: CloudPulseMetricsFilter;
+  /**
+   * The selected grouping criteria
+   */
   groupBy: string[];
   /**
    * The selected resource id

--- a/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.test.tsx
@@ -27,6 +27,7 @@ const props: CloudPulseWidgetProperties = {
     scrape_interval: '2m',
     unit: 'percent',
   },
+  dashboardId: 1,
   duration: {
     end: DateTime.now().toISO(),
     preset: '30minutes',

--- a/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.tsx
+++ b/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.tsx
@@ -61,6 +61,11 @@ export interface CloudPulseWidgetProperties {
   availableMetrics: MetricDefinition | undefined;
 
   /**
+   * ID of the selected dashboard
+   */
+  dashboardId: number;
+
+  /**
    * time duration to fetch the metrics data in this widget
    */
   duration: DateTimeWithPreset;
@@ -143,6 +148,7 @@ export const CloudPulseWidget = (props: CloudPulseWidgetProperties) => {
 
   const {
     additionalFilters,
+    dashboardId,
     ariaLabel,
     authToken,
     availableMetrics,

--- a/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.tsx
+++ b/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 import { useFlags } from 'src/hooks/useFlags';
 import { useCloudPulseMetricsQuery } from 'src/queries/cloudpulse/metrics';
 
+import { WidgetFilterGroupByRenderer } from '../GroupBy/WidgetFilterGroupByRenderer';
 import {
   generateGraphData,
   getCloudPulseMetricRequest,
@@ -119,7 +120,6 @@ export interface CloudPulseWidgetProperties {
    * color index to be selected from available them if not theme is provided by user
    */
   useColorIndex?: number;
-
   /**
    * this comes from dashboard, has inbuilt metrics, agg_func,group_by,filters,gridsize etc , also helpful in publishing any changes
    */
@@ -143,6 +143,7 @@ export const CloudPulseWidget = (props: CloudPulseWidgetProperties) => {
   const { data: profile } = useProfile();
 
   const [widget, setWidget] = React.useState<Widgets>({ ...props.widget });
+  const [groupBy, setGroupBy] = React.useState<string[]>([]);
 
   const theme = useTheme();
 
@@ -243,7 +244,9 @@ export const CloudPulseWidget = (props: CloudPulseWidgetProperties) => {
     },
     []
   );
-
+  const handleGroupByChange = React.useCallback((selectedGroupBy: string[]) => {
+    setGroupBy(selectedGroupBy);
+  }, []);
   const {
     data: metricsList,
     error,
@@ -257,7 +260,7 @@ export const CloudPulseWidget = (props: CloudPulseWidgetProperties) => {
         entityIds,
         resources,
         widget,
-        groupBy: widgetProp.group_by,
+        groupBy: [...(widgetProp.group_by ?? []), ...groupBy],
         linodeRegion,
       }),
       filters, // any additional dimension filters will be constructed and passed here
@@ -284,7 +287,7 @@ export const CloudPulseWidget = (props: CloudPulseWidgetProperties) => {
       status,
       unit,
       serviceType,
-      groupBy: widgetProp.group_by,
+      groupBy: [...(widgetProp.group_by ?? []), ...groupBy],
     });
 
     data = generatedData.dimensions;
@@ -359,7 +362,14 @@ export const CloudPulseWidget = (props: CloudPulseWidgetProperties) => {
                   onAggregateFuncChange={handleAggregateFunctionChange}
                 />
               )}
-              <Box sx={{ display: { lg: 'flex', xs: 'none' } }}>
+              <Box sx={{ display: { lg: 'flex', xs: 'none' }, gap: 2 }}>
+                <WidgetFilterGroupByRenderer
+                  dashboardId={dashboardId}
+                  handleChange={handleGroupByChange}
+                  label={widget.label}
+                  metric={widget.metric}
+                  serviceType={serviceType}
+                />
                 <ZoomIcon
                   handleZoomToggle={handleZoomToggle}
                   zoomIn={widget?.size === 12}

--- a/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.tsx
+++ b/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.tsx
@@ -288,6 +288,7 @@ export const CloudPulseWidget = (props: CloudPulseWidgetProperties) => {
       unit,
       serviceType,
       groupBy: [...(widgetProp.group_by ?? []), ...groupBy],
+      metricLabel: availableMetrics?.label,
     });
 
     data = generatedData.dimensions;

--- a/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.tsx
+++ b/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.tsx
@@ -362,7 +362,7 @@ export const CloudPulseWidget = (props: CloudPulseWidgetProperties) => {
                   onAggregateFuncChange={handleAggregateFunctionChange}
                 />
               )}
-              <Box sx={{ display: { lg: 'flex', xs: 'none' }, gap: 2 }}>
+              <Box sx={{ display: 'flex', gap: 2 }}>
                 <WidgetFilterGroupByRenderer
                   dashboardId={dashboardId}
                   handleChange={handleGroupByChange}

--- a/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.tsx
+++ b/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.tsx
@@ -251,6 +251,7 @@ export const CloudPulseWidget = (props: CloudPulseWidgetProperties) => {
         entityIds,
         resources,
         widget,
+        groupBy: widgetProp.group_by,
         linodeRegion,
       }),
       filters, // any additional dimension filters will be constructed and passed here

--- a/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidgetRenderer.tsx
+++ b/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidgetRenderer.tsx
@@ -86,7 +86,7 @@ export const RenderWidgets = React.memo(
         serviceType: dashboard.service_type,
         timeStamp: manualRefreshTimeStamp,
         unit: widget.unit ?? '%',
-
+        dashboardId: dashboard.id,
         widget: {
           ...widget,
           time_granularity: autoIntervalOption,

--- a/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidgetRenderer.tsx
+++ b/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidgetRenderer.tsx
@@ -30,6 +30,7 @@ interface WidgetProps {
   additionalFilters?: CloudPulseMetricsAdditionalFilters[];
   dashboard: Dashboard;
   duration: DateTimeWithPreset;
+  groupBy: string[];
   isJweTokenFetching: boolean;
   jweToken?: JWEToken | undefined;
   linodeRegion?: string;
@@ -65,6 +66,7 @@ export const RenderWidgets = React.memo(
       resourceList,
       resources,
       savePref,
+      groupBy,
       linodeRegion,
     } = props;
 
@@ -84,7 +86,12 @@ export const RenderWidgets = React.memo(
         serviceType: dashboard.service_type,
         timeStamp: manualRefreshTimeStamp,
         unit: widget.unit ?? '%',
-        widget: { ...widget, time_granularity: autoIntervalOption },
+
+        widget: {
+          ...widget,
+          time_granularity: autoIntervalOption,
+          group_by: groupBy.length === 0 ? undefined : groupBy,
+        },
       };
       if (savePref) {
         graphProp.widget = setPreferredWidgetPlan(graphProp.widget);
@@ -188,6 +195,7 @@ export const RenderWidgets = React.memo(
       'duration',
       'resources',
       'additionalFilters',
+      'groupBy',
     ];
 
     for (const key of keysToCompare) {

--- a/packages/manager/src/features/CloudPulse/Widget/components/Zoomer.tsx
+++ b/packages/manager/src/features/CloudPulse/Widget/components/Zoomer.tsx
@@ -29,6 +29,7 @@ export const ZoomIcon = React.memo((props: ZoomIconProperties) => {
           onClick={() => handleZoomToggle(false)}
           sx={{
             padding: 0,
+            visibility: { lg: 'visible', xs: 'hidden' },
           }}
         >
           <ZoomOutMap />
@@ -50,6 +51,7 @@ export const ZoomIcon = React.memo((props: ZoomIconProperties) => {
         onClick={() => handleZoomToggle(true)}
         sx={{
           padding: 0,
+          visibility: { lg: 'visible', xs: 'hidden' },
         }}
       >
         <ZoomInMap />


### PR DESCRIPTION
## Description 📝

Enable Group By option in metrics and widget filter

## Changes  🔄

List any change(s) relevant to the reviewer.

1. Updated GlobalFilters component to show Group By option
2. Updated Widget component to show Group By option
3.  Updated types and metrics request to accept group by parameter

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

Please specify a release date (and environment, if applicable) to guarantee timely review of this PR. If exact date is not known, please approximate and update it as needed.

## Preview 📷

**Include a screenshot `<img src="" />` or video `<video src="" />` of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: For changes requiring multiple steps to validate, prefer a video for clarity.

| Before  | After   |
| ------- | ------- |
|![Screenshot 2025-09-17 at 1 34 48 PM](https://github.com/user-attachments/assets/0197b14f-a8c3-41a5-80b5-4639215825ad)|![Screenshot 2025-09-17 at 1 43 25 PM](https://github.com/user-attachments/assets/d46317a4-0465-44c2-b877-402fd10c4bb7)|
|![Screenshot 2025-09-17 at 1 34 58 PM](https://github.com/user-attachments/assets/96485b6f-15cf-48a8-afb6-9ce6ef166470)|![Screenshot 2025-09-17 at 1 43 40 PM](https://github.com/user-attachments/assets/d970ae25-b0e7-4d69-9c18-c2b56de907ff)|
|![Screenshot 2025-09-17 at 1 35 07 PM](https://github.com/user-attachments/assets/8b2b4c68-58e9-416c-a24f-6a142bd1a20c)|![Screenshot 2025-09-17 at 1 43 48 PM](https://github.com/user-attachments/assets/1c8dfc05-7da1-4c2c-a9f6-1259e261b1fc)|
|![Screenshot 2025-09-17 at 1 35 29 PM](https://github.com/user-attachments/assets/9bbfc83e-5103-4e7c-b9e8-8d65ffc08617)|![Screenshot 2025-09-17 at 1 43 59 PM](https://github.com/user-attachments/assets/4af1f4e7-a1de-4b0c-b6d4-c72d89bfaefc)|
|![Screenshot 2025-09-17 at 1 35 35 PM](https://github.com/user-attachments/assets/b102f1e7-18df-44d6-9d2a-277431b11b1a)|![Screenshot 2025-09-17 at 1 44 08 PM](https://github.com/user-attachments/assets/5a137172-3a22-49d2-87cc-4e769544bcd3)|
|![Screenshot 2025-09-17 at 1 35 42 PM](https://github.com/user-attachments/assets/041f85d5-2b6e-4c46-8973-4604b7877ebb)|![Screenshot 2025-09-17 at 1 44 14 PM](https://github.com/user-attachments/assets/36546b20-980a-4327-8ff0-daecd9bafb55)|

## How to test 🧪

### Prerequisites
1. Switch to mock user
2. Go to metrics tab
3. Select linode dashboard and required filters

### Verification steps

1. A group by icon on left size on both global filter as well as widget filter
2. Click on any group by button and selection options
3. On click of cancel or close button will revert your changes to previous state in dimension drop down
4. On selecting some value for any group by dimensions, that button will turn blue otherwise black if nothing is selected
5. Group by buttons will be in disabled mode if no options are present
6. From the network tab validate following parameters in the metrics tab
      6.1 group_by in request payload will be undefined if nothing is selected on global level as well as that particular widget level
      6.2 order of group_by list will contains first global filter selected dimensions then widget filter selected dimensions
      6.3 selection order of individual dimension drop downs will be maintained while sending to for API request
      Ex: if it has 2 options dim_1 and dim_2 then if you select in order dim_1 -> dim_2 then list will contains [dim_1, dim_2] but if you've select dim_2 -> dim_1 then list will contains [dim_2, dim_1]

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>