### PR TITLE
feat: [UIE-9068] - IAM RBAC: disable field in the drawer

### DIFF
--- a/packages/manager/.changeset/pr-12892-added-1758187361526.md
+++ b/packages/manager/.changeset/pr-12892-added-1758187361526.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+IAM RBAC: disable fields in the drawer ([#12892](https://github.com/linode/manager/pull/12892))

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddNodebalancerDrawer.test.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddNodebalancerDrawer.test.tsx
@@ -1,3 +1,4 @@
+import { waitFor } from '@testing-library/react';
 import * as React from 'react';
 
 import { renderWithTheme } from 'src/utilities/testHelpers';
@@ -11,19 +12,11 @@ const props = {
   helperText,
   onClose,
   open: true,
+  disabled: false,
 };
 
 const queryMocks = vi.hoisted(() => ({
   useParams: vi.fn().mockReturnValue({}),
-  userPermissions: vi.fn(() => ({
-    data: {
-      create_firewall_device: true,
-    },
-  })),
-}));
-
-vi.mock('src/features/IAM/hooks/usePermissions', () => ({
-  usePermissions: queryMocks.userPermissions,
 }));
 
 vi.mock('@tanstack/react-router', async () => {
@@ -60,20 +53,30 @@ describe('AddNodeBalancerDrawer', () => {
     const { getByText } = renderWithTheme(<AddNodebalancerDrawer {...props} />);
     expect(getByText('Add')).toBeInTheDocument();
   });
-
-  it('should disable "Add" button if the user does not have create_firewall_device permission', async () => {
-    queryMocks.userPermissions.mockReturnValue({
-      data: {
-        create_firewall_device: false,
-      },
-    });
-
+  it('should enable select if the user has create_firewall_device permission', async () => {
     const { getByRole } = renderWithTheme(<AddNodebalancerDrawer {...props} />);
+
+    const select = getByRole('combobox');
+    expect(select).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(select).toBeEnabled();
+    });
+  });
+
+  it('should disable "Add" button and select if the user does not have create_firewall_device permission', async () => {
+    const { getByRole } = renderWithTheme(
+      <AddNodebalancerDrawer {...props} disabled={true} />
+    );
 
     const addButton = getByRole('button', {
       name: 'Add',
     });
     expect(addButton).toBeInTheDocument();
     expect(addButton).toBeDisabled();
+
+    const select = getByRole('combobox');
+    expect(select).toBeInTheDocument();
+    expect(select).toBeDisabled();
   });
 });

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddNodebalancerDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddNodebalancerDrawer.tsx
@@ -14,7 +14,7 @@ import * as React from 'react';
 import { Link } from 'src/components/Link';
 import { SupportLink } from 'src/components/SupportLink';
 import { FIREWALL_LIMITS_CONSIDERATIONS_LINK } from 'src/constants';
-import { usePermissions } from 'src/features/IAM/hooks/usePermissions';
+import { getRestrictedResourceText } from 'src/features/Account/utils';
 import { NodeBalancerSelect } from 'src/features/NodeBalancers/NodeBalancerSelect';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { sanitizeHTML } from 'src/utilities/sanitizeHTML';
@@ -22,13 +22,14 @@ import { sanitizeHTML } from 'src/utilities/sanitizeHTML';
 import type { NodeBalancer } from '@linode/api-v4';
 
 interface Props {
+  disabled?: boolean;
   helperText: string;
   onClose: () => void;
   open: boolean;
 }
 
 export const AddNodebalancerDrawer = (props: Props) => {
-  const { helperText, onClose, open } = props;
+  const { helperText, onClose, open, disabled } = props;
   const { enqueueSnackbar } = useSnackbar();
   const { id } = useParams({ strict: false });
   const { data: grants } = useGrants();
@@ -38,12 +39,6 @@ export const AddNodebalancerDrawer = (props: Props) => {
   const { data, error, isLoading } = useAllFirewallsQuery(open);
 
   const firewall = data?.find((firewall) => firewall.id === Number(id));
-
-  const { data: permissions } = usePermissions(
-    'firewall',
-    ['create_firewall_device'],
-    firewall?.id
-  );
 
   const theme = useTheme();
 
@@ -187,6 +182,14 @@ export const AddNodebalancerDrawer = (props: Props) => {
       open={open}
       title={`Add Nodebalancer to Firewall: ${firewall?.label}`}
     >
+      {disabled && (
+        <Notice
+          text={getRestrictedResourceText({
+            resourceType: 'Firewalls',
+          })}
+          variant="error"
+        />
+      )}
       <Notice variant={'warning'}>
         Only the Firewall's inbound rules apply to NodeBalancers. Any existing
         outbound rules won't be applied.{' '}
@@ -200,7 +203,7 @@ export const AddNodebalancerDrawer = (props: Props) => {
       >
         {localError ? errorNotice() : null}
         <NodeBalancerSelect
-          disabled={isLoading}
+          disabled={isLoading || disabled}
           helperText={helperText}
           multiple
           onSelectionChange={(nodebalancers) =>
@@ -211,9 +214,7 @@ export const AddNodebalancerDrawer = (props: Props) => {
         />
         <ActionsPanel
           primaryButtonProps={{
-            disabled:
-              selectedNodebalancers.length === 0 ||
-              !permissions.create_firewall_device,
+            disabled: selectedNodebalancers.length === 0 || disabled,
             label: 'Add',
             loading: addDeviceIsLoading,
             onClick: handleSubmit,

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallDeviceLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallDeviceLanding.tsx
@@ -160,6 +160,7 @@ export const FirewallDeviceLanding = React.memo(
           />
         ) : (
           <AddNodebalancerDrawer
+            disabled={isCreateDeviceDisabled}
             helperText={helperText}
             onClose={handleClose}
             open={location.pathname.endsWith('add')}


### PR DESCRIPTION
## Description 📝

Add more checking for users manually inputting route

## Changes  🔄

List any change(s) relevant to the reviewer.

- Add a noticication banner and disable autocomplete if no permissions
- Update test

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [x] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

10/7

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <img width="3018" height="1414" alt="image" src="https://github.com/user-attachments/assets/783851b1-5680-4ca2-8d4c-1608d078477e" /> | <img width="2980" height="1236" alt="image" src="https://github.com/user-attachments/assets/9d990eb8-ae66-448f-889e-450a250bb6d3" /> |


## How to test 🧪

### Prerequisites

(How to setup test environment)

- iam (restricted) + regular account to compare

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] role is firewall_viewer and nodebalancer_admin and you 
- [ ] manually go to the route /firewalls/<id>/nodebalancers/add

### Verification steps

(How to verify changes)

- [ ] All fields are disabled if no permissions
- [ ] All fields are enabled if user has permission 

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>