### PR TITLE
fix: [STORIF-101] - Volume deletion from the Volume Details page fixed.

### DIFF
--- a/packages/manager/.changeset/pr-12894-fixed-1758298095602.md
+++ b/packages/manager/.changeset/pr-12894-fixed-1758298095602.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Navigation after successful volume deletion ([#12894](https://github.com/linode/manager/pull/12894))

--- a/packages/manager/src/features/Volumes/Dialogs/DeleteVolumeDialog.tsx
+++ b/packages/manager/src/features/Volumes/Dialogs/DeleteVolumeDialog.tsx
@@ -9,13 +9,15 @@ import type { APIError, Volume } from '@linode/api-v4';
 interface Props {
   isFetching?: boolean;
   onClose: () => void;
+  onDeleteSuccess?: () => void;
   open: boolean;
   volume: undefined | Volume;
   volumeError?: APIError[] | null;
 }
 
 export const DeleteVolumeDialog = (props: Props) => {
-  const { isFetching, onClose, open, volume, volumeError } = props;
+  const { isFetching, onClose, onDeleteSuccess, open, volume, volumeError } =
+    props;
 
   const {
     error,
@@ -27,7 +29,12 @@ export const DeleteVolumeDialog = (props: Props) => {
 
   const onDelete = () => {
     deleteVolume({ id: volume?.id ?? -1 }).then(() => {
-      onClose();
+      if (onDeleteSuccess) {
+        onDeleteSuccess();
+      } else {
+        onClose();
+      }
+
       checkForNewEvents();
     });
   };

--- a/packages/manager/src/features/Volumes/VolumeDetails/VolumeDetails.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDetails/VolumeDetails.tsx
@@ -36,6 +36,13 @@ export const VolumeDetails = () => {
     return <CircleProgress />;
   }
 
+  const navigateToVolumes = () => {
+    navigate({
+      search: (prev) => prev,
+      to: '/volumes',
+    });
+  };
+
   const navigateToVolumeSummary = () => {
     navigate({
       search: (prev) => prev,
@@ -62,7 +69,10 @@ export const VolumeDetails = () => {
         </React.Suspense>
       </Tabs>
 
-      <VolumeDrawers onCloseHandler={navigateToVolumeSummary} />
+      <VolumeDrawers
+        onCloseHandler={navigateToVolumeSummary}
+        onDeleteSuccessHandler={navigateToVolumes}
+      />
     </>
   );
 };

--- a/packages/manager/src/features/Volumes/VolumeDrawers/VolumeDrawers.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawers/VolumeDrawers.tsx
@@ -14,9 +14,13 @@ import { VolumeDetailsDrawer } from './VolumeDetailsDrawer';
 
 interface Props {
   onCloseHandler: () => void;
+  onDeleteSuccessHandler: () => void;
 }
 
-export const VolumeDrawers = ({ onCloseHandler }: Props) => {
+export const VolumeDrawers = ({
+  onCloseHandler,
+  onDeleteSuccessHandler,
+}: Props) => {
   const params = useParams({ strict: false });
 
   const {
@@ -85,6 +89,7 @@ export const VolumeDrawers = ({ onCloseHandler }: Props) => {
       <DeleteVolumeDialog
         isFetching={isFetchingVolume}
         onClose={onCloseHandler}
+        onDeleteSuccess={onDeleteSuccessHandler}
         open={params.action === 'delete'}
         volume={selectedVolume}
         volumeError={selectedVolumeError}

--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -235,7 +235,10 @@ export const VolumesLanding = () => {
         pageSize={pagination.pageSize}
       />
 
-      <VolumeDrawers onCloseHandler={navigateToVolumes} />
+      <VolumeDrawers
+        onCloseHandler={navigateToVolumes}
+        onDeleteSuccessHandler={navigateToVolumes}
+      />
     </Stack>
   );
 };


### PR DESCRIPTION
## Description 📝

Volume deletion from the Volume Details page fixed.

## Changes  🔄

Additional "onDeleteClose" method added to the "DeleteVolumeDialog" which
is executed when delete operation is successful.

## How to test 🧪

- Navigate to the volumes page.
- Create a dummy volume.
- Navigate to the volume details page.
- Open delete volume dialog.
- Cancel deletion and make sure the app stays on the volume details page.
- Open delete dialog again and delete volume.
- Make sure the app navigate back to volumes page after deletion.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>