### PR TITLE
fix: Cypress Github Actions after Node 22 upgrade

### DIFF
--- a/packages/manager/cypress/support/plugins/split-run.ts
+++ b/packages/manager/cypress/support/plugins/split-run.ts
@@ -2,7 +2,8 @@
  * @file Allows parallelization without Cypress Cloud.
  */
 
-import { globSync, readFileSync } from 'fs';
+import { readFileSync } from 'fs';
+import { globSync } from 'glob';
 import { resolve } from 'path';
 
 import { specWeightsSchema } from './generate-weights';

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -171,6 +171,7 @@
     "cypress-vite": "^1.6.0",
     "dotenv": "^16.0.3",
     "factory.ts": "^0.5.1",
+    "glob": "^10.3.1",
     "globals": "^16.0.0",
     "history": "4",
     "jsdom": "^24.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -491,6 +491,9 @@ importers:
       factory.ts:
         specifier: ^0.5.1
         version: 0.5.2
+      glob:
+        specifier: ^10.3.1
+        version: 10.4.5
       globals:
         specifier: ^16.0.0
         version: 16.0.0
@@ -4001,8 +4004,8 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
-  foreground-child@3.3.0:
-    resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
   forever-agent@0.6.1:
@@ -9826,7 +9829,7 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
-  foreground-child@3.3.0:
+  foreground-child@3.3.1:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
@@ -9956,7 +9959,7 @@ snapshots:
 
   glob@10.4.5:
     dependencies:
-      foreground-child: 3.3.0
+      foreground-child: 3.3.1
       jackspeak: 3.4.3
       minimatch: 9.0.5
       minipass: 7.1.2


### PR DESCRIPTION
## Description 📝

- Our Github Actions that run Cypress on `develop` after merging https://github.com/linode/manager/pull/12838
- This is because Cypress invokes the tests using Node 20 and there does not seem to be a clear way to change it
  - The [docs](https://github.com/cypress-io/github-action?tab=readme-ov-file#usage) say: ![Screenshot 2025-09-19 at 10 33 10 AM](https://github.com/user-attachments/assets/6cd4b81f-f99b-42f8-87ae-21ca8804c429)
- There may be other ways to address this, but for now, the easiest solution is to just revert to using the `glob` package rather than Node 22's built in `glob` so that the cypress pipeline can run on older versions of node if needed


## Preview 📷

![Screenshot 2025-09-19 at 10 32 31 AM](https://github.com/user-attachments/assets/d3f3629f-8eff-4a1a-ab0b-17046385327d)



## How to test 🧪

- We'll merge and verify that the Cypress Github actions run correctly on the develop branch