### PR TITLE
upcoming: [DI-27317] - Onboarding Object Storage service to Alerts UI

### DIFF
--- a/packages/api-v4/src/cloudpulse/types.ts
+++ b/packages/api-v4/src/cloudpulse/types.ts
@@ -7,7 +7,8 @@ export type CloudPulseServiceType =
   | 'dbaas'
   | 'firewall'
   | 'linode'
-  | 'nodebalancer';
+  | 'nodebalancer'
+  | 'objectstorage';
 
 export type AlertClass = 'dedicated' | 'shared';
 export type DimensionFilterOperatorType =
@@ -375,6 +376,7 @@ export const capabilityServiceTypeMapping: Record<
   dbaas: 'Managed Databases',
   nodebalancer: 'NodeBalancers',
   firewall: 'Cloud Firewall',
+  objectstorage: 'Object Storage',
 };
 
 /**

--- a/packages/manager/src/factories/cloudpulse/services.ts
+++ b/packages/manager/src/factories/cloudpulse/services.ts
@@ -8,6 +8,7 @@ const serviceTypes: CloudPulseServiceType[] = [
   'nodebalancer',
   'dbaas',
   'firewall',
+  'objectstorage',
 ];
 
 export const serviceAlertFactory = Factory.Sync.makeFactory<ServiceAlert>({

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsResources/AlertsEndpointFilter.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsResources/AlertsEndpointFilter.test.tsx
@@ -1,0 +1,78 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { AlertsEndpointFilter } from './AlertsEndpointFilter';
+
+describe('AlertsEndpointFilter', () => {
+  const endpointOptions = ['endpoint-1', 'endpoint-2'];
+  it('calls handleFilterChange with correct arguments when an endpoint is selected', async () => {
+    const handleFilterChange = vi.fn();
+
+    renderWithTheme(
+      <AlertsEndpointFilter
+        endpointOptions={endpointOptions}
+        handleFilterChange={handleFilterChange}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open' }));
+
+    // Check first option exists
+    expect(
+      screen.getByRole('option', { name: endpointOptions[0] })
+    ).toBeVisible();
+
+    // Select first option
+    await userEvent.click(
+      screen.getByRole('option', { name: endpointOptions[0] })
+    );
+    expect(handleFilterChange).toHaveBeenCalledWith(
+      [endpointOptions[0]],
+      'endpoint'
+    );
+  });
+  it('renders with empty endpointOptions', async () => {
+    const handleFilterChange = vi.fn();
+
+    renderWithTheme(
+      <AlertsEndpointFilter
+        endpointOptions={[]}
+        handleFilterChange={handleFilterChange}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open' })); // indicates there is a drop down
+    expect(
+      screen.getByText('You have no options to choose from')
+    ).toBeVisible();
+  });
+
+  it('renders with multiple selection endpoints', async () => {
+    const handleFilterChange = vi.fn();
+
+    renderWithTheme(
+      <AlertsEndpointFilter
+        endpointOptions={endpointOptions}
+        handleFilterChange={handleFilterChange}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open' }));
+
+    // Select first option
+    await userEvent.click(
+      screen.getByRole('option', { name: endpointOptions[0] })
+    );
+    // Select second option
+    await userEvent.click(
+      screen.getByRole('option', { name: endpointOptions[1] })
+    );
+    expect(handleFilterChange).toHaveBeenCalledWith(
+      [...endpointOptions],
+      'endpoint'
+    );
+  });
+});

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsResources/AlertsEndpointFilter.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsResources/AlertsEndpointFilter.tsx
@@ -1,0 +1,58 @@
+import { Autocomplete } from '@linode/ui';
+import React from 'react';
+
+import type { AlertFilterKey } from './types';
+
+export interface AlertsEndpointFilterProps {
+  /**
+   * List of object storage endpoints.
+   */
+  endpointOptions: string[];
+  /**
+   * Callback to publish the selected engine type
+   */
+  handleFilterChange: (
+    endpoints: string[] | undefined,
+    type: AlertFilterKey
+  ) => void;
+}
+
+export const AlertsEndpointFilter = React.memo(
+  (props: AlertsEndpointFilterProps) => {
+    const { handleFilterChange: handleSelection, endpointOptions } = props;
+    const [selectedEndpoints, setSelectedEndpoints] = React.useState<
+      { label: string }[]
+    >([]);
+    const endpointBuiltOptions = endpointOptions.map((option) => ({
+      label: option,
+    }));
+
+    const handleFilterSelection = React.useCallback(
+      (_: React.SyntheticEvent, endpoints: { label: string }[]) => {
+        setSelectedEndpoints(endpoints);
+        handleSelection(
+          endpoints.length ? endpoints.map(({ label }) => label) : undefined,
+          'endpoint'
+        );
+      },
+      [handleSelection]
+    );
+    return (
+      <Autocomplete
+        autoHighlight
+        clearOnBlur
+        isOptionEqualToValue={(option, value) => option.label === value.label}
+        label="Endpoints"
+        limitTags={1}
+        multiple
+        onChange={handleFilterSelection}
+        options={endpointBuiltOptions}
+        placeholder="Select Endpoints"
+        textFieldProps={{
+          hideLabel: true,
+        }}
+        value={selectedEndpoints}
+      />
+    );
+  }
+);

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsResources/AlertsResources.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsResources/AlertsResources.tsx
@@ -12,7 +12,9 @@ import { MULTILINE_ERROR_SEPARATOR } from '../constants';
 import { AlertListNoticeMessages } from '../Utils/AlertListNoticeMessages';
 import {
   getAlertResourceFilterProps,
+  getEndpointOptions,
   getFilteredResources,
+  getOfflineRegionFilteredResources,
   getRegionOptions,
   getRegionsIdRegionMap,
   getSupportedRegionIds,
@@ -119,7 +121,7 @@ export const AlertResources = React.memo((props: AlertResourcesProp) => {
   const [selectedOnly, setSelectedOnly] = React.useState<boolean>(false);
   const [additionalFilters, setAdditionalFilters] = React.useState<
     Record<AlertAdditionalFilterKey, AlertFilterType>
-  >({ engineType: undefined, tags: undefined });
+  >({ engineType: undefined, tags: undefined, endpoint: undefined });
 
   const {
     data: regions,
@@ -129,19 +131,23 @@ export const AlertResources = React.memo((props: AlertResourcesProp) => {
 
   const theme = useTheme();
 
-  const supportedRegionIds = getSupportedRegionIds(regions, serviceType);
+  const supportedRegionIds = React.useMemo(() => {
+    return getSupportedRegionIds(regions, serviceType);
+  }, [regions, serviceType]);
   const xFilterToBeApplied: Filter | undefined = React.useMemo(() => {
-    if (serviceType === 'firewall') {
+    if (
+      serviceType === 'firewall' ||
+      serviceType === 'objectstorage' ||
+      !supportedRegionIds?.length
+    ) {
       return undefined;
     }
 
-    const regionFilter: Filter = supportedRegionIds
-      ? {
-          '+or': supportedRegionIds.map((regionId) => ({
-            region: regionId,
-          })),
-        }
-      : {};
+    const regionFilter: Filter = {
+      '+or': supportedRegionIds?.map((regionId) => ({
+        region: regionId,
+      })),
+    };
 
     // if service type is other than dbaas, return only region filter
     if (serviceType !== 'dbaas') {
@@ -153,7 +159,7 @@ export const AlertResources = React.memo((props: AlertResourcesProp) => {
 
     // If alertType is not 'system' or alertClass is not defined, return only platform filter
     if (alertType !== 'system' || !alertClass) {
-      return platformFilter;
+      return { ...platformFilter, '+and': [regionFilter] };
     }
 
     // Dynamically exclude 'dedicated' if alertClass is 'shared'
@@ -182,20 +188,29 @@ export const AlertResources = React.memo((props: AlertResourcesProp) => {
     isError: isResourcesError,
     isLoading: isResourcesLoading,
   } = useResourcesQuery(
-    Boolean(serviceType),
+    Boolean(
+      serviceType && (serviceType === 'firewall' || supportedRegionIds?.length)
+    ), // Enable query only if serviceType and supportedRegionIds are available
     serviceType,
     {},
     xFilterToBeApplied
   );
 
+  const regionFilteredResources = React.useMemo(() => {
+    if (serviceType === 'objectstorage' && resources && supportedRegionIds) {
+      return getOfflineRegionFilteredResources(resources, supportedRegionIds);
+    }
+    return resources;
+  }, [serviceType, resources, supportedRegionIds]);
+
   const computedSelectedResources = React.useMemo(() => {
-    if (!isSelectionsNeeded || !resources) {
+    if (!isSelectionsNeeded || !regionFilteredResources) {
       return alertResourceIds;
     }
-    return resources
+    return regionFilteredResources
       .filter(({ id }) => alertResourceIds.includes(id))
       .map(({ id }) => id);
-  }, [resources, isSelectionsNeeded, alertResourceIds]);
+  }, [regionFilteredResources, isSelectionsNeeded, alertResourceIds]);
 
   React.useEffect(() => {
     setSelectedResources(computedSelectedResources);
@@ -209,13 +224,25 @@ export const AlertResources = React.memo((props: AlertResourcesProp) => {
   // Derived list of regions associated with the provided resource IDs, filtered based on available data.
   const regionOptions: Region[] = React.useMemo(() => {
     return getRegionOptions({
-      data: resources,
+      data: regionFilteredResources,
       isAdditionOrDeletionNeeded: isSelectionsNeeded,
       regionsIdToRegionMap,
       resourceIds: alertResourceIds,
     });
-  }, [resources, alertResourceIds, regionsIdToRegionMap, isSelectionsNeeded]);
+  }, [
+    regionFilteredResources,
+    alertResourceIds,
+    regionsIdToRegionMap,
+    isSelectionsNeeded,
+  ]);
 
+  const endpointOptions: string[] = React.useMemo(() => {
+    return getEndpointOptions(
+      regionFilteredResources,
+      isSelectionsNeeded,
+      alertResourceIds
+    );
+  }, [alertResourceIds, isSelectionsNeeded, regionFilteredResources]);
   const isDataLoadingError = isRegionsError || isResourcesError;
 
   const handleSearchTextChange = (searchText: string) => {
@@ -246,7 +273,7 @@ export const AlertResources = React.memo((props: AlertResourcesProp) => {
   const filteredResources: AlertInstance[] = React.useMemo(() => {
     return getFilteredResources({
       additionalFilters,
-      data: resources,
+      data: regionFilteredResources,
       filteredRegions,
       isAdditionOrDeletionNeeded: isSelectionsNeeded,
       regionsIdToRegionMap,
@@ -256,7 +283,7 @@ export const AlertResources = React.memo((props: AlertResourcesProp) => {
       selectedResources,
     });
   }, [
-    resources,
+    regionFilteredResources,
     filteredRegions,
     isSelectionsNeeded,
     regionsIdToRegionMap,
@@ -283,7 +310,7 @@ export const AlertResources = React.memo((props: AlertResourcesProp) => {
 
   const handleAllSelection = React.useCallback(
     (action: SelectDeselectAll) => {
-      if (!resources) {
+      if (!regionFilteredResources) {
         return;
       }
 
@@ -294,7 +321,7 @@ export const AlertResources = React.memo((props: AlertResourcesProp) => {
         setSelectedResources([]);
       } else {
         // Select all
-        currentSelections = resources.map(({ id }) => id);
+        currentSelections = regionFilteredResources.map(({ id }) => id);
         setSelectedResources(currentSelections);
       }
 
@@ -302,7 +329,7 @@ export const AlertResources = React.memo((props: AlertResourcesProp) => {
         handleResourcesSelection(currentSelections); // publish the resources selected
       }
     },
-    [handleResourcesSelection, resources]
+    [handleResourcesSelection, regionFilteredResources]
   );
 
   const titleRef = React.useRef<HTMLDivElement>(null); // Reference to the component title, used for scrolling to the title when the table's page size or page number changes.
@@ -352,7 +379,6 @@ export const AlertResources = React.memo((props: AlertResourcesProp) => {
     maxSelectionCount && selectedResources
       ? Math.max(0, maxSelectionCount - selectedResources.length)
       : undefined;
-
   return (
     <Stack gap={2}>
       {!hideLabel && (
@@ -401,11 +427,14 @@ export const AlertResources = React.memo((props: AlertResourcesProp) => {
                   filterKey,
                   handleFilterChange,
                   handleFilteredRegionsChange,
+                  endpointOptions,
                   regionOptions,
                   tagOptions: Array.from(
                     new Set(
-                      resources
-                        ? resources.flatMap(({ tags }) => tags ?? [])
+                      regionFilteredResources
+                        ? regionFilteredResources.flatMap(
+                            ({ tags }) => tags ?? []
+                          )
                         : []
                     )
                   ),
@@ -454,15 +483,15 @@ export const AlertResources = React.memo((props: AlertResourcesProp) => {
         )}
         {isSelectionsNeeded &&
           !isDataLoadingError &&
-          resources &&
-          resources.length > 0 && (
+          regionFilteredResources &&
+          regionFilteredResources.length > 0 && (
             <GridLegacy item xs={12}>
               <AlertSelectedInfoNotice
                 handleSelectionChange={handleAllSelection}
                 maxSelectionCount={maxSelectionCount}
                 property="entities"
                 selectedCount={selectedResources.length}
-                totalCount={resources?.length ?? 0}
+                totalCount={regionFilteredResources?.length ?? 0}
               />
             </GridLegacy>
           )}

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsResources/AlertsResourcesFilterRenderer.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsResources/AlertsResourcesFilterRenderer.test.tsx
@@ -1,3 +1,4 @@
+import { screen } from '@testing-library/react';
 import React from 'react';
 
 import { renderWithTheme } from 'src/utilities/testHelpers';
@@ -8,12 +9,14 @@ import { serviceToFiltersMap } from './constants';
 
 describe('AlertsResourcesFilterRenderer', () => {
   const filters = serviceToFiltersMap['dbaas'] ?? []; // Get filters for dbaas service type
+  const objectStorageFilters = serviceToFiltersMap['objectstorage'] ?? [];
   it('renders the correct filter components based on properties passed', () => {
     const handleFilterChangeMock = vi.fn();
     const engineProps = getAlertResourceFilterProps({
       filterKey: 'engineType',
       handleFilterChange: handleFilterChangeMock,
       handleFilteredRegionsChange: handleFilterChangeMock,
+      endpointOptions: [],
       regionOptions: [],
       tagOptions: [],
     });
@@ -36,6 +39,7 @@ describe('AlertsResourcesFilterRenderer', () => {
       filterKey: 'region',
       handleFilterChange: handleFilterChangeMock,
       handleFilteredRegionsChange: handleFilterChangeMock,
+      endpointOptions: [],
       regionOptions: [],
       tagOptions: [],
     });
@@ -52,5 +56,27 @@ describe('AlertsResourcesFilterRenderer', () => {
     );
 
     expect(getByPlaceholderText('Select Regions')).toBeInTheDocument();
+
+    const endpointProps = getAlertResourceFilterProps({
+      filterKey: 'endpoint',
+      handleFilterChange: handleFilterChangeMock,
+      handleFilteredRegionsChange: handleFilterChangeMock,
+      endpointOptions: [],
+      regionOptions: [],
+      tagOptions: [],
+    });
+    const endpointPropKeys = Object.keys(endpointProps);
+    expect(endpointPropKeys.includes('handleFilterChange')).toBeTruthy();
+    expect(endpointPropKeys.includes('handleSelectionChange')).toBeFalsy();
+
+    // Check for region filter
+    renderWithTheme(
+      <AlertResourcesFilterRenderer
+        component={objectStorageFilters[1].component}
+        componentProps={endpointProps}
+      />
+    );
+
+    expect(screen.getByPlaceholderText('Select Endpoints')).toBeVisible();
   });
 });

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsResources/DisplayAlertResources.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsResources/DisplayAlertResources.tsx
@@ -25,6 +25,10 @@ export interface AlertInstance {
    */
   checked?: boolean;
   /**
+   * The endpoint associated with the object storage instance
+   */
+  endpoint?: string;
+  /**
    * The region associated with the instance
    */
   engineType?: string;

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsResources/constants.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsResources/constants.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { engineTypeMap } from '../constants';
+import { AlertsEndpointFilter } from './AlertsEndpointFilter';
 import { AlertsEngineTypeFilter } from './AlertsEngineTypeFilter';
 import { AlertsRegionFilter } from './AlertsRegionFilter';
 import { AlertsTagFilter } from './AlertsTagsFilter';
@@ -86,6 +87,23 @@ export const serviceTypeBasedColumns: ServiceColumns<AlertInstance> = {
       sortingKey: 'tags',
     },
   ],
+  objectstorage: [
+    {
+      accessor: ({ label }) => label,
+      label: 'Entity',
+      sortingKey: 'label',
+    },
+    {
+      accessor: ({ region }) => region,
+      label: 'Region',
+      sortingKey: 'region',
+    },
+    {
+      accessor: ({ endpoint }) => endpoint,
+      label: 'Endpoint',
+      sortingKey: 'endpoint',
+    },
+  ],
 };
 
 export const serviceToFiltersMap: Partial<
@@ -103,16 +121,22 @@ export const serviceToFiltersMap: Partial<
     { component: AlertsRegionFilter, filterKey: 'region' },
     { component: AlertsTagFilter, filterKey: 'tags' },
   ],
+  objectstorage: [
+    { component: AlertsRegionFilter, filterKey: 'region' },
+    { component: AlertsEndpointFilter, filterKey: 'endpoint' },
+  ],
 };
 export const applicableAdditionalFilterKeys: AlertAdditionalFilterKey[] = [
   'engineType', // Extendable in future for filter keys like 'tags', 'plan', etc.
   'tags',
+  'endpoint',
 ];
 
 export const alertAdditionalFilterKeyMap: Record<
   AlertAdditionalFilterKey,
   keyof AlertInstance
 > = {
+  endpoint: 'endpoint',
   engineType: 'engineType', // engineType filter selected here, will map to engineType property on AlertInstance
   tags: 'tags',
 };

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsResources/types.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsResources/types.ts
@@ -1,5 +1,6 @@
 import type { MemoExoticComponent } from 'react';
 
+import type { AlertsEndpointFilterProps } from './AlertsEndpointFilter';
 import type { AlertsEngineOptionProps } from './AlertsEngineTypeFilter';
 import type { AlertsRegionProps } from './AlertsRegionFilter';
 import type { AlertsTagFilterProps } from './AlertsTagsFilter';
@@ -46,7 +47,7 @@ export type ServiceColumns<T> = Partial<
  * Defines the available filter keys that can be used to filter alerts.
  * This type will be extended in the future to include other attributes like tags, plan, etc.
  */
-export type AlertFilterKey = 'engineType' | 'region' | 'tags'; // will be extended to have tags, plan etc.,
+export type AlertFilterKey = 'endpoint' | 'engineType' | 'region' | 'tags'; // will be extended to have tags, plan etc.,
 
 /**
  * Represents the possible types for alert filter values.
@@ -58,9 +59,10 @@ export type AlertFilterType = boolean | number | string | string[] | undefined;
  * Defines additional filter keys that can be used beyond the primary ones.
  * Future Extensions: Additional attributes like 'tags' and 'plan' can be added here.
  */
-export type AlertAdditionalFilterKey = 'engineType' | 'tags'; // will be extended to have tags, plan etc.,
+export type AlertAdditionalFilterKey = 'endpoint' | 'engineType' | 'tags'; // will be extended to have tags, plan etc.,
 
 export type AlertResourceFiltersProps =
+  | AlertsEndpointFilterProps
   | AlertsEngineOptionProps
   | AlertsRegionProps
   | AlertsTagFilterProps;

--- a/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertResourceUtils.test.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertResourceUtils.test.ts
@@ -1,7 +1,9 @@
 import { regionFactory } from '@linode/utilities';
 
 import {
+  getEndpointOptions,
   getFilteredResources,
+  getOfflineRegionFilteredResources,
   getRegionOptions,
   getRegionsIdRegionMap,
   getSupportedRegionIds,
@@ -194,5 +196,67 @@ describe('getSupportedRegionIds', () => {
   it('should return empty list if regions list empty', () => {
     const result = getSupportedRegionIds([], 'linode');
     expect(result).toHaveLength(0);
+  });
+});
+
+describe('getEndpointOptions', () => {
+  const mockResources: CloudPulseResources[] = [
+    { id: '1', endpoint: 'endpoint-a', region: 'us-east', label: 'r1' },
+    { id: '2', endpoint: 'endpoint-b', region: 'us-east', label: 'r2' },
+    { id: '3', endpoint: 'endpoint-a', region: 'us-west', label: 'r3' },
+    { id: '4', endpoint: undefined, region: 'us-west', label: 'r4' },
+  ];
+
+  it('returns all unique endpoints when isAdditionOrDeletionNeeded = true', () => {
+    const result = getEndpointOptions(mockResources, true);
+    expect(result).toEqual(['endpoint-a', 'endpoint-b']);
+  });
+
+  it('returns endpoints only for matching resourceIds when flag = false', () => {
+    const result = getEndpointOptions(mockResources, false, ['2', '4']);
+    expect(result).toEqual(['endpoint-b']);
+  });
+
+  it('returns empty array when no data provided', () => {
+    const result = getEndpointOptions(undefined, true);
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array when no resourceIds and flag = false', () => {
+    const result = getEndpointOptions(mockResources, false, []);
+    expect(result).toEqual([]);
+  });
+});
+
+describe('getOfflineRegionFilteredResources', () => {
+  const mockResources: CloudPulseResources[] = [
+    { id: '1', region: 'us-east', label: 'r1' },
+    { id: '2', region: 'us-west', label: 'r2' },
+    { id: '3', region: '', label: 'r3' },
+  ];
+
+  it('filters resources based on supportedRegionIds', () => {
+    const result = getOfflineRegionFilteredResources(mockResources, [
+      'us-east',
+    ]);
+    expect(result).toEqual([{ id: '1', region: 'us-east', label: 'r1' }]);
+  });
+
+  it('returns empty array if no supported regions match', () => {
+    const result = getOfflineRegionFilteredResources(mockResources, [
+      'eu-central',
+    ]);
+    expect(result).toEqual([]);
+  });
+
+  it('excludes resources with undefined region', () => {
+    const result = getOfflineRegionFilteredResources(mockResources, [
+      'us-east',
+      'us-west',
+    ]);
+    expect(result).toEqual([
+      { id: '1', region: 'us-east', label: 'r1' },
+      { id: '2', region: 'us-west', label: 'r2' },
+    ]);
   });
 });

--- a/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertResourceUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertResourceUtils.ts
@@ -63,6 +63,10 @@ interface FilterResourceProps {
 
 interface FilterRendererProps {
   /**
+   * The endpoints to be displayed according the resources associated with alerts
+   */
+  endpointOptions: string[];
+  /**
    * The filter to which the props needs to built for
    */
   filterKey: AlertFilterKey;
@@ -135,6 +139,32 @@ export const getRegionOptions = (
     }
   });
   return Array.from(uniqueRegions);
+};
+/**
+ * Builds a list of unique endpoint strings from CloudPulse resources.
+ *
+ * @param data - List of CloudPulse resources to extract endpoints from.
+ * @param isAdditionOrDeletionNeeded - Flag to include all resources regardless of `resourceIds`.
+ * @param resourceIds - Optional list of resource IDs to filter which endpoints are included.
+ * @returns A unique list of endpoint strings. Returns an empty array if no valid data.
+ */
+export const getEndpointOptions = (
+  data?: CloudPulseResources[],
+  isAdditionOrDeletionNeeded?: boolean,
+  resourceIds?: string[]
+): string[] => {
+  const isEmpty =
+    !data || (!isAdditionOrDeletionNeeded && !resourceIds?.length);
+
+  if (isEmpty) return [];
+
+  const uniqueEndpoints = new Set<string>();
+  data.forEach(({ id, endpoint }) => {
+    if (isAdditionOrDeletionNeeded || resourceIds?.includes(String(id))) {
+      if (endpoint) uniqueEndpoints.add(endpoint);
+    }
+  });
+  return Array.from(uniqueEndpoints);
 };
 
 /**
@@ -242,6 +272,10 @@ const applyAdditionalFilter = (
       return value.some((obj) => resourceValue.includes(obj));
     }
 
+    // to cover the endpoint scenario where resourceValue is string and value can be string[]
+    if (Array.isArray(value) && typeof resourceValue === 'string') {
+      return resourceValue && value.includes(resourceValue);
+    }
     return resourceValue === value;
   });
 };
@@ -319,10 +353,13 @@ export const getAlertResourceFilterProps = ({
   filterKey,
   handleFilterChange,
   handleFilteredRegionsChange: handleSelectionChange,
+  endpointOptions,
   regionOptions,
   tagOptions,
 }: FilterRendererProps): AlertResourceFiltersProps => {
   switch (filterKey) {
+    case 'endpoint':
+      return { handleFilterChange, endpointOptions };
     case 'engineType':
       return { handleFilterChange };
     case 'region':
@@ -332,4 +369,20 @@ export const getAlertResourceFilterProps = ({
     default:
       return { handleFilterChange };
   }
+};
+
+/**
+ * Filters CloudPulse resources to include only those whose region
+ * is present in the given list of ACLP supported region IDs.
+ * @param resources - The unfiltered list of CloudPulse resources.
+ * @param supportedRegionIds - Region IDs that have ACLP support and required capabilities.
+ * @returns A filtered list of CloudPulse resources located in supported regions.
+ */
+export const getOfflineRegionFilteredResources = (
+  resources: CloudPulseResources[],
+  supportedRegionIds: string[]
+): CloudPulseResources[] => {
+  return resources.filter(
+    ({ region }) => region && supportedRegionIds.includes(region)
+  );
 };

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.tsx
@@ -13,6 +13,7 @@ import type { CloudPulseServiceType, FilterValue } from '@linode/api-v4';
 
 export interface CloudPulseResources {
   clusterSize?: number;
+  endpoint?: string;
   engineType?: string;
   entities?: Record<string, string>;
   id: string;

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -1340,6 +1340,16 @@ export const handlers = [
         region: 'us-mia',
         s3_endpoint: 'us-mia-1.linodeobjects.com',
       }),
+      objectStorageEndpointsFactory.build({
+        endpoint_type: 'E3',
+        region: 'ap-west',
+        s3_endpoint: 'ap-west-1.linodeobjects.com',
+      }),
+      objectStorageEndpointsFactory.build({
+        endpoint_type: 'E3',
+        region: 'us-iad',
+        s3_endpoint: 'us-iad-1.linodeobjects.com',
+      }),
     ];
     return HttpResponse.json(makeResourcePage(endpoints));
   }),
@@ -1441,14 +1451,49 @@ export const handlers = [
       Math.random() * 4
     )}` as ObjectStorageEndpointTypes;
 
-    const buckets = objectStorageBucketFactoryGen2.buildList(1, {
-      cluster: `${region}-1`,
-      endpoint_type: randomEndpointType,
-      hostname: `obj-bucket-${randomBucketNumber}.${region}.linodeobjects.com`,
-      label: `obj-bucket-${randomBucketNumber}`,
-      region,
-    });
-
+    const buckets =
+      region !== 'ap-west' && region !== 'us-iad'
+        ? objectStorageBucketFactoryGen2.buildList(1, {
+            cluster: `${region}-1`,
+            endpoint_type: randomEndpointType,
+            hostname: `obj-bucket-${randomBucketNumber}.${region}.linodeobjects.com`,
+            label: `obj-bucket-${randomBucketNumber}`,
+            region,
+          })
+        : [];
+    if (region === 'ap-west') {
+      buckets.push(
+        objectStorageBucketFactoryGen2.build({
+          cluster: `ap-west-1`,
+          endpoint_type: 'E3',
+          s3_endpoint: 'ap-west-1.linodeobjects.com',
+          hostname: `obj-bucket-804.ap-west.linodeobjects.com`,
+          label: `obj-bucket-804`,
+          region,
+        })
+      );
+      buckets.push(
+        objectStorageBucketFactoryGen2.build({
+          cluster: `ap-west-1`,
+          endpoint_type: 'E3',
+          s3_endpoint: 'ap-west-1.linodeobjects.com',
+          hostname: `obj-bucket-902.ap-west.linodeobjects.com`,
+          label: `obj-bucket-902`,
+          region,
+        })
+      );
+    }
+    if (region === 'us-iad')
+      buckets.push(
+        objectStorageBucketFactoryGen2.build({
+          cluster: `us-iad-1`,
+          endpoint_type: 'E3',
+          s3_endpoint: 'us-iad-1.linodeobjects.com',
+          hostname: `obj-bucket-230.us-iad.linodeobjects.com`,
+          label: `obj-bucket-230`,
+          region,
+        })
+      );
     return HttpResponse.json({
       data: buckets.slice(
         (page - 1) * pageSize,
@@ -3048,6 +3093,12 @@ export const handlers = [
           regions: 'us-iad,us-east',
           alert: serviceAlertFactory.build({ scope: ['entity'] }),
         }),
+        serviceTypesFactory.build({
+          label: 'Object Storage',
+          service_type: 'objectstorage',
+          regions: '',
+          alert: serviceAlertFactory.build({ scope: ['entity'] }),
+        }),
       ],
     };
 
@@ -3060,6 +3111,7 @@ export const handlers = [
       dbaas: 'Databases',
       nodebalancer: 'NodeBalancers',
       firewall: 'Firewalls',
+      objectstorage: 'ObjectStorage',
     };
     const response = serviceTypesFactory.build({
       service_type: `${serviceType}`,
@@ -3067,6 +3119,7 @@ export const handlers = [
       alert: serviceAlertFactory.build({
         evaluation_period_seconds: [300],
         polling_interval_seconds: [300],
+        scope: ['entity']
       }),
     });
 

--- a/packages/manager/src/queries/cloudpulse/queries.ts
+++ b/packages/manager/src/queries/cloudpulse/queries.ts
@@ -16,6 +16,11 @@ import {
 } from '@linode/queries';
 import { createQueryKeys } from '@lukemorales/query-key-factory';
 
+import { objectStorageQueries } from '../object-storage/queries';
+import {
+  getAllBucketsFromEndpoints,
+  getAllObjectStorageEndpoints,
+} from '../object-storage/requests';
 import { fetchCloudPulseMetrics } from './metrics';
 import {
   getAllAlertsRequest,
@@ -121,12 +126,18 @@ export const queryFactory = createQueryKeys(key, {
           queryFn: () => getAllLinodesRequest(params, filters), // since we don't have query factory implementation, in linodes.ts, once it is ready we will reuse that, untill then we will use same query keys
           queryKey: ['linodes', params, filters],
         };
-
       case 'nodebalancer':
         return nodebalancerQueries.nodebalancers._ctx.all(params, filters);
+      case 'objectstorage':
+        return {
+          queryFn: () => getAllBuckets(),
+          queryKey: [
+            ...objectStorageQueries.endpoints.queryKey,
+            objectStorageQueries.buckets.queryKey[1],
+          ],
+        };
       case 'volumes':
         return volumeQueries.lists._ctx.all(params, filters); // in this we don't need to define our own query factory, we will reuse existing implementation in volumes.ts
-
       default:
         return volumeQueries.lists._ctx.all(params, filters); // default to volumes
     }
@@ -134,6 +145,23 @@ export const queryFactory = createQueryKeys(key, {
 
   token: (serviceType: string | undefined, request: JWETokenPayLoad) => ({
     queryFn: () => getJWEToken(request, serviceType!),
-    queryKey: [serviceType, { resource_ids: request.entity_ids.sort() }],
+    queryKey: [serviceType, { resource_ids: request.entity_ids?.sort() }],
   }),
 });
+
+const getAllBuckets = async () => {
+  const endpoints = await getAllObjectStorageEndpoints();
+
+  // Get all the buckets from the endpoints
+  const allBuckets = await getAllBucketsFromEndpoints(endpoints);
+
+  // Throw the error if we encounter any error for any single call.
+  if (allBuckets.errors.length) {
+    throw new Error('Unable to fetch the data.');
+  }
+
+  // Filter the E0, E1 endpoint_type out and return the buckets
+  return allBuckets.buckets.filter(
+    (bucket) => bucket.endpoint_type !== 'E0' && bucket.endpoint_type !== 'E1'
+  );
+};

--- a/packages/manager/src/queries/cloudpulse/resources.ts
+++ b/packages/manager/src/queries/cloudpulse/resources.ts
@@ -14,7 +14,11 @@ export const useResourcesQuery = (
   useQuery<any[], unknown, CloudPulseResources[]>({
     ...queryFactory.resources(resourceType, params, filters),
     enabled,
+    retry: resourceType === 'objectstorage' ? false : 3,
     select: (resources) => {
+      if (!enabled) {
+        return []; // Return empty array if the query is not enabled
+      }
       return resources.map((resource) => {
         const entities: Record<string, string> = {};
 
@@ -33,13 +37,18 @@ export const useResourcesQuery = (
             }
           });
         }
+        const id =
+          resourceType === 'objectstorage'
+            ? resource.hostname
+            : String(resource.id);
         return {
           engineType: resource.engine,
-          id: String(resource.id),
-          label: resource.label,
+          id,
+          label: resourceType === 'objectstorage' ? id : resource.label,
           region: resource.region,
           regions: resource.regions ? resource.regions : [],
           tags: resource.tags,
+          endpoint: resource.s3_endpoint,
           entities,
           clusterSize: resource.cluster_size,
         };

--- a/packages/utilities/src/__data__/regionsData.ts
+++ b/packages/utilities/src/__data__/regionsData.ts
@@ -27,7 +27,7 @@ export const regions: Region[] = [
     },
     site_type: 'core',
     status: 'ok',
-    monitors: { alerts: ['Cloud Firewall'], metrics: [] },
+    monitors: { alerts: ['Cloud Firewall', 'Object Storage'], metrics: [] },
   },
   {
     capabilities: [
@@ -113,7 +113,7 @@ export const regions: Region[] = [
     },
     site_type: 'core',
     status: 'ok',
-    monitors: { alerts: ['Linodes'], metrics: ['Linodes'] },
+    monitors: { alerts: ['Linodes', 'Object Storage'], metrics: ['Linodes'] },
   },
   {
     capabilities: [


### PR DESCRIPTION
## Description 📝

Object storage service integration for Alerts UI 

## Changes  🔄

List any change(s) relevant to the reviewer.

- Util to offline filter object storage resources to have the supportedRegions 
- New component : AlertsEndpointFilter 
- Necessary changes to integrate object storage with the existing AlertsResources component
- UTs for the utils

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [x] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

October 1st

## Preview 📷

| Alert Flow | Screen Recording |
| -- | -- |
| Create Flow| <video src="https://github.com/user-attachments/assets/d53c507b-24a3-44b4-bd58-eae3feb4cf51" />|
| Show-Details Flow | <video src ="https://github.com/user-attachments/assets/c4917e6a-93f1-4c79-a0c1-f23a1c915878" />|
| Edit Flow | <video src = "https://github.com/user-attachments/assets/f8f965d0-3404-4635-bdd8-e3f1a994c856"/> |

 
### Object Storage Alert Creation Payload
<img width="3456" height="520" alt="image" src="https://github.com/user-attachments/assets/0c7c1607-3de5-4a82-a37e-8868d2db68a3" />


## How to test 🧪

### Prerequisites

(How to setup test environment)

- Enable MSW and choose Legacy MSW Handler as Base Preset
- Go to Alerts , under Monitor
- Click on Create Alert to test the behaviour in Create flow
- Search for `Object Storage - testing` alert in the Alerts List . Click on Show-Details/Edit to test the show-details and edit flow respectively.

The current mocks only mock the serviceType, endpoints and buckets API Calls. The metric-definitions call for object-storage is not updated in mocks, it will be done in the upcoming object-storage related PRs. 

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] ...
- [ ] ...

### Verification steps

(How to verify changes)

- [ ] Create Flow is working as show-cased in the recording
- [ ] Show Details Flow is working as show-cased in the recording
- [ ] Edit Flow is working as show-cased in the recording

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>