### PR TITLE
change: Remove deprecated flag from Flags interface

### DIFF
--- a/packages/manager/.changeset/pr-12911-tech-stories-1758736596975.md
+++ b/packages/manager/.changeset/pr-12911-tech-stories-1758736596975.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Remove deprecated `lkeEnterprise` flag from Flags interface ([#12911](https://github.com/linode/manager/pull/12911))

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -182,7 +182,6 @@ export interface Flags {
   linodeCloneFirewall: boolean;
   linodeDiskEncryption: boolean;
   linodeInterfaces: LinodeInterfacesFlag;
-  lkeEnterprise: LkeEnterpriseFlag;
   lkeEnterprise2: LkeEnterpriseFlag;
   mainContentBanner: MainContentBanner;
   marketplaceAppOverrides: MarketplaceAppOverride[];


### PR DESCRIPTION
## Description 📝

Tiny PR to remove the left-behind and now deprecated `lkeEnterprise` flag from the Feature Flags interface.

With the release of CM v1.151.0, we moved to `lkeEnterprise2`, which is currently serving LKE-E features as of 9/23.

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [x] No customers / Not applicable

## Target release date 🗓️

10/7

## How to test 🧪

### Verification steps

(How to verify changes)

- [ ] Check the diff.
- [ ] Search Cloud Manager for `lkeEnterprise` and confirm that flag name is no longer found in code. Only the `lkeEnterprise2` flag is used.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>