### PR TITLE
[DI-26882] - Handle integration of Object Storage in Metrics

### DIFF
--- a/packages/api-v4/src/cloudpulse/types.ts
+++ b/packages/api-v4/src/cloudpulse/types.ts
@@ -9,7 +9,6 @@ export type CloudPulseServiceType =
   | 'linode'
   | 'nodebalancer'
   | 'objectstorage';
-
 export type AlertClass = 'dedicated' | 'shared';
 export type DimensionFilterOperatorType =
   | 'endswith'
@@ -134,7 +133,7 @@ export interface Dimension {
 }
 
 export interface JWETokenPayLoad {
-  entity_ids: number[];
+  entity_ids: number[] | undefined;
 }
 
 export interface JWEToken {
@@ -149,7 +148,8 @@ export interface Metric {
 export interface CloudPulseMetricsRequest {
   absolute_time_duration: DateTimeWithPreset | undefined;
   associated_entity_region?: string;
-  entity_ids: number[];
+  entity_ids: number[] | string[];
+  entity_region?: string;
   filters?: Filters[];
   group_by?: string[];
   metrics: Metric[];

--- a/packages/api-v4/src/cloudpulse/types.ts
+++ b/packages/api-v4/src/cloudpulse/types.ts
@@ -133,7 +133,7 @@ export interface Dimension {
 }
 
 export interface JWETokenPayLoad {
-  entity_ids: number[] | undefined;
+  entity_ids?: number[];
 }
 
 export interface JWEToken {

--- a/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboard.tsx
+++ b/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboard.tsx
@@ -17,7 +17,11 @@ import {
 } from '../Widget/CloudPulseWidgetRenderer';
 
 import type { CloudPulseMetricsAdditionalFilters } from '../Widget/CloudPulseWidget';
-import type { DateTimeWithPreset, JWETokenPayLoad } from '@linode/api-v4';
+import type {
+  CloudPulseServiceType,
+  DateTimeWithPreset,
+  JWETokenPayLoad,
+} from '@linode/api-v4';
 
 export interface DashboardProperties {
   /**
@@ -66,6 +70,11 @@ export interface DashboardProperties {
   savePref?: boolean;
 
   /**
+   * Selected service type for the dashboard
+   */
+  serviceType: CloudPulseServiceType;
+
+  /**
    * Selected tags for the dashboard
    */
   tags?: string[];
@@ -79,6 +88,7 @@ export const CloudPulseDashboard = (props: DashboardProperties) => {
     manualRefreshTimeStamp,
     resources,
     savePref,
+    serviceType,
     groupBy,
     linodeRegion,
     region,
@@ -86,10 +96,8 @@ export const CloudPulseDashboard = (props: DashboardProperties) => {
 
   const { preferences } = useAclpPreference();
 
-  const getJweTokenPayload = (
-    dashboardId: number | undefined
-  ): JWETokenPayLoad => {
-    if (!dashboardId || dashboardId === 6) {
+  const getJweTokenPayload = (): JWETokenPayLoad => {
+    if (serviceType === 'objectstorage') {
       return {};
     }
     return {
@@ -129,7 +137,7 @@ export const CloudPulseDashboard = (props: DashboardProperties) => {
     isFetching: isJweTokenFetching,
   } = useCloudPulseJWEtokenQuery(
     dashboard?.service_type,
-    getJweTokenPayload(dashboard?.id),
+    getJweTokenPayload(),
     Boolean(resources) && !isDashboardLoading && !isDashboardApiError
   );
 

--- a/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboard.tsx
+++ b/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboard.tsx
@@ -90,7 +90,7 @@ export const CloudPulseDashboard = (props: DashboardProperties) => {
     dashboardId: number | undefined
   ): JWETokenPayLoad => {
     if (!dashboardId || dashboardId === 6) {
-      return { entity_ids: undefined };
+      return {};
     }
     return {
       entity_ids: resources?.map((resource) => Number(resource)) ?? [],

--- a/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboard.tsx
+++ b/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboard.tsx
@@ -81,10 +81,17 @@ export const CloudPulseDashboard = (props: DashboardProperties) => {
     savePref,
     groupBy,
     linodeRegion,
+    region,
   } = props;
 
   const { preferences } = useAclpPreference();
-  const getJweTokenPayload = (): JWETokenPayLoad => {
+
+  const getJweTokenPayload = (
+    dashboardId: number | undefined
+  ): JWETokenPayLoad => {
+    if (!dashboardId || dashboardId === 6) {
+      return { entity_ids: undefined };
+    }
     return {
       entity_ids: resources?.map((resource) => Number(resource)) ?? [],
     };
@@ -122,7 +129,7 @@ export const CloudPulseDashboard = (props: DashboardProperties) => {
     isFetching: isJweTokenFetching,
   } = useCloudPulseJWEtokenQuery(
     dashboard?.service_type,
-    getJweTokenPayload(),
+    getJweTokenPayload(dashboard?.id),
     Boolean(resources) && !isDashboardLoading && !isDashboardApiError
   );
 
@@ -169,6 +176,7 @@ export const CloudPulseDashboard = (props: DashboardProperties) => {
       manualRefreshTimeStamp={manualRefreshTimeStamp}
       metricDefinitions={metricDefinitions}
       preferences={preferences}
+      region={region}
       resourceList={resourceList}
       resources={resources}
       savePref={savePref}

--- a/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardRenderer.tsx
+++ b/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardRenderer.tsx
@@ -85,6 +85,7 @@ export const CloudPulseDashboardRenderer = React.memo(
             : []
         }
         savePref={true}
+        serviceType={dashboard.service_type}
         tags={
           filterValue[TAGS] && Array.isArray(filterValue[TAGS])
             ? (filterValue[TAGS] as string[])

--- a/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardWithFilters.tsx
+++ b/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardWithFilters.tsx
@@ -185,7 +185,13 @@ export const CloudPulseDashboardWithFilters = React.memo(
                 emitFilterChange={onFilterChange}
                 handleToggleAppliedFilter={toggleAppliedFilter}
                 isServiceAnalyticsIntegration
-                resource_ids={[resource]}
+                resource_ids={
+                  dashboard.service_type !== 'objectstorage'
+                    ? typeof resource === 'number'
+                      ? [resource]
+                      : undefined
+                    : undefined
+                }
               />
             )}
             <GridLegacy

--- a/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardWithFilters.tsx
+++ b/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardWithFilters.tsx
@@ -35,7 +35,7 @@ export interface CloudPulseDashboardWithFiltersProp {
   /**
    * The resource id for which the metrics will be listed
    */
-  resource: number;
+  resource: number | string;
 }
 
 export const CloudPulseDashboardWithFilters = React.memo(

--- a/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardWithFilters.tsx
+++ b/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardWithFilters.tsx
@@ -29,6 +29,10 @@ export interface CloudPulseDashboardWithFiltersProp {
    */
   dashboardId: number;
   /**
+   * The region for which the metrics will be listed
+   */
+  region?: string;
+  /**
    * The resource id for which the metrics will be listed
    */
   resource: number;
@@ -36,7 +40,7 @@ export interface CloudPulseDashboardWithFiltersProp {
 
 export const CloudPulseDashboardWithFilters = React.memo(
   (props: CloudPulseDashboardWithFiltersProp) => {
-    const { dashboardId, resource } = props;
+    const { dashboardId, resource, region } = props;
     const { data: dashboard, isError } =
       useCloudPulseDashboardByIdQuery(dashboardId);
     const [filterData, setFilterData] = React.useState<FilterData>({
@@ -122,6 +126,7 @@ export const CloudPulseDashboardWithFilters = React.memo(
       dashboardObj: dashboard,
       filterValue: filterData.id,
       resource,
+      region,
       timeDuration,
       groupBy,
     });
@@ -206,6 +211,7 @@ export const CloudPulseDashboardWithFilters = React.memo(
               dashboardObj: dashboard,
               filterValue: filterData.id,
               resource,
+              region,
               timeDuration,
               groupBy,
             })}

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.test.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.test.ts
@@ -266,22 +266,22 @@ describe('getTimeDurationFromPreset method', () => {
   });
 
   describe('getEntityIds method', () => {
-    it('should return entity ids for dashboard id 6', () => {
+    it('should return entity ids for linode service type', () => {
       const result = getEntityIds(
         [{ id: '123', label: 'linode-1' }],
         ['123'],
         widgetFactory.build(),
-        2
+        'linode'
       );
       expect(result).toEqual([123]);
     });
 
-    it('should return entity ids for dashboard id 2', () => {
+    it('should return entity ids for objectstorage service type', () => {
       const result = getEntityIds(
         [{ id: 'bucket-1', label: 'bucket-name-1' }],
         ['bucket-1'],
         widgetFactory.build(),
-        6
+        'objectstorage'
       );
       expect(result).toEqual(['bucket-1']);
     });

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.test.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.test.ts
@@ -1,9 +1,12 @@
 import { formatPercentage } from '@linode/utilities';
 
+import { widgetFactory } from 'src/factories';
+
 import {
   generateGraphData,
   generateMaxUnit,
   getDimensionName,
+  getEntityIds,
   getLabelName,
   getTimeDurationFromPreset,
   mapResourceIdToName,
@@ -260,5 +263,27 @@ describe('getTimeDurationFromPreset method', () => {
   it('shoult return undefined of invalid preset', () => {
     const result = getTimeDurationFromPreset('15min');
     expect(result).toBe(undefined);
+  });
+
+  describe('getEntityIds method', () => {
+    it('should return entity ids for dashboard id 6', () => {
+      const result = getEntityIds(
+        [{ id: '123', label: 'linode-1' }],
+        ['123'],
+        widgetFactory.build(),
+        2
+      );
+      expect(result).toEqual([123]);
+    });
+
+    it('should return entity ids for dashboard id 2', () => {
+      const result = getEntityIds(
+        [{ id: 'bucket-1', label: 'bucket-name-1' }],
+        ['bucket-1'],
+        widgetFactory.build(),
+        6
+      );
+      expect(result).toEqual(['bucket-1']);
+    });
   });
 });

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
@@ -112,11 +112,6 @@ interface GraphDataOptionsProps {
 
 interface MetricRequestProps {
   /**
-   * id of the selected dashboard
-   */
-  dashboardId: number;
-
-  /**
    * time duration for the metrics data
    */
   duration: DateTimeWithPreset;
@@ -142,6 +137,11 @@ interface MetricRequestProps {
    * list of CloudPulse resources available
    */
   resources: CloudPulseResources[];
+
+  /**
+   * service type of the widget
+   */
+  serviceType: CloudPulseServiceType;
 
   /**
    * widget filters for metrics data
@@ -343,16 +343,16 @@ export const getCloudPulseMetricRequest = (
     widget,
     groupBy,
     linodeRegion,
-    dashboardId,
     region,
+    serviceType,
   } = props;
   const preset = duration.preset;
-  const metricsRequest: CloudPulseMetricsRequest = {
+  return {
     absolute_time_duration:
       preset !== 'reset' && preset !== 'this month' && preset !== 'last month'
         ? undefined
         : { end: duration.end, start: duration.start },
-    entity_ids: getEntityIds(resources, entityIds, widget, dashboardId),
+    entity_ids: getEntityIds(resources, entityIds, widget, serviceType),
     filters: undefined,
     group_by: !groupBy?.length ? undefined : groupBy,
     relative_time_duration: getTimeDurationFromPreset(preset),
@@ -370,15 +370,8 @@ export const getCloudPulseMetricRequest = (
             value: widget.time_granularity.value,
           },
     associated_entity_region: linodeRegion,
+    entity_region: serviceType === 'objectstorage' ? region : undefined,
   };
-
-  if (dashboardId === 6) {
-    return {
-      ...metricsRequest,
-      entity_region: region,
-    };
-  }
-  return metricsRequest;
 };
 
 /**
@@ -392,9 +385,9 @@ export const getEntityIds = (
   resources: CloudPulseResources[],
   entityIds: string[],
   widget: Widgets,
-  dashboardId: number
+  serviceType: CloudPulseServiceType
 ) => {
-  if (dashboardId === 6) {
+  if (serviceType === 'objectstorage') {
     return entityIds;
   }
   return resources

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.test.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.test.ts
@@ -433,18 +433,26 @@ it('test getEndpointsProperties method', () => {
       },
       vi.fn()
     );
+    const {
+      label,
+      serviceType,
+      disabled,
+      savePreferences,
+      handleEndpointsSelection,
+      defaultValue,
+      region,
+      xFilter,
+    } = endpointsProperties;
 
     expect(endpointsProperties).toBeDefined();
-    expect(endpointsProperties.label).toEqual(
-      endpointsConfig.configuration.name
-    );
-    expect(endpointsProperties.serviceType).toEqual('objectstorage');
-    expect(endpointsProperties.savePreferences).toEqual(true);
-    expect(endpointsProperties.disabled).toEqual(false);
-    expect(endpointsProperties.handleEndpointsSelection).toBeDefined();
-    expect(endpointsProperties.defaultValue).toEqual(undefined);
-    expect(endpointsProperties.region).toEqual('us-east');
-    expect(endpointsProperties.xFilter).toEqual({ region: 'us-east' });
+    expect(label).toEqual(endpointsConfig.configuration.name);
+    expect(serviceType).toEqual('objectstorage');
+    expect(savePreferences).toEqual(true);
+    expect(disabled).toEqual(false);
+    expect(handleEndpointsSelection).toBeDefined();
+    expect(defaultValue).toEqual(undefined);
+    expect(region).toEqual('us-east');
+    expect(xFilter).toEqual({ region: 'us-east' });
   }
 });
 

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.test.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.test.ts
@@ -13,6 +13,7 @@ import {
   filterBasedOnConfig,
   filterEndpointsUsingRegion,
   filterUsingDependentFilters,
+  getEndpointsProperties,
   getFilters,
   getTextFilterProperties,
 } from './FilterBuilder';
@@ -45,6 +46,13 @@ const nodeBalancerConfig = FILTER_CONFIG.get(3);
 const firewallConfig = FILTER_CONFIG.get(4);
 
 const dbaasDashboard = dashboardFactory.build({ service_type: 'dbaas', id: 1 });
+
+const objectStorageBucketDashboard = dashboardFactory.build({
+  service_type: 'objectstorage',
+  id: 6,
+});
+
+const objectStorageBucketConfig = FILTER_CONFIG.get(6);
 
 it('test getRegionProperties method', () => {
   const regionConfig = linodeConfig?.filters.find(
@@ -405,6 +413,38 @@ it('test getTextFilterProperties method for interface_id', () => {
     expect(handleTextFilterChange).toBeDefined();
     expect(label).toEqual(interfaceIdFilterConfig.configuration.name);
     expect(savePreferences).toEqual(true);
+  }
+});
+
+it('test getEndpointsProperties method', () => {
+  const endpointsConfig = objectStorageBucketConfig?.filters.find(
+    (filterObj) => filterObj.name === 'Endpoints'
+  );
+
+  expect(endpointsConfig).toBeDefined();
+
+  if (endpointsConfig) {
+    const endpointsProperties = getEndpointsProperties(
+      {
+        config: endpointsConfig,
+        dashboard: objectStorageBucketDashboard,
+        dependentFilters: { region: 'us-east' },
+        isServiceAnalyticsIntegration: false,
+      },
+      vi.fn()
+    );
+
+    expect(endpointsProperties).toBeDefined();
+    expect(endpointsProperties.label).toEqual(
+      endpointsConfig.configuration.name
+    );
+    expect(endpointsProperties.serviceType).toEqual('objectstorage');
+    expect(endpointsProperties.savePreferences).toEqual(true);
+    expect(endpointsProperties.disabled).toEqual(false);
+    expect(endpointsProperties.handleEndpointsSelection).toBeDefined();
+    expect(endpointsProperties.defaultValue).toEqual(undefined);
+    expect(endpointsProperties.region).toEqual('us-east');
+    expect(endpointsProperties.xFilter).toEqual({ region: 'us-east' });
   }
 });
 

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.test.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.test.ts
@@ -527,6 +527,12 @@ describe('filterUsingDependentFilters', () => {
     expect(result).toEqual([mockData[0], mockData[1]]);
   });
 
+  it('should filter when resource value is a string and filter value is an array', () => {
+    const filters = { region: ['us-east', 'us-west'] };
+    const result = filterUsingDependentFilters(mockData, filters);
+    expect(result).toEqual([mockData[0], mockData[1]]);
+  });
+
   it('should return empty array if no resource matches', () => {
     const filters = { region: 'us-central' };
     const result = filterUsingDependentFilters(mockData, filters);

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.test.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.test.ts
@@ -575,12 +575,6 @@ describe('filterUsingDependentFilters', () => {
     expect(result).toEqual([mockData[0], mockData[1]]);
   });
 
-  it('should filter when resource value is a string and filter value is an array', () => {
-    const filters = { region: ['us-east', 'us-west'] };
-    const result = filterUsingDependentFilters(mockData, filters);
-    expect(result).toEqual([mockData[0], mockData[1]]);
-  });
-
   it('should return empty array if no resource matches', () => {
     const filters = { region: 'us-central' };
     const result = filterUsingDependentFilters(mockData, filters);

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
@@ -361,6 +361,15 @@ export const getTextFilterProperties = (
   };
 };
 
+/**
+ * This function helps in building the properties needed for endpoints selection component
+ *
+ * @param config - accepts a CloudPulseServiceTypeFilters of endpoints key
+ * @param handleEndpointsChange - the callback when we select new endpoints
+ * @param dashboard - the actual selected dashboard
+ * @param isServiceAnalyticsIntegration - only if this is false, we need to save preferences , else no need
+ * @returns CloudPulseEndpointsSelectProps
+ */
 export const getEndpointsProperties = (
   props: CloudPulseFilterProperties,
   handleEndpointsChange: (endpoints: string[], savePref?: boolean) => void

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
@@ -695,17 +695,17 @@ export const getFilters = (
  * @param dependentFilters The selected dependent filters that will be used to filter the resources
  * @returns The filtered resources
  */
-export function filterUsingDependentFilters<T extends { [key: string]: any }>(
-  data?: T[],
+export function filterUsingDependentFilters<CloudPulseResources>(
+  data?: CloudPulseResources[],
   dependentFilters?: CloudPulseMetricsFilter
-): T[] | undefined {
+): CloudPulseResources[] | undefined {
   if (!dependentFilters || !data) {
     return data;
   }
 
   return data.filter((resource) => {
     return Object.entries(dependentFilters).every(([key, filterValue]) => {
-      const resourceValue = resource[key as keyof T];
+      const resourceValue = resource[key as keyof CloudPulseResources];
 
       if (Array.isArray(resourceValue) && Array.isArray(filterValue)) {
         return filterValue.some((val) => resourceValue.includes(String(val)));

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
@@ -695,10 +695,10 @@ export const getFilters = (
  * @param dependentFilters The selected dependent filters that will be used to filter the resources
  * @returns The filtered resources
  */
-export function filterUsingDependentFilters<CloudPulseResources>(
+export const filterUsingDependentFilters = (
   data?: CloudPulseResources[],
   dependentFilters?: CloudPulseMetricsFilter
-): CloudPulseResources[] | undefined {
+): CloudPulseResources[] | undefined => {
   if (!dependentFilters || !data) {
     return data;
   }

--- a/packages/manager/src/features/CloudPulse/Utils/FilterConfig.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterConfig.ts
@@ -1,6 +1,7 @@
 import { capabilityServiceTypeMapping } from '@linode/api-v4';
 
 import {
+  ENDPOINT,
   INTERFACE_IDS_PLACEHOLDER_TEXT,
   LINODE_REGION,
   RESOURCE_ID,
@@ -315,6 +316,55 @@ export const FIREWALL_CONFIG: Readonly<CloudPulseServiceTypeFilterMap> = {
   serviceType: 'firewall',
 };
 
+export const OBJECTSTORAGE_CONFIG_BUCKET: Readonly<CloudPulseServiceTypeFilterMap> =
+  {
+    capability: capabilityServiceTypeMapping['objectstorage'],
+    filters: [
+      {
+        configuration: {
+          filterKey: 'region',
+          filterType: 'string',
+          isFilterable: true,
+          isMetricsFilter: true,
+          name: 'Region',
+          priority: 1,
+          neededInViews: [CloudPulseAvailableViews.central],
+        },
+        name: 'Region',
+      },
+      {
+        configuration: {
+          dependency: ['region'],
+          filterKey: ENDPOINT,
+          filterType: 'string',
+          isFilterable: false,
+          isMetricsFilter: false,
+          isMultiSelect: true,
+          name: 'Endpoints',
+          priority: 2,
+          neededInViews: [CloudPulseAvailableViews.central],
+        },
+        name: 'Endpoints',
+      },
+      {
+        configuration: {
+          dependency: ['region', ENDPOINT],
+          filterKey: RESOURCE_ID,
+          filterType: 'string',
+          isFilterable: true,
+          isMetricsFilter: true,
+          isMultiSelect: true,
+          name: 'Buckets',
+          neededInViews: [CloudPulseAvailableViews.central],
+          placeholder: 'Select Buckets',
+          priority: 3,
+        },
+        name: 'Buckets',
+      },
+    ],
+    serviceType: 'objectstorage',
+  };
+
 export const FILTER_CONFIG: Readonly<
   Map<number, CloudPulseServiceTypeFilterMap>
 > = new Map([
@@ -322,4 +372,5 @@ export const FILTER_CONFIG: Readonly<
   [2, LINODE_CONFIG],
   [3, NODEBALANCER_CONFIG],
   [4, FIREWALL_CONFIG],
+  [6, OBJECTSTORAGE_CONFIG_BUCKET],
 ]);

--- a/packages/manager/src/features/CloudPulse/Utils/FilterConfig.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterConfig.ts
@@ -4,6 +4,7 @@ import {
   ENDPOINT,
   INTERFACE_IDS_PLACEHOLDER_TEXT,
   LINODE_REGION,
+  REGION,
   RESOURCE_ID,
 } from './constants';
 import { CloudPulseAvailableViews, CloudPulseSelectTypes } from './models';
@@ -322,7 +323,7 @@ export const OBJECTSTORAGE_CONFIG_BUCKET: Readonly<CloudPulseServiceTypeFilterMa
     filters: [
       {
         configuration: {
-          filterKey: 'region',
+          filterKey: REGION,
           filterType: 'string',
           isFilterable: true,
           isMetricsFilter: true,
@@ -334,7 +335,7 @@ export const OBJECTSTORAGE_CONFIG_BUCKET: Readonly<CloudPulseServiceTypeFilterMa
       },
       {
         configuration: {
-          dependency: ['region'],
+          dependency: [REGION],
           filterKey: ENDPOINT,
           filterType: 'string',
           isFilterable: false,
@@ -348,7 +349,7 @@ export const OBJECTSTORAGE_CONFIG_BUCKET: Readonly<CloudPulseServiceTypeFilterMa
       },
       {
         configuration: {
-          dependency: ['region', ENDPOINT],
+          dependency: [REGION, ENDPOINT],
           filterKey: RESOURCE_ID,
           filterType: 'string',
           isFilterable: true,

--- a/packages/manager/src/features/CloudPulse/Utils/ReusableDashboardFilterUtils.test.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/ReusableDashboardFilterUtils.test.ts
@@ -25,6 +25,7 @@ it('test getDashboardProperties method', () => {
 
   expect(result).toBeDefined();
   expect(result.dashboardId).toEqual(mockDashboard.id);
+  expect(result.serviceType).toEqual(mockDashboard.service_type);
   expect(result.resources).toEqual(['1']);
   expect(result.region).toEqual('us-east');
 });
@@ -95,9 +96,9 @@ it('test checkMandatoryFiltersSelected method for role', () => {
   expect(result).toBe(true);
 });
 
-it('checkMandatoryFiltersSelected method should return false if no region is selected for dashboard id 6', () => {
+it('checkMandatoryFiltersSelected method should return false if no region is selected for objectstorage service type', () => {
   const result = checkMandatoryFiltersSelected({
-    dashboardObj: { ...mockDashboard, id: 6 },
+    dashboardObj: { ...mockDashboard, service_type: 'objectstorage', id: 6 },
     filterValue: {},
     resource: 1,
     timeDuration: { end: end.toISO(), preset, start: start.toISO() },
@@ -106,9 +107,9 @@ it('checkMandatoryFiltersSelected method should return false if no region is sel
   expect(result).toBe(false);
 });
 
-it('checkMandatoryFiltersSelected method should return true if region is selected for dashboard id 6', () => {
+it('checkMandatoryFiltersSelected method should return true if region is selected for objectstorage service type', () => {
   const result = checkMandatoryFiltersSelected({
-    dashboardObj: { ...mockDashboard, id: 6 },
+    dashboardObj: { ...mockDashboard, service_type: 'objectstorage', id: 6 },
     filterValue: {},
     resource: 1,
     timeDuration: { end: end.toISO(), preset, start: start.toISO() },

--- a/packages/manager/src/features/CloudPulse/Utils/ReusableDashboardFilterUtils.test.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/ReusableDashboardFilterUtils.test.ts
@@ -93,6 +93,29 @@ it('test checkMandatoryFiltersSelected method for role', () => {
   expect(result).toBe(true);
 });
 
+it('checkMandatoryFiltersSelected method should return false if no region is selected for dashboard id 5', () => {
+  const result = checkMandatoryFiltersSelected({
+    dashboardObj: { ...mockDashboard, id: 5 },
+    filterValue: {},
+    resource: 1,
+    timeDuration: { end: end.toISO(), preset, start: start.toISO() },
+    groupBy: [],
+  });
+  expect(result).toBe(false);
+});
+
+it('checkMandatoryFiltersSelected method should return true if region is selected for dashboard id 5', () => {
+  const result = checkMandatoryFiltersSelected({
+    dashboardObj: { ...mockDashboard, id: 5 },
+    filterValue: {},
+    resource: 1,
+    timeDuration: { end: end.toISO(), preset, start: start.toISO() },
+    groupBy: [],
+    region: 'ap-west',
+  });
+  expect(result).toBe(true);
+});
+
 it('test constructDimensionFilters method', () => {
   mockDashboard.service_type = 'dbaas';
   const result = constructDimensionFilters({

--- a/packages/manager/src/features/CloudPulse/Utils/ReusableDashboardFilterUtils.test.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/ReusableDashboardFilterUtils.test.ts
@@ -93,9 +93,9 @@ it('test checkMandatoryFiltersSelected method for role', () => {
   expect(result).toBe(true);
 });
 
-it('checkMandatoryFiltersSelected method should return false if no region is selected for dashboard id 5', () => {
+it('checkMandatoryFiltersSelected method should return false if no region is selected for dashboard id 6', () => {
   const result = checkMandatoryFiltersSelected({
-    dashboardObj: { ...mockDashboard, id: 5 },
+    dashboardObj: { ...mockDashboard, id: 6 },
     filterValue: {},
     resource: 1,
     timeDuration: { end: end.toISO(), preset, start: start.toISO() },
@@ -104,9 +104,9 @@ it('checkMandatoryFiltersSelected method should return false if no region is sel
   expect(result).toBe(false);
 });
 
-it('checkMandatoryFiltersSelected method should return true if region is selected for dashboard id 5', () => {
+it('checkMandatoryFiltersSelected method should return true if region is selected for dashboard id 6', () => {
   const result = checkMandatoryFiltersSelected({
-    dashboardObj: { ...mockDashboard, id: 5 },
+    dashboardObj: { ...mockDashboard, id: 6 },
     filterValue: {},
     resource: 1,
     timeDuration: { end: end.toISO(), preset, start: start.toISO() },

--- a/packages/manager/src/features/CloudPulse/Utils/ReusableDashboardFilterUtils.test.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/ReusableDashboardFilterUtils.test.ts
@@ -20,11 +20,13 @@ it('test getDashboardProperties method', () => {
     filterValue: { region: 'us-east' },
     resource: 1,
     groupBy: [],
+    region: 'us-east',
   });
 
   expect(result).toBeDefined();
   expect(result.dashboardId).toEqual(mockDashboard.id);
   expect(result.resources).toEqual(['1']);
+  expect(result.region).toEqual('us-east');
 });
 
 it('test checkMandatoryFiltersSelected method for time duration and resource', () => {

--- a/packages/manager/src/features/CloudPulse/Utils/ReusableDashboardFilterUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/ReusableDashboardFilterUtils.ts
@@ -56,6 +56,7 @@ export const getDashboardProperties = (
     dashboardId: dashboardObj.id,
     duration: timeDuration ?? defaultTimeDuration(),
     resources: [String(resource)],
+    serviceType: dashboardObj.service_type,
     savePref: false,
     groupBy,
     region,
@@ -80,7 +81,7 @@ export const checkMandatoryFiltersSelected = (
     return false;
   }
 
-  if (dashboardObj.id === 6 && !region) {
+  if (dashboardObj.service_type === 'objectstorage' && !region) {
     return false;
   }
 

--- a/packages/manager/src/features/CloudPulse/Utils/ReusableDashboardFilterUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/ReusableDashboardFilterUtils.ts
@@ -24,6 +24,10 @@ interface ReusableDashboardFilterUtilProps {
    */
   groupBy: string[];
   /**
+   * The selected region
+   */
+  region?: string;
+  /**
    * The selected resource id
    */
   resource: number;
@@ -40,7 +44,8 @@ interface ReusableDashboardFilterUtilProps {
 export const getDashboardProperties = (
   props: ReusableDashboardFilterUtilProps
 ): DashboardProperties => {
-  const { dashboardObj, filterValue, resource, timeDuration, groupBy } = props;
+  const { dashboardObj, filterValue, resource, timeDuration, groupBy, region } =
+    props;
   return {
     additionalFilters: constructDimensionFilters({
       dashboardObj,
@@ -53,6 +58,7 @@ export const getDashboardProperties = (
     resources: [String(resource)],
     savePref: false,
     groupBy,
+    region,
   };
 };
 
@@ -63,7 +69,7 @@ export const getDashboardProperties = (
 export const checkMandatoryFiltersSelected = (
   props: ReusableDashboardFilterUtilProps
 ): boolean => {
-  const { dashboardObj, filterValue, resource, timeDuration } = props;
+  const { dashboardObj, filterValue, resource, timeDuration, region } = props;
   const serviceTypeConfig = FILTER_CONFIG.get(dashboardObj.id);
 
   if (!serviceTypeConfig) {
@@ -71,6 +77,10 @@ export const checkMandatoryFiltersSelected = (
   }
 
   if (!timeDuration || !resource) {
+    return false;
+  }
+
+  if (dashboardObj.id === 6 && !region) {
     return false;
   }
 

--- a/packages/manager/src/features/CloudPulse/Utils/ReusableDashboardFilterUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/ReusableDashboardFilterUtils.ts
@@ -30,7 +30,7 @@ interface ReusableDashboardFilterUtilProps {
   /**
    * The selected resource id
    */
-  resource: number;
+  resource: number | string;
   /**
    * The selected time duration
    */

--- a/packages/manager/src/features/CloudPulse/Utils/constants.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/constants.ts
@@ -8,6 +8,10 @@ export const SECONDARY_NODE = 'secondary';
 
 export const REGION = 'region';
 
+export const ENTITY_REGION = 'entity_region';
+
+export const ENDPOINT = 'endpoint';
+
 export const LINODE_REGION = 'associated_entity_region';
 
 export const RESOURCES = 'resources';
@@ -85,6 +89,7 @@ export const NO_REGION_MESSAGE: Record<string, string> = {
   linode: 'No Linodes configured in any regions.',
   nodebalancer: 'No NodeBalancers configured in any regions.',
   firewall: 'No firewalls configured in any Linode regions.',
+  objectstorage: 'No Object Storage buckets configured in any region.',
 };
 
 export const HELPER_TEXT: Record<string, string> = {

--- a/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.tsx
+++ b/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.tsx
@@ -92,7 +92,7 @@ export interface CloudPulseWidgetProperties {
   linodeRegion?: string;
 
   /**
-   * selected region for the widget
+   * Selected region for the widget
    */
   region?: string;
 
@@ -278,7 +278,7 @@ export const CloudPulseWidget = (props: CloudPulseWidgetProperties) => {
       isFlags: Boolean(flags && !isJweTokenFetching),
       label: widget.label,
       timeStamp,
-      url: 'https://mr-devcloud.cloud-observability-dev.akadns.net/v2beta/monitor/services/',
+      url: flags.aclpReadEndpoint!,
     }
   );
   let data: DataSet[] = [];

--- a/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.tsx
+++ b/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.tsx
@@ -92,6 +92,11 @@ export interface CloudPulseWidgetProperties {
   linodeRegion?: string;
 
   /**
+   * selected region for the widget
+   */
+  region?: string;
+
+  /**
    * List of resources available of selected service type
    */
   resources: CloudPulseResources[];
@@ -149,7 +154,6 @@ export const CloudPulseWidget = (props: CloudPulseWidgetProperties) => {
 
   const {
     additionalFilters,
-    dashboardId,
     ariaLabel,
     authToken,
     availableMetrics,
@@ -163,6 +167,8 @@ export const CloudPulseWidget = (props: CloudPulseWidgetProperties) => {
     unit,
     widget: widgetProp,
     linodeRegion,
+    dashboardId,
+    region,
   } = props;
 
   const timezone =
@@ -262,6 +268,8 @@ export const CloudPulseWidget = (props: CloudPulseWidgetProperties) => {
         widget,
         groupBy: [...(widgetProp.group_by ?? []), ...groupBy],
         linodeRegion,
+        dashboardId,
+        region,
       }),
       filters, // any additional dimension filters will be constructed and passed here
     },

--- a/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.tsx
+++ b/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.tsx
@@ -278,7 +278,7 @@ export const CloudPulseWidget = (props: CloudPulseWidgetProperties) => {
       isFlags: Boolean(flags && !isJweTokenFetching),
       label: widget.label,
       timeStamp,
-      url: flags.aclpReadEndpoint!,
+      url: 'https://mr-devcloud.cloud-observability-dev.akadns.net/v2beta/monitor/services/',
     }
   );
   let data: DataSet[] = [];

--- a/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.tsx
+++ b/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.tsx
@@ -268,8 +268,8 @@ export const CloudPulseWidget = (props: CloudPulseWidgetProperties) => {
         widget,
         groupBy: [...(widgetProp.group_by ?? []), ...groupBy],
         linodeRegion,
-        dashboardId,
         region,
+        serviceType,
       }),
       filters, // any additional dimension filters will be constructed and passed here
     },

--- a/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidgetRenderer.tsx
+++ b/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidgetRenderer.tsx
@@ -37,6 +37,10 @@ interface WidgetProps {
   manualRefreshTimeStamp?: number;
   metricDefinitions: ResourcePage<MetricDefinition> | undefined;
   preferences?: AclpConfig;
+  /**
+   * Selected region for the widget
+   */
+  region?: string;
   resourceList: CloudPulseResources[] | undefined;
   resources: string[];
   savePref?: boolean;
@@ -68,6 +72,7 @@ export const RenderWidgets = React.memo(
       savePref,
       groupBy,
       linodeRegion,
+      region,
     } = props;
 
     const getCloudPulseGraphProperties = (
@@ -176,6 +181,7 @@ export const RenderWidgets = React.memo(
                 availableMetrics={availMetrics}
                 isJweTokenFetching={isJweTokenFetching}
                 linodeRegion={linodeRegion}
+                region={region}
                 resources={resourceList!}
                 savePref={savePref}
               />

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseComponentRenderer.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseComponentRenderer.tsx
@@ -5,6 +5,7 @@ import NullComponent from 'src/components/NullComponent';
 
 import { CloudPulseCustomSelect } from './CloudPulseCustomSelect';
 import { CloudPulseDateTimeRangePicker } from './CloudPulseDateTimeRangePicker';
+import { CloudPulseEndpointsSelect } from './CloudPulseEndpointsSelect';
 import { CloudPulseNodeTypeFilter } from './CloudPulseNodeTypeFilter';
 import { CloudPulseRegionSelect } from './CloudPulseRegionSelect';
 import { CloudPulseResourcesSelect } from './CloudPulseResourcesSelect';
@@ -13,6 +14,7 @@ import { CloudPulseTextFilter } from './CloudPulseTextFilter';
 
 import type { CloudPulseCustomSelectProps } from './CloudPulseCustomSelect';
 import type { CloudPulseDateTimeRangePickerProps } from './CloudPulseDateTimeRangePicker';
+import type { CloudPulseEndpointsSelectProps } from './CloudPulseEndpointsSelect';
 import type { CloudPulseNodeTypeFilterProps } from './CloudPulseNodeTypeFilter';
 import type { CloudPulseRegionSelectProps } from './CloudPulseRegionSelect';
 import type { CloudPulseResourcesSelectProps } from './CloudPulseResourcesSelect';
@@ -24,6 +26,7 @@ export interface CloudPulseComponentRendererProps {
   componentProps:
     | CloudPulseCustomSelectProps
     | CloudPulseDateTimeRangePickerProps
+    | CloudPulseEndpointsSelectProps
     | CloudPulseNodeTypeFilterProps
     | CloudPulseRegionSelectProps
     | CloudPulseResourcesSelectProps
@@ -37,6 +40,7 @@ const Components: {
     React.ComponentType<
       | CloudPulseCustomSelectProps
       | CloudPulseDateTimeRangePickerProps
+      | CloudPulseEndpointsSelectProps
       | CloudPulseNodeTypeFilterProps
       | CloudPulseRegionSelectProps
       | CloudPulseResourcesSelectProps
@@ -54,6 +58,7 @@ const Components: {
   resource_id: CloudPulseResourcesSelect,
   tags: CloudPulseTagsSelect,
   associated_entity_region: CloudPulseRegionSelect,
+  endpoint: CloudPulseEndpointsSelect,
 };
 
 const buildComponent = (props: CloudPulseComponentRendererProps) => {

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardFilterBuilder.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardFilterBuilder.tsx
@@ -84,7 +84,7 @@ export interface CloudPulseDashboardFilterBuilderProps {
   /**
    * selected resource ids
    */
-  resource_ids?: (number | string)[];
+  resource_ids?: number[];
 }
 
 export const CloudPulseDashboardFilterBuilder = React.memo(
@@ -341,12 +341,12 @@ export const CloudPulseDashboardFilterBuilder = React.memo(
               config,
               dashboard,
               dependentFilters: resource_ids?.length
-                ? { [RESOURCE_ID]: resource_ids as number[] }
+                ? { [RESOURCE_ID]: resource_ids }
                 : dependentFilterReference.current,
               isServiceAnalyticsIntegration,
               preferences,
               resource_ids: resource_ids?.length
-                ? (resource_ids as number[])
+                ? resource_ids
                 : (
                     dependentFilterReference.current[RESOURCE_ID] as string[]
                   )?.map((id: string) => Number(id)),
@@ -387,7 +387,7 @@ export const CloudPulseDashboardFilterBuilder = React.memo(
               config,
               dashboard,
               dependentFilters: resource_ids?.length
-                ? { [RESOURCE_ID]: resource_ids as number[] }
+                ? { [RESOURCE_ID]: resource_ids }
                 : dependentFilterReference.current,
               isServiceAnalyticsIntegration,
               preferences,

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardFilterBuilder.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardFilterBuilder.tsx
@@ -10,6 +10,7 @@ import NullComponent from 'src/components/NullComponent';
 import RenderComponent from '../shared/CloudPulseComponentRenderer';
 import {
   DASHBOARD_ID,
+  ENDPOINT,
   INTERFACE_ID,
   LINODE_REGION,
   NODE_TYPE,
@@ -21,6 +22,7 @@ import {
 } from '../Utils/constants';
 import {
   getCustomSelectProperties,
+  getEndpointsProperties,
   getFilters,
   getNodeTypeProperties,
   getRegionProperties,
@@ -234,6 +236,7 @@ export const CloudPulseDashboardFilterBuilder = React.memo(
           filterKey === REGION
             ? {
                 [filterKey]: region,
+                [ENDPOINT]: undefined,
                 [RESOURCES]: undefined,
                 [TAGS]: undefined,
               }
@@ -247,6 +250,16 @@ export const CloudPulseDashboardFilterBuilder = React.memo(
           savePref,
           updatedPreferenceData
         );
+      },
+      [emitFilterChangeByFilterKey]
+    );
+
+    const handleEndpointsChange = React.useCallback(
+      (endpoints: string[], savePref: boolean = false) => {
+        emitFilterChangeByFilterKey(ENDPOINT, endpoints, endpoints, savePref, {
+          [ENDPOINT]: endpoints,
+          [RESOURCE_ID]: undefined,
+        });
       },
       [emitFilterChangeByFilterKey]
     );
@@ -356,6 +369,18 @@ export const CloudPulseDashboardFilterBuilder = React.memo(
             },
             handleTextFilterChange
           );
+        } else if (config.configuration.filterKey === ENDPOINT) {
+          return getEndpointsProperties(
+            {
+              config,
+              dashboard,
+              dependentFilters: dependentFilterReference.current,
+              isServiceAnalyticsIntegration,
+              preferences,
+              shouldDisable: isError || isLoading,
+            },
+            handleEndpointsChange
+          );
         } else {
           return getCustomSelectProperties(
             {
@@ -379,6 +404,7 @@ export const CloudPulseDashboardFilterBuilder = React.memo(
         handleRegionChange,
         handleTextFilterChange,
         handleResourceChange,
+        handleEndpointsChange,
         handleCustomSelectChange,
         isServiceAnalyticsIntegration,
         preferences,

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardFilterBuilder.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardFilterBuilder.tsx
@@ -82,7 +82,7 @@ export interface CloudPulseDashboardFilterBuilderProps {
   /**
    * selected resource ids
    */
-  resource_ids?: number[];
+  resource_ids?: (number | string)[];
 }
 
 export const CloudPulseDashboardFilterBuilder = React.memo(
@@ -328,12 +328,12 @@ export const CloudPulseDashboardFilterBuilder = React.memo(
               config,
               dashboard,
               dependentFilters: resource_ids?.length
-                ? { [RESOURCE_ID]: resource_ids }
+                ? { [RESOURCE_ID]: resource_ids as number[] }
                 : dependentFilterReference.current,
               isServiceAnalyticsIntegration,
               preferences,
               resource_ids: resource_ids?.length
-                ? resource_ids
+                ? (resource_ids as number[])
                 : (
                     dependentFilterReference.current[RESOURCE_ID] as string[]
                   )?.map((id: string) => Number(id)),
@@ -362,7 +362,7 @@ export const CloudPulseDashboardFilterBuilder = React.memo(
               config,
               dashboard,
               dependentFilters: resource_ids?.length
-                ? { [RESOURCE_ID]: resource_ids }
+                ? { [RESOURCE_ID]: resource_ids as number[] }
                 : dependentFilterReference.current,
               isServiceAnalyticsIntegration,
               preferences,

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/index.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/index.tsx
@@ -8,6 +8,7 @@ import { SafeTabPanel } from 'src/components/Tabs/SafeTabPanel';
 import { TabPanels } from 'src/components/Tabs/TabPanels';
 import { Tabs } from 'src/components/Tabs/Tabs';
 import { TanStackTabLinkList } from 'src/components/Tabs/TanStackTabLinkList';
+import { CloudPulseDashboardWithFilters } from 'src/features/CloudPulse/Dashboard/CloudPulseDashboardWithFilters';
 import { useIsObjectStorageGen2Enabled } from 'src/features/ObjectStorage/hooks/useIsObjectStorageGen2Enabled';
 import { useTabs } from 'src/hooks/useTabs';
 import { useObjectStorageBuckets } from 'src/queries/object-storage/queries';
@@ -55,6 +56,10 @@ export const BucketDetailLanding = React.memo(() => {
       title: 'SSL/TLS',
       to: `/object-storage/buckets/$clusterId/$bucketName/ssl`,
     },
+    {
+      title: 'Metrics',
+      to: `/object-storage/buckets/$clusterId/$bucketName/metrics`,
+    },
   ]);
 
   return (
@@ -94,6 +99,14 @@ export const BucketDetailLanding = React.memo(() => {
             </SafeTabPanel>
             <SafeTabPanel index={tabs.length - 1}>
               <BucketSSL bucketName={bucketName} clusterId={clusterId} />
+            </SafeTabPanel>
+            <SafeTabPanel index={tabs.length - 1}>
+              <CloudPulseDashboardWithFilters
+                dashboardId={6}
+                region={bucket?.region}
+                // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
+                resource={bucket?.hostname!}
+              />
             </SafeTabPanel>
           </TabPanels>
         </React.Suspense>

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -1340,6 +1340,11 @@ export const handlers = [
         region: 'us-mia',
         s3_endpoint: 'us-mia-1.linodeobjects.com',
       }),
+      objectStorageBucketFactoryGen2.build({
+        endpoint_type: 'E3',
+        region: 'ap-west',
+        s3_endpoint: 'ap-west-1.linodeobjects.com',
+      }),
     ];
     return HttpResponse.json(makeResourcePage(endpoints));
   }),
@@ -1448,6 +1453,18 @@ export const handlers = [
       label: `obj-bucket-${randomBucketNumber}`,
       region,
     });
+    if (region === 'ap-west') {
+      buckets.push(
+        objectStorageBucketFactoryGen2.build({
+          cluster: `${region}-1`,
+          endpoint_type: 'E3',
+          s3_endpoint: 'ap-west-1.linodeobjects.com',
+          hostname: `obj-bucket-${randomBucketNumber}.${region}.linodeobjects.com`,
+          label: `obj-bucket-${randomBucketNumber}`,
+          region,
+        })
+      );
+    }
 
     return HttpResponse.json({
       data: buckets.slice(
@@ -3048,6 +3065,12 @@ export const handlers = [
           regions: 'us-iad,us-east',
           alert: serviceAlertFactory.build({ scope: ['entity'] }),
         }),
+        serviceTypesFactory.build({
+          label: 'Object Storage',
+          service_type: 'objectstorage',
+          regions: 'us-iad,us-east',
+          alert: serviceAlertFactory.build({ scope: ['entity'] }),
+        }),
       ],
     };
 
@@ -3132,6 +3155,16 @@ export const handlers = [
           id: 4,
           label: 'Firewall Dashboard',
           service_type: 'firewall',
+        })
+      );
+    }
+
+    if (params.serviceType === 'objectstorage') {
+      response.data.push(
+        dashboardFactory.build({
+          id: 6,
+          label: 'Object Storage Dashboard',
+          service_type: 'objectstorage',
         })
       );
     }
@@ -3422,6 +3455,9 @@ export const handlers = [
     } else if (id === '4') {
       serviceType = 'firewall';
       dashboardLabel = 'Firewall Service I/O Statistics';
+    } else if (id === '6') {
+      serviceType = 'objectstorage';
+      dashboardLabel = 'Object Storage Service I/O Statistics';
     } else {
       serviceType = 'linode';
       dashboardLabel = 'Linode Service I/O Statistics';

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -3598,9 +3598,8 @@ export const handlers = [
           },
           {
             metric: {
-              entity_id: '789',
+              entity_id: 'obj-bucket-383.ap-west.linodeobjects.com',
               metric_name: 'average_cpu_usage',
-              node_id: 'primary-3',
             },
             values: [
               [1721854379, '0.3744841110560275'],

--- a/packages/manager/src/queries/cloudpulse/queries.ts
+++ b/packages/manager/src/queries/cloudpulse/queries.ts
@@ -153,15 +153,17 @@ export const queryFactory = createQueryKeys(key, {
 
 const getAllBuckets = async () => {
   const endpoints = await getAllObjectStorageEndpoints();
-  // Filter out the endpoints that are not GEN2
-  const endpointsGen2 = endpoints.filter(
-    (endpoint) =>
-      endpoint.endpoint_type !== 'E0' && endpoint.endpoint_type !== 'E1'
-  );
+
   // Get all the buckets from the endpoints
-  const allBuckets = await getAllBucketsFromEndpoints(endpointsGen2);
+  const allBuckets = await getAllBucketsFromEndpoints(endpoints);
+
+  // Throw the error if we encounter any error for any single call.
   if (allBuckets.errors.length) {
     throw new Error('Unable to fetch the data.');
   }
-  return allBuckets.buckets;
+
+  // Filter the E0, E1 endpoint_type out and return the buckets
+  return allBuckets.buckets.filter(
+    (bucket) => bucket.endpoint_type !== 'E0' && bucket.endpoint_type !== 'E1'
+  );
 };

--- a/packages/manager/src/queries/cloudpulse/queries.ts
+++ b/packages/manager/src/queries/cloudpulse/queries.ts
@@ -16,6 +16,11 @@ import {
 } from '@linode/queries';
 import { createQueryKeys } from '@lukemorales/query-key-factory';
 
+import { objectStorageQueries } from '../object-storage/queries';
+import {
+  getAllBucketsFromEndpoints,
+  getAllObjectStorageEndpoints,
+} from '../object-storage/requests';
 import { fetchCloudPulseMetrics } from './metrics';
 import {
   getAllAlertsRequest,
@@ -124,6 +129,14 @@ export const queryFactory = createQueryKeys(key, {
 
       case 'nodebalancer':
         return nodebalancerQueries.nodebalancers._ctx.all(params, filters);
+      case 'objectstorage':
+        return {
+          queryFn: () => getAllBuckets(),
+          queryKey: [
+            objectStorageQueries.buckets.queryKey,
+            objectStorageQueries.endpoints.queryKey,
+          ],
+        };
       case 'volumes':
         return volumeQueries.lists._ctx.all(params, filters); // in this we don't need to define our own query factory, we will reuse existing implementation in volumes.ts
 
@@ -134,6 +147,21 @@ export const queryFactory = createQueryKeys(key, {
 
   token: (serviceType: string | undefined, request: JWETokenPayLoad) => ({
     queryFn: () => getJWEToken(request, serviceType!),
-    queryKey: [serviceType, { resource_ids: request.entity_ids.sort() }],
+    queryKey: [serviceType, { resource_ids: request.entity_ids?.sort() }],
   }),
 });
+
+const getAllBuckets = async () => {
+  const endpoints = await getAllObjectStorageEndpoints();
+  // Filter out the endpoints that are not GEN2
+  const endpointsGen2 = endpoints.filter(
+    (endpoint) =>
+      endpoint.endpoint_type !== 'E0' && endpoint.endpoint_type !== 'E1'
+  );
+  // Get all the buckets from the endpoints
+  const allBuckets = await getAllBucketsFromEndpoints(endpointsGen2);
+  if (allBuckets.errors.length) {
+    throw new Error('Unable to fetch the data.');
+  }
+  return allBuckets.buckets;
+};

--- a/packages/manager/src/queries/cloudpulse/resources.ts
+++ b/packages/manager/src/queries/cloudpulse/resources.ts
@@ -38,12 +38,10 @@ export const useResourcesQuery = (
           resourceType === 'objectstorage'
             ? resource.hostname
             : String(resource.id);
-        const label =
-          resourceType === 'objectstorage' ? resource.hostname : resource.label;
         return {
           engineType: resource.engine,
           id,
-          label,
+          label: resourceType === 'objectstorage' ? id : resource.label,
           region: resource.region,
           regions: resource.regions ? resource.regions : [],
           tags: resource.tags,

--- a/packages/manager/src/queries/cloudpulse/resources.ts
+++ b/packages/manager/src/queries/cloudpulse/resources.ts
@@ -14,7 +14,8 @@ export const useResourcesQuery = (
   useQuery<any[], unknown, CloudPulseResources[]>({
     ...queryFactory.resources(resourceType, params, filters),
     enabled,
-    select: (resources) => {
+    retry: resourceType === 'objectstorage' ? false : 3,
+    select: (resources: any[]) => {
       return resources.map((resource) => {
         const entities: Record<string, string> = {};
 
@@ -33,13 +34,20 @@ export const useResourcesQuery = (
             }
           });
         }
+        const id =
+          resourceType === 'objectstorage'
+            ? resource.hostname
+            : String(resource.id);
+        const label =
+          resourceType === 'objectstorage' ? resource.hostname : resource.label;
         return {
           engineType: resource.engine,
-          id: String(resource.id),
-          label: resource.label,
+          id,
+          label,
           region: resource.region,
           regions: resource.regions ? resource.regions : [],
           tags: resource.tags,
+          endpoint: resource.s3_endpoint,
           entities,
           clusterSize: resource.cluster_size,
         };

--- a/packages/manager/src/routes/objectStorage/index.ts
+++ b/packages/manager/src/routes/objectStorage/index.ts
@@ -89,6 +89,15 @@ const objectStorageBucketDetailAccessRoute = createRoute({
   ).then((m) => m.bucketDetailLandingLazyRoute)
 );
 
+const objectStorageBucketMetricsRoute = createRoute({
+  getParentRoute: () => objectStorageBucketDetailRoute,
+  path: 'metrics',
+}).lazy(() =>
+  import(
+    'src/features/ObjectStorage/BucketDetail/bucketDetailLandingLazyRoute'
+  ).then((m) => m.bucketDetailLandingLazyRoute)
+);
+
 const objectStorageBucketSSLRoute = createRoute({
   getParentRoute: () => objectStorageBucketDetailRoute,
   path: 'ssl',
@@ -108,5 +117,6 @@ export const objectStorageRouteTree = objectStorageRoute.addChildren([
     objectStorageBucketDetailObjectsRoute,
     objectStorageBucketDetailAccessRoute,
     objectStorageBucketSSLRoute,
+    objectStorageBucketMetricsRoute,
   ]),
 ]);

--- a/packages/utilities/src/__data__/regionsData.ts
+++ b/packages/utilities/src/__data__/regionsData.ts
@@ -13,6 +13,7 @@ export const regions: Region[] = [
       'VPCs',
       'Block Storage Migrations',
       'Managed Databases',
+      'Object Storage'
     ],
     country: 'in',
     id: 'ap-west',
@@ -27,7 +28,7 @@ export const regions: Region[] = [
     },
     site_type: 'core',
     status: 'ok',
-    monitors: { alerts: ['Cloud Firewall'], metrics: [] },
+    monitors: { alerts: ['Cloud Firewall'], metrics: ['Object Storage'] },
   },
   {
     capabilities: [

--- a/packages/utilities/src/__data__/regionsData.ts
+++ b/packages/utilities/src/__data__/regionsData.ts
@@ -13,7 +13,7 @@ export const regions: Region[] = [
       'VPCs',
       'Block Storage Migrations',
       'Managed Databases',
-      'Object Storage'
+      'Object Storage',
     ],
     country: 'in',
     id: 'ap-west',


### PR DESCRIPTION
## Description 📝

Handle integration of Object Storage in Metrics.

## Changes  🔄

- Update`types.ts` according to new service requirements.
- Update reusable component `CloudPulseDashboardWithFilters.tsx` - Add optional prop `region` as it is required for /metrics payload. Update `resource` (id) type.
- Update `CloudPulseWidgetUtils.tsx` to handle special conditions for new service.
- Update filterConfig at `filterConfig.ts` - Add `objectstorage` service filters.
- Add test cases, update queries, update mocks.

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️
1st October 2025

## Preview 📷

https://github.com/user-attachments/assets/8521b9b8-a4dd-4577-b2f8-059f95fa4f2a

Preferences

https://github.com/user-attachments/assets/2462908b-9a01-43a4-a5cb-b5fe679f894b

/Metrics Request Payload

<img width="1298" height="322" alt="image" src="https://github.com/user-attachments/assets/325c56dd-5e71-4e4f-8430-d92e559c7aa9" />

## How to test 🧪

### Verification steps

(How to verify changes)

- [ ] ...
- [ ] ...

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
-->