### PR TITLE
fix: Update LKE-E cluster Upgrade Version modal copy to mention update strategy

### DIFF
--- a/packages/manager/.changeset/pr-12922-fixed-1758907285299.md
+++ b/packages/manager/.changeset/pr-12922-fixed-1758907285299.md
@@ -2,4 +2,4 @@
 "@linode/manager": Fixed
 ---
 
-Missing mention of worker node update strategy in Upgrade Version modal copy for LKE-E clusters ([#12922](https://github.com/linode/manager/pull/12922))
+Inaccurate Upgrade Version modal copy for LKE-E clusters and overly verbose modal title ([#12922](https://github.com/linode/manager/pull/12922))

--- a/packages/manager/.changeset/pr-12922-fixed-1758907285299.md
+++ b/packages/manager/.changeset/pr-12922-fixed-1758907285299.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Missing mention of worker node update strategy in Upgrade Version modal copy for LKE-E clusters ([#12922](https://github.com/linode/manager/pull/12922))

--- a/packages/manager/cypress/e2e/core/account/restricted-user-details-pages.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/restricted-user-details-pages.spec.ts
@@ -462,9 +462,7 @@ describe('restricted user details pages', () => {
       .click();
 
     ui.dialog
-      .findByTitle(
-        `Upgrade Kubernetes version to ${newVersion} on ${mockCluster.label}?`
-      )
+      .findByTitle(`Upgrade Cluster ${mockCluster.label} to ${newVersion}`)
       .should('be.visible')
       .within(() => {
         upgradeNotes.forEach((note: string) => {

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-landing-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-landing-page.spec.ts
@@ -278,9 +278,7 @@ describe('LKE landing page', () => {
     cy.wait(['@getCluster']);
 
     ui.dialog
-      .findByTitle(
-        `Upgrade Kubernetes version to ${newVersion} on ${cluster.label}?`
-      )
+      .findByTitle(`Upgrade Cluster ${cluster.label} to ${newVersion}`)
       .should('be.visible');
 
     mockGetClusters([updatedCluster]).as('getClusters');
@@ -353,9 +351,7 @@ describe('LKE landing page', () => {
     cy.wait(['@getCluster']);
 
     ui.dialog
-      .findByTitle(
-        `Upgrade Kubernetes version to ${newVersion} on ${cluster.label}?`
-      )
+      .findByTitle(`Upgrade Cluster ${cluster.label} to ${newVersion}`)
       .should('be.visible');
 
     mockGetClusters([updatedCluster]).as('getClusters');

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
@@ -298,7 +298,7 @@ describe('LKE cluster updates', () => {
 
       const upgradeNotes = [
         'This upgrades the control plane on your cluster',
-        'Worker nodes within each node pool can then be upgraded separately.',
+        'Existing worker nodes are updated automatically or manually, depending on the update strategy defined for each node pool.',
         // Confirm that the old version and new version are both shown.
         oldVersion,
         newVersion,

--- a/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-update.spec.ts
@@ -192,9 +192,7 @@ describe('LKE cluster updates', () => {
         .click();
 
       ui.dialog
-        .findByTitle(
-          `Upgrade Kubernetes version to ${newVersion} on ${mockCluster.label}?`
-        )
+        .findByTitle(`Upgrade Cluster ${mockCluster.label} to ${newVersion}`)
         .should('be.visible')
         .within(() => {
           upgradeNotes.forEach((note: string) => {
@@ -332,9 +330,7 @@ describe('LKE cluster updates', () => {
         .click();
 
       ui.dialog
-        .findByTitle(
-          `Upgrade Kubernetes version to ${newVersion} on ${mockCluster.label}?`
-        )
+        .findByTitle(`Upgrade Cluster ${mockCluster.label} to ${newVersion}`)
         .should('be.visible')
         .within(() => {
           upgradeNotes.forEach((note: string) => {

--- a/packages/manager/src/features/Kubernetes/UpgradeVersionModal.tsx
+++ b/packages/manager/src/features/Kubernetes/UpgradeVersionModal.tsx
@@ -126,9 +126,7 @@ export const UpgradeDialog = (props: Props) => {
 
   const dialogTitle = shouldShowRecycleNodesStep
     ? 'Upgrade complete'
-    : `Upgrade Kubernetes version ${
-        nextVersion ? `to ${nextVersion}` : ''
-      } on ${cluster?.label}?`;
+    : `Upgrade ${cluster?.label} to ${nextVersion}`;
 
   const actions = (
     <ActionsPanel

--- a/packages/manager/src/features/Kubernetes/UpgradeVersionModal.tsx
+++ b/packages/manager/src/features/Kubernetes/UpgradeVersionModal.tsx
@@ -35,7 +35,8 @@ const getWorkerNodeCopy = (clusterTier: KubernetesTier = 'standard') => {
     </span>
   ) : (
     <span>
-      . Worker nodes within each node pool can then be upgraded separately.{' '}
+      . Existing worker nodes are updated automatically or manually, depending
+      on the update strategy defined for each node pool.{' '}
       <Link to="https://techdocs.akamai.com/cloud-computing/docs/upgrade-an-lke-enterprise-cluster-to-a-newer-kubernetes-version">
         Learn more
       </Link>

--- a/packages/manager/src/features/Kubernetes/UpgradeVersionModal.tsx
+++ b/packages/manager/src/features/Kubernetes/UpgradeVersionModal.tsx
@@ -126,7 +126,7 @@ export const UpgradeDialog = (props: Props) => {
 
   const dialogTitle = shouldShowRecycleNodesStep
     ? 'Upgrade complete'
-    : `Upgrade ${cluster?.label} to ${nextVersion}`;
+    : `Upgrade Cluster ${cluster?.label} to ${nextVersion}`;
 
   const actions = (
     <ActionsPanel


### PR DESCRIPTION
## Description 📝

This PR updates the upgrade version modal so that the UX copy more accurately reflects the behavior based on the  update strategy. Since the version upgrade is at the cluster level, while the update strategies are at the node pool level, we worked with Tech Writing to use one sentence that is applicable in all cases.

## Changes  🔄
- Updates the line of copy in the UpgradeVersionModal that references worker nodes updates for LKE-E clusters
- Updates the title (from Tech Writing: Reframes the modal as an action instead of a question. Also, this removes the word Kubernetes, since it’ll also be mentioned in the description and doing so shortens the title to the most important details.)
- Updates test coverage

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [x] All customers - the title change also applies to standard clusters
- [x] Some customers (e.g. in Beta or Limited Availability) - the body change for all current LKE-E customers
- [ ] No customers / Not applicable

## Target release date 🗓️

10/7

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <img width="643" height="266" alt="image" src="https://github.com/user-attachments/assets/a0cba57a-68ca-4717-b97f-54a46ace5fdc" /> | LKE-Enterprise (one-step modal): ![Screenshot 2025-09-26 at 11 54 32 AM](https://github.com/user-attachments/assets/e2a6fbeb-da1e-4c4b-bf17-2f2432f9e7b8) LKE Standard (two-step modal): ![Screenshot 2025-09-26 at 11 55 34 AM](https://github.com/user-attachments/assets/0b5eadfa-ea6d-4b06-9cf0-2a7f38cc6f30)![Screenshot 2025-09-26 at 11 55 41 AM](https://github.com/user-attachments/assets/6d7e2883-05b1-4fed-a2f2-d0290e880fd6)


## How to test 🧪

### Prerequisites

(How to setup test environment)

-  Have the LKE-E customer tag on your account and at least the LKE Enterprise `la` flag enabled locally
- Either have an old LKE-E cluster on your account or **use the MSW in CRUD mode** to create an LKE-E cluster *with an older version* (e.g. `v1.31.6+lke3`)
   - (There is technically a way to create LKE-E clusters in prod with older versions too, if you don't want to mock this, but you'll need a customer tag. See project tracker.)

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] On another branch, go to the LKE-E cluster's details page or the UPGRADE chip on the landing page to open the Upgrade Version modal. 
- [ ] Observe the current copy.
- [ ] Confirm `lke-update.spec.ts` and all other LKE tests still pass.

### Verification steps

(How to verify changes)

- [ ] Check out this branch and repeat the same steps to open the LKE-E cluster's Upgrade Version modal.
- [ ] Observe the new copy.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>