### PR TITLE
fix: [UIE-9289] - Use abs value for Assign User Autocomplete next fetch

### DIFF
--- a/packages/manager/src/features/IAM/Roles/RolesTable/AssignSelectedRolesDrawer.tsx
+++ b/packages/manager/src/features/IAM/Roles/RolesTable/AssignSelectedRolesDrawer.tsx
@@ -143,11 +143,14 @@ export const AssignSelectedRolesDrawer = ({
 
   const handleScroll = (event: React.SyntheticEvent) => {
     const listboxNode = event.currentTarget;
-    if (
-      listboxNode.scrollTop + listboxNode.clientHeight >=
-        listboxNode.scrollHeight &&
-      hasNextPage
-    ) {
+    const isAtBottom =
+      Math.abs(
+        listboxNode.scrollHeight -
+          listboxNode.clientHeight -
+          listboxNode.scrollTop
+      ) < 1;
+
+    if (isAtBottom && hasNextPage) {
       fetchNextPage();
     }
   };


### PR DESCRIPTION
## Description 📝
This PR fixes a small issue (a bit hard to reproduce) where we don't get the next paginated data while scrolling down the Assign User Autocomplete in the `AssignSelectedRolesDrawer` component.

This is due to floating-point precision issues where height calculations are off by less than a pixel.

> [!IMPORTANT]
> This is yet another issue stemming from not having the ability to do API filtering and finding client-side workarounds

## Changes  🔄
- Add 1px tolerance to height comparison logic

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [x] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Preview 📷

| Failed  | Succeeded   |
| ------- | ------- |
| <img width="3204" height="1874" alt="image-2025-09-29-10-55-28-306" src="https://github.com/user-attachments/assets/56eeeeeb-7786-4958-a24a-665e1608742c" /> | ![Uploading image-2025-09-29-10-59-49-839.png…]() |

## How to test 🧪
Navigate to `/iam/roles` with an account with many users

### Reproduction steps
- on Develop, try reproducing the above issue by having the dev tools open at various heights

### Verification steps
- on this branch, confirm bug above is fixed

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support
</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules