### PR TITLE
fix: [UIE-9294] - DBaaS - Database Create Subnet field should display backend error messages

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2025-09-30] - v1.151.2
+
+### Fixed:
+
+- DBaaS - Database Create Subnet field should display backend error messages
+
 ## [2025-09-25] - v1.151.1
 
 ### Added:

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.151.1",
+  "version": "1.151.2",
   "private": true,
   "type": "module",
   "bugs": {

--- a/packages/manager/src/utilities/formikErrorUtils.test.ts
+++ b/packages/manager/src/utilities/formikErrorUtils.test.ts
@@ -17,11 +17,33 @@ const setFieldError = vi.fn();
 const setError = vi.fn();
 
 describe('handleAPIErrors', () => {
-  it('should handle api error with a field', () => {
+  it('should handle api error with a regular field', () => {
+    const errorWithFlatField = [{ field: 'label', reason: 'Invalid label' }];
+    handleAPIErrors(errorWithFlatField, setFieldError, setError);
+    expect(setFieldError).toHaveBeenCalledWith(
+      'label',
+      errorWithFlatField[0].reason
+    );
+    expect(setError).not.toHaveBeenCalled();
+  });
+
+  it('should handle api error with a parent field', () => {
     handleAPIErrors(errorWithField, setFieldError, setError);
     expect(setFieldError).toHaveBeenCalledWith(
       'card_number',
       errorWithField[0].reason
+    );
+    expect(setError).not.toHaveBeenCalled();
+  });
+
+  it('should handle api error with a parent field that needs to provide the full parent-child key', () => {
+    const errorWithParentField = [
+      { field: 'private_network.subnet_id', reason: 'Invalid subnet ID' },
+    ];
+    handleAPIErrors(errorWithParentField, setFieldError, setError);
+    expect(setFieldError).toHaveBeenCalledWith(
+      'private_network.subnet_id',
+      errorWithParentField[0].reason
     );
     expect(setError).not.toHaveBeenCalled();
   });

--- a/packages/manager/src/utilities/formikErrorUtils.ts
+++ b/packages/manager/src/utilities/formikErrorUtils.ts
@@ -122,6 +122,17 @@ export const handleGeneralErrors = (
   }
 };
 
+/**
+ * This function checks if the field from the APIError object is included
+ * in the list of parent fields that need to provide the full key that includes the child field.
+ * It returns true if that parent field is in the list.
+ */
+const shouldProvideFullKey = (error: APIError): boolean => {
+  const key = error.field?.split('.')[0];
+  const parentFields = ['private_network'];
+  return parentFields.includes(key ?? '') ? true : false;
+};
+
 export const handleAPIErrors = (
   errors: APIError[],
   setFieldError: (field: string, message: string) => void,
@@ -133,8 +144,12 @@ export const handleAPIErrors = (
        * The line below gets the field name because the API returns something like this...
        * {"errors": [{"reason": "Invalid credit card number", "field": "data.card_number"}]}
        * It takes 'data.card_number' and translates it to 'card_number'
+       * This will return the full field key for certain parent fields. See the shouldProvideFullKey function above.
        */
-      const key = error.field.split('.')[error.field.split('.').length - 1];
+      const key = shouldProvideFullKey(error)
+        ? error.field
+        : error.field.split('.')[error.field.split('.').length - 1];
+
       if (key) {
         setFieldError(key, error.reason);
       }


### PR DESCRIPTION


## Description 📝

When the backend returns an error for the Subnet field in Database Create, the error does not appear in the UI. This Subnet field should display any error messages provided from the backend response.

## Changes  🔄

List any change(s) relevant to the reviewer.

- Updates the formikErrorUtils `handleAPIErrors` function to provide the full parent-child key for certain fields.
- Hotfix updates the package.json and changelog

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [x] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

9/30/2025

## Preview 📷

**Include a screenshot `<img src="" />` or video `<video src="" />` of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: For changes requiring multiple steps to validate, prefer a video for clarity.

| Before  | After   |
| ------- | ------- |
| ![BEFORE-DBaaS-Create-Subnet](https://github.com/user-attachments/assets/bde54053-4542-419c-9384-c93ee3a7f816) | ![AFTER-DBaaS-Create-Subnet](https://github.com/user-attachments/assets/61443706-a726-4fe3-8ec6-8df2f3580471) |

## How to test 🧪

### Prerequisites

(How to setup test environment)
**NOTE:** Changes have been made to the behavior in the environments. So this will have to be tested with mock data.
- Have the `databaseVpc` flag enabled
- Have access to the databases tab and DatabaseCreate
- We'll need to simulate the error with the mock data, so In the database instance creation request on [line 379 of the serverHandler.ts](https://github.com/linode/manager/blob/develop/packages/manager/src/mocks/serverHandlers.ts#L378), update the return value to:
``` javascript
return HttpResponse.json(
      {
        errors: [
          {
            reason: 'Dual-stack subnets are not supported',
            field: 'private_network.subnet_id',
          },
        ],
      },
      { status: 403 }
    );
```

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] Make sure the mock data is active.
- [ ] Navigate to the Databases tab and select the `Create Database cluster button` to navigate to the DatabaseCreate view
- [ ] Open the networking tab in dev tools to observe the response
- [ ] Fill out all fields including VPC and Subnet
- [ ] Select `Create Database Cluster`
- [ ] Observe that, even though the backend database instance POST request responds with an error, no error message is displayed on the UI

### Verification steps

(How to verify changes)

- [ ] ...
- [ ] ...

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

-->