### PR TITLE
fix: [UIE-9286] - User Menu: Hide IAM Beta badge for LA

### DIFF
--- a/packages/manager/.changeset/pr-12933-fixed-1759235571094.md
+++ b/packages/manager/.changeset/pr-12933-fixed-1759235571094.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+IAM: Hide IAM Beta badge in User Menu for LA ([#12933](https://github.com/linode/manager/pull/12933))

--- a/packages/manager/src/features/TopMenu/UserMenu/UserMenuPopover.tsx
+++ b/packages/manager/src/features/TopMenu/UserMenu/UserMenuPopover.tsx
@@ -40,7 +40,7 @@ export const UserMenuPopover = (props: UserMenuPopoverProps) => {
 
   const { data: account } = useAccount();
   const { data: profile } = useProfile();
-  const { isIAMEnabled } = useIsIAMEnabled();
+  const { isIAMEnabled, isIAMBeta } = useIsIAMEnabled();
 
   const isChildAccountAccessRestricted = useRestrictedGlobalGrantCheck({
     globalGrantType: 'child_account_access',
@@ -114,7 +114,7 @@ export const UserMenuPopover = (props: UserMenuPopoverProps) => {
             : iamRbacPrimaryNavChanges && !isIAMEnabled
               ? '/users'
               : '/account/users',
-        isBeta: iamRbacPrimaryNavChanges && isIAMEnabled,
+        isBeta: iamRbacPrimaryNavChanges && isIAMBeta,
       },
       {
         display: 'Quotas',


### PR DESCRIPTION
## Description 📝

User Menu: Hide IAM Beta badge for LA.

## Changes  🔄

List any change(s) relevant to the reviewer.

- hide IAM Beta badge for LA.

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [x] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

October 7th

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-09-30 at 2 29 25 PM](https://github.com/user-attachments/assets/7907fc96-a4b6-4534-b4da-cbd6da42fb50) | ![Screenshot 2025-09-30 at 2 29 02 PM](https://github.com/user-attachments/assets/2f7ca002-594b-4724-b50a-e49ced331543) |

## How to test 🧪

### Prerequisites

(How to setup test environment)

Use IAM account.

### Verification steps

(How to verify changes)

- [ ] Enable LA in DevTools (iam.enabled = ON, iam.beta = OFF)
- [ ] Click User Menu.
- [ ] Verify that Beta badge is not visible in Identity & Access.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>