### PR TITLE
fix: [UIE-9266], [UIE-9268], [UIE-9299] - IAM RBAC: Fix permission checks for subnet actions in VPC, fetch permissions only when drawer is open

### DIFF
--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetActionMenu.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetActionMenu.test.tsx
@@ -13,6 +13,7 @@ const queryMocks = vi.hoisted(() => ({
       update_linode: true,
       delete_linode: true,
       update_vpc: true,
+      delete_vpc: true,
     },
   })),
   useQueryWithPermissions: vi.fn().mockReturnValue({
@@ -133,6 +134,7 @@ describe('SubnetActionMenu', () => {
         update_linode: false,
         delete_linode: false,
         update_vpc: false,
+        delete_vpc: false,
       },
     });
     const view = renderWithTheme(<SubnetActionMenu {...props} />);
@@ -149,6 +151,7 @@ describe('SubnetActionMenu', () => {
         update_linode: true,
         delete_linode: false,
         update_vpc: true,
+        delete_vpc: false,
       },
     });
     const view = renderWithTheme(<SubnetActionMenu {...props} />);
@@ -165,6 +168,7 @@ describe('SubnetActionMenu', () => {
         update_linode: false,
         delete_linode: false,
         update_vpc: false,
+        delete_vpc: false,
       },
     });
     const view = renderWithTheme(<SubnetActionMenu {...props} />);
@@ -181,6 +185,7 @@ describe('SubnetActionMenu', () => {
         update_linode: false,
         delete_linode: false,
         update_vpc: true,
+        delete_vpc: false,
       },
     });
     const view = renderWithTheme(<SubnetActionMenu {...props} />);

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetActionMenu.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetActionMenu.tsx
@@ -35,8 +35,13 @@ export const SubnetActionMenu = (props: Props) => {
 
   const flags = useIsNodebalancerVPCEnabled();
 
-  const { data: permissions } = usePermissions('vpc', ['update_vpc'], vpcId);
+  const { data: permissions } = usePermissions(
+    'vpc',
+    ['update_vpc', 'delete_vpc'],
+    vpcId
+  );
   const canUpdateVPC = permissions?.update_vpc;
+  const canDeleteVPC = permissions?.delete_vpc;
 
   const actions: Action[] = [
     {
@@ -72,7 +77,7 @@ export const SubnetActionMenu = (props: Props) => {
     },
     {
       // TODO: change to 'delete_vpc_subnet' once it's available
-      disabled: numLinodes !== 0 || numNodebalancers !== 0 || !canUpdateVPC,
+      disabled: numLinodes !== 0 || numNodebalancers !== 0 || !canDeleteVPC,
       onClick: () => {
         handleDelete(subnet);
       },
@@ -80,7 +85,7 @@ export const SubnetActionMenu = (props: Props) => {
       tooltip:
         numLinodes > 0 || numNodebalancers > 0
           ? `${flags.isNodebalancerVPCEnabled ? 'Resources' : 'Linodes'} assigned to a subnet must be unassigned before the subnet can be deleted.`
-          : !canUpdateVPC
+          : !canDeleteVPC
             ? 'You do not have permission to delete this subnet.'
             : undefined,
     },

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeActionMenu.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeActionMenu.tsx
@@ -22,7 +22,6 @@ interface Props extends SubnetLinodeActionHandlers {
   linode: Linode;
   showPowerButton: boolean;
   subnet: Subnet;
-  vpcId?: number;
 }
 
 export const SubnetLinodeActionMenu = (props: Props) => {
@@ -34,10 +33,8 @@ export const SubnetLinodeActionMenu = (props: Props) => {
     subnet,
     linode,
     showPowerButton,
-    vpcId,
   } = props;
 
-  const { data: permissions } = usePermissions('vpc', ['update_vpc'], vpcId);
   // TODO: change 'delete_linode' to 'delete_linode_config_profile_interface' once it's available
   const { data: linodePermissions } = usePermissions(
     'linode',
@@ -52,8 +49,8 @@ export const SubnetLinodeActionMenu = (props: Props) => {
         handlePowerActionsLinode(linode, 'Reboot', subnet);
       },
       title: 'Reboot',
-      disabled: !(linodePermissions?.reboot_linode && permissions?.update_vpc),
-      tooltip: !(linodePermissions?.reboot_linode && permissions?.update_vpc)
+      disabled: !linodePermissions?.reboot_linode,
+      tooltip: !linodePermissions?.reboot_linode
         ? 'You do not have permission to reboot this Linode.'
         : undefined,
     });
@@ -69,11 +66,11 @@ export const SubnetLinodeActionMenu = (props: Props) => {
         );
       },
       disabled: isOffline
-        ? !(linodePermissions?.boot_linode && permissions?.update_vpc)
-        : !(linodePermissions?.shutdown_linode && permissions?.update_vpc),
-      tooltip: !(linodePermissions?.boot_linode && permissions?.update_vpc)
+        ? !linodePermissions?.boot_linode
+        : !linodePermissions?.shutdown_linode,
+      tooltip: !linodePermissions?.boot_linode
         ? 'You do not have permission to power on this Linode.'
-        : !(linodePermissions?.shutdown_linode && permissions?.update_vpc)
+        : !linodePermissions?.shutdown_linode
           ? 'You do not have permission to power off this Linode.'
           : undefined,
       title: isOffline ? 'Power On' : 'Power Off',
@@ -85,8 +82,8 @@ export const SubnetLinodeActionMenu = (props: Props) => {
       handleUnassignLinode(linode, subnet);
     },
     title: 'Unassign Linode',
-    disabled: !(linodePermissions?.delete_linode && permissions?.update_vpc),
-    tooltip: !(linodePermissions?.delete_linode && permissions?.update_vpc)
+    disabled: !linodePermissions?.delete_linode,
+    tooltip: !linodePermissions?.delete_linode
       ? 'You do not have permission to unassign this Linode.'
       : undefined,
   });

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.test.tsx
@@ -103,7 +103,6 @@ describe('SubnetLinodeRow', () => {
           subnet={subnetFactory.build()}
           subnetId={0}
           subnetInterfaces={[{ active: true, config_id: 1, id: 1 }]}
-          vpcId={1}
         />
       )
     );
@@ -136,7 +135,6 @@ describe('SubnetLinodeRow', () => {
             subnet={subnetFactory1}
             subnetId={1}
             subnetInterfaces={[{ active: true, config_id: config.id, id: 1 }]}
-            vpcId={1}
           />,
           { flags: { vpcIpv6: false } }
         )
@@ -194,7 +192,6 @@ describe('SubnetLinodeRow', () => {
           subnet={subnetFactory.build()}
           subnetId={1}
           subnetInterfaces={[{ active: true, config_id: null, id: 1 }]}
-          vpcId={1}
         />
       )
     );
@@ -241,7 +238,6 @@ describe('SubnetLinodeRow', () => {
           subnet={subnetFactory1}
           subnetId={1}
           subnetInterfaces={[{ active: true, config_id: config.id, id: 1 }]}
-          vpcId={1}
         />,
         {
           flags: { vpcIpv6: true },
@@ -285,7 +281,6 @@ describe('SubnetLinodeRow', () => {
           subnetInterfaces={[
             { active: true, config_id: null, id: vpcLinodeInterface.id },
           ]}
-          vpcId={1}
         />,
         {
           flags: { vpcIpv6: true },
@@ -329,7 +324,6 @@ describe('SubnetLinodeRow', () => {
           subnetInterfaces={[
             { active: true, config_id: config.id, id: vpcInterface.id },
           ]}
-          vpcId={1}
         />
       )
     );
@@ -387,7 +381,6 @@ describe('SubnetLinodeRow', () => {
           subnet={subnet}
           subnetId={subnet.id}
           subnetInterfaces={[{ active: true, config_id: 1, id: 1 }]}
-          vpcId={1}
         />
       )
     );
@@ -416,7 +409,6 @@ describe('SubnetLinodeRow', () => {
           subnet={subnet}
           subnetId={subnet.id}
           subnetInterfaces={[{ active: true, config_id: 1, id: 1 }]}
-          vpcId={1}
         />
       )
     );

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetLinodeRow.tsx
@@ -56,7 +56,6 @@ interface Props {
   subnet: Subnet;
   subnetId: number;
   subnetInterfaces: SubnetLinodeInterfaceData[];
-  vpcId: number;
 }
 
 export const SubnetLinodeRow = (props: Props) => {
@@ -69,7 +68,6 @@ export const SubnetLinodeRow = (props: Props) => {
     subnet,
     subnetId,
     subnetInterfaces,
-    vpcId,
   } = props;
 
   const { isDualStackEnabled } = useVPCDualStack();
@@ -276,7 +274,6 @@ export const SubnetLinodeRow = (props: Props) => {
           linode={linode}
           showPowerButton={showPowerButton}
           subnet={subnet}
-          vpcId={vpcId}
         />
       </TableCell>
     </TableRow>

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetUnassignLinodesDrawer.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetUnassignLinodesDrawer.tsx
@@ -126,7 +126,8 @@ export const SubnetUnassignLinodesDrawer = React.memo(
     const { data: filteredLinodes } = useQueryWithPermissions(
       useAllLinodesQuery(),
       'linode',
-      ['delete_linode']
+      ['delete_linode'],
+      open
     );
     const userCanUnassignLinodes =
       permissions.update_vpc && filteredLinodes?.length > 0;

--- a/packages/manager/src/features/VPCs/VPCDetail/VPCSubnetsTable.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/VPCSubnetsTable.tsx
@@ -366,7 +366,6 @@ export const VPCSubnetsTable = (props: Props) => {
                     subnet={subnet}
                     subnetId={subnet.id}
                     subnetInterfaces={linodeInfo.interfaces}
-                    vpcId={vpcId}
                   />
                 ))
               ) : (


### PR DESCRIPTION
## Description 📝

This PR fixes permission mismatches in VPC actions. It removes the unnecessary ``update_vpc`` check for PowerOn/PowerOff/Reboot/Unassign Linode and replaces the subnet deletion check with ``delete_vpc`` instead of ``update_vpc``. Additionally, it addresses an issue where multiple unnecessary requests were sent to the Permission API after navigating to /vpcs/[vpcId].

## Changes  🔄

List any change(s) relevant to the reviewer.

- Removed ``update_vpc`` permission check from Power On/Off/Reboot/Unassign Linode actions.
- Updated subnet deletion check to use ``delete_vpc`` instead of ``update_vpc``.
- Optimized permission fetching to avoid redundant API calls on the VPC details route.

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [x] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

October 7th

## Preview 📷

| Before  | After   |
| ------- | ------- |
| 📷 | 📷 |

## How to test 🧪

### Prerequisites

- devcloud IAM account or mock data.

### Verification steps

(How to verify changes)

- [ ] Login as the user with the ``vpc_viewer`` and ``linode_admin`` roles.
- [ ] Go to /vpcs/[vpcId] route.
- [ ] Expand subnet row.
- [ ] Click the action menu of the Linode with the linode_admin role.
- [ ] Verify that the Reboot/Power On/Power Off (depending on the Linode state) and Unassign Linode buttons are enabled.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>