### PR TITLE
feat: [UIE-9181] - DBaaS - Display hostname in summary tables based on VPC configuration and refactor connection details

### DIFF
--- a/packages/manager/.changeset/pr-12939-added-1759348628476.md
+++ b/packages/manager/.changeset/pr-12939-added-1759348628476.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+ConnectionDetailsRow and ConnectionDetailsHostRows components to manage connection details table content ([#12939](https://github.com/linode/manager/pull/12939))

--- a/packages/manager/.changeset/pr-12939-changed-1759348579491.md
+++ b/packages/manager/.changeset/pr-12939-changed-1759348579491.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+DBaaS - Host field in connection details table renders based on VPC configuration and host fields are synced between Details and Networking tabs ([#12939](https://github.com/linode/manager/pull/12939))

--- a/packages/manager/src/features/Databases/DatabaseDetail/ConnectionDetailsHostRows.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/ConnectionDetailsHostRows.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { databaseFactory } from 'src/factories/databases';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
-import ConnectionDetailsHostRows from './ConnectionDetailsHostRows';
+import { ConnectionDetailsHostRows } from './ConnectionDetailsHostRows';
 
 import type { Database } from '@linode/api-v4/lib/databases';
 
@@ -14,7 +14,7 @@ const LEGACY_PRIMARY = 'db-mysql-legacy-primary.net';
 const LEGACY_SECONDARY = 'db-mysql-legacy-secondary.net';
 
 describe('ConnectionDetailsHostRows', () => {
-  it('should display correctly for default database', async () => {
+  it('should display correctly for default database', () => {
     const database = databaseFactory.build({
       hosts: {
         primary: DEFAULT_PRIMARY,
@@ -35,7 +35,7 @@ describe('ConnectionDetailsHostRows', () => {
     expect(queryAllByText('Read-only Host')).toHaveLength(1);
   });
 
-  it('should display N/A for default DB with blank read-only Host field', async () => {
+  it('should display N/A for default DB with blank read-only Host field', () => {
     const database = databaseFactory.build({
       hosts: {
         primary: DEFAULT_PRIMARY,
@@ -52,7 +52,7 @@ describe('ConnectionDetailsHostRows', () => {
     expect(queryAllByText('N/A')).toHaveLength(1);
   });
 
-  it('should display Host rows correctly for legacy db', async () => {
+  it('should display Host rows correctly for legacy db', () => {
     const database = databaseFactory.build({
       hosts: {
         primary: LEGACY_PRIMARY,
@@ -76,7 +76,7 @@ describe('ConnectionDetailsHostRows', () => {
     expect(queryAllByText(LEGACY_SECONDARY)).toHaveLength(1);
   });
 
-  it('should display provisioning text when hosts are not available', async () => {
+  it('should display provisioning text when hosts are not available', () => {
     const database = databaseFactory.build({
       hosts: undefined,
       platform: 'rdbms-default',
@@ -93,7 +93,7 @@ describe('ConnectionDetailsHostRows', () => {
     expect(hostNameProvisioningText).toBeInTheDocument();
   });
 
-  it('should display Host when VPC is not configured', async () => {
+  it('should display Host when VPC is not configured', () => {
     const privateStrIndex = DEFAULT_PRIMARY.indexOf('-');
     const baseHostName = DEFAULT_PRIMARY.slice(privateStrIndex + 1);
 
@@ -113,7 +113,7 @@ describe('ConnectionDetailsHostRows', () => {
     expect(queryAllByText(baseHostName)).toHaveLength(1);
   });
 
-  it('should display Private Host field when VPC is configured with public access as false', async () => {
+  it('should display Private Host field when VPC is configured with public access as false', () => {
     const database = databaseFactory.build({
       hosts: {
         primary: DEFAULT_PRIMARY,
@@ -135,7 +135,7 @@ describe('ConnectionDetailsHostRows', () => {
     expect(queryAllByText(DEFAULT_PRIMARY)).toHaveLength(1);
   });
 
-  it('should display both Private Host and Public Host fields when VPC is configured with public access as true', async () => {
+  it('should display both Private Host and Public Host fields when VPC is configured with public access as true', () => {
     const database = databaseFactory.build({
       hosts: {
         primary: DEFAULT_PRIMARY,
@@ -166,7 +166,7 @@ describe('ConnectionDetailsHostRows', () => {
     expect(queryAllByText(expectedPublicHostname)).toHaveLength(1);
   });
 
-  it('should display Read-only Host when read-only host is available', async () => {
+  it('should display Read-only Host when read-only host is available', () => {
     const database = databaseFactory.build({
       hosts: {
         primary: DEFAULT_PRIMARY,

--- a/packages/manager/src/features/Databases/DatabaseDetail/ConnectionDetailsHostRows.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/ConnectionDetailsHostRows.test.tsx
@@ -1,0 +1,186 @@
+import React from 'react';
+
+import { databaseFactory } from 'src/factories/databases';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import ConnectionDetailsHostRows from './ConnectionDetailsHostRows';
+
+import type { Database } from '@linode/api-v4/lib/databases';
+
+const DEFAULT_PRIMARY = 'private-db-mysql-default-primary.net';
+const DEFAULT_STANDBY = 'db-mysql-default-standby.net';
+
+const LEGACY_PRIMARY = 'db-mysql-legacy-primary.net';
+const LEGACY_SECONDARY = 'db-mysql-legacy-secondary.net';
+
+describe('ConnectionDetailsHostRows', () => {
+  it('should display correctly for default database', async () => {
+    const database = databaseFactory.build({
+      hosts: {
+        primary: DEFAULT_PRIMARY,
+        secondary: undefined,
+        standby: DEFAULT_STANDBY,
+      },
+      platform: 'rdbms-default',
+      private_network: null, // Added to test that Host field renders
+    }) as Database;
+
+    const { queryAllByText } = renderWithTheme(
+      <ConnectionDetailsHostRows database={database} />
+    );
+
+    expect(queryAllByText('Host')).toHaveLength(1);
+    expect(queryAllByText(DEFAULT_PRIMARY)).toHaveLength(1);
+
+    expect(queryAllByText('Read-only Host')).toHaveLength(1);
+  });
+
+  it('should display N/A for default DB with blank read-only Host field', async () => {
+    const database = databaseFactory.build({
+      hosts: {
+        primary: DEFAULT_PRIMARY,
+        secondary: undefined,
+        standby: undefined,
+      },
+      platform: 'rdbms-default',
+    });
+
+    const { queryAllByText } = renderWithTheme(
+      <ConnectionDetailsHostRows database={database} />
+    );
+
+    expect(queryAllByText('N/A')).toHaveLength(1);
+  });
+
+  it('should display Host rows correctly for legacy db', async () => {
+    const database = databaseFactory.build({
+      hosts: {
+        primary: LEGACY_PRIMARY,
+        secondary: LEGACY_SECONDARY,
+        standby: undefined,
+      },
+      id: 22,
+      platform: 'rdbms-legacy',
+      port: 3306,
+      ssl_connection: true,
+    }) as Database;
+
+    const { queryAllByText } = renderWithTheme(
+      <ConnectionDetailsHostRows database={database} />
+    );
+
+    expect(queryAllByText('Host')).toHaveLength(1);
+    expect(queryAllByText(LEGACY_PRIMARY)).toHaveLength(1);
+
+    expect(queryAllByText('Private Network Host')).toHaveLength(1);
+    expect(queryAllByText(LEGACY_SECONDARY)).toHaveLength(1);
+  });
+
+  it('should display provisioning text when hosts are not available', async () => {
+    const database = databaseFactory.build({
+      hosts: undefined,
+      platform: 'rdbms-default',
+    }) as Database;
+
+    const { getByText } = renderWithTheme(
+      <ConnectionDetailsHostRows database={database} />
+    );
+
+    const hostNameProvisioningText = getByText(
+      'Your hostname will appear here once it is available.'
+    );
+
+    expect(hostNameProvisioningText).toBeInTheDocument();
+  });
+
+  it('should display Host when VPC is not configured', async () => {
+    const privateStrIndex = DEFAULT_PRIMARY.indexOf('-');
+    const baseHostName = DEFAULT_PRIMARY.slice(privateStrIndex + 1);
+
+    const database = databaseFactory.build({
+      hosts: {
+        primary: baseHostName,
+      },
+      platform: 'rdbms-default',
+      private_network: null, // VPC not configured
+    }) as Database;
+
+    const { queryAllByText } = renderWithTheme(
+      <ConnectionDetailsHostRows database={database} />
+    );
+
+    expect(queryAllByText('Host')).toHaveLength(1);
+    expect(queryAllByText(baseHostName)).toHaveLength(1);
+  });
+
+  it('should display Private Host field when VPC is configured with public access as false', async () => {
+    const database = databaseFactory.build({
+      hosts: {
+        primary: DEFAULT_PRIMARY,
+        secondary: undefined,
+        standby: undefined,
+      },
+      platform: 'rdbms-default',
+      private_network: {
+        public_access: false,
+        subnet_id: 1,
+        vpc_id: 123,
+      },
+    }) as Database;
+
+    const { queryAllByText } = renderWithTheme(
+      <ConnectionDetailsHostRows database={database} />
+    );
+    expect(queryAllByText('Private Host')).toHaveLength(1);
+    expect(queryAllByText(DEFAULT_PRIMARY)).toHaveLength(1);
+  });
+
+  it('should display both Private Host and Public Host fields when VPC is configured with public access as true', async () => {
+    const database = databaseFactory.build({
+      hosts: {
+        primary: DEFAULT_PRIMARY,
+        secondary: undefined,
+        standby: undefined,
+      },
+      platform: 'rdbms-default',
+      private_network: {
+        public_access: true,
+        subnet_id: 1,
+        vpc_id: 123,
+      },
+    }) as Database;
+
+    const { queryAllByText } = renderWithTheme(
+      <ConnectionDetailsHostRows database={database} />
+    );
+    // Verify that both Private Host and Public Host fields are rendered
+    expect(queryAllByText('Private Host')).toHaveLength(1);
+    expect(queryAllByText('Public Host')).toHaveLength(1);
+
+    // Verify that the Private hostname is rendered correctly
+    expect(queryAllByText(DEFAULT_PRIMARY)).toHaveLength(1);
+    // Verify that the Public hostname is rendered correctly
+    const privateStrIndex = DEFAULT_PRIMARY.indexOf('-');
+    const baseHostName = DEFAULT_PRIMARY.slice(privateStrIndex + 1);
+    const expectedPublicHostname = `public-${baseHostName}`;
+    expect(queryAllByText(expectedPublicHostname)).toHaveLength(1);
+  });
+
+  it('should display Read-only Host when read-only host is available', async () => {
+    const database = databaseFactory.build({
+      hosts: {
+        primary: DEFAULT_PRIMARY,
+        secondary: undefined,
+        standby: DEFAULT_STANDBY,
+      },
+      platform: 'rdbms-default',
+    }) as Database;
+
+    const { queryAllByText } = renderWithTheme(
+      <ConnectionDetailsHostRows database={database} />
+    );
+
+    expect(queryAllByText('Read-only Host')).toHaveLength(1);
+    expect(queryAllByText(DEFAULT_STANDBY)).toHaveLength(1);
+  });
+});

--- a/packages/manager/src/features/Databases/DatabaseDetail/ConnectionDetailsHostRows.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/ConnectionDetailsHostRows.tsx
@@ -47,37 +47,40 @@ export const ConnectionDetailsHostRows = (
   const getHostContent = (
     mode: 'default' | 'private' | 'public' = 'default'
   ) => {
-    const hasPrimaryHostname = !!database.hosts?.primary;
     let primaryHostName = database.hosts?.primary;
 
-    if (mode === 'public' && hasPrimaryHostname) {
+    if (mode === 'public' && primaryHostName) {
       // Remove 'private-' substring at the beginning of the hostname and replace it with 'public-'
       const privateStrIndex = database.hosts.primary.indexOf('-');
       const baseHostName = database.hosts.primary.slice(privateStrIndex + 1);
       primaryHostName = `public-${baseHostName}`;
     }
 
-    return hasPrimaryHostname ? (
-      <>
-        {primaryHostName}
-        <CopyTooltip
-          className={classes.inlineCopyToolTip}
-          text={primaryHostName}
-        />
-        {!isLegacy && (
-          <TooltipIcon
-            componentsProps={hostTooltipComponentProps}
-            status="info"
-            sxTooltipIcon={sxTooltipIcon}
-            text={
-              mode === 'private'
-                ? SUMMARY_PRIVATE_HOST_COPY
-                : SUMMARY_HOST_TOOLTIP_COPY
-            }
+    if (primaryHostName) {
+      return (
+        <>
+          {primaryHostName}
+          <CopyTooltip
+            className={classes.inlineCopyToolTip}
+            text={primaryHostName}
           />
-        )}
-      </>
-    ) : (
+          {!isLegacy && (
+            <TooltipIcon
+              componentsProps={hostTooltipComponentProps}
+              status="info"
+              sxTooltipIcon={sxTooltipIcon}
+              text={
+                mode === 'private'
+                  ? SUMMARY_PRIVATE_HOST_COPY
+                  : SUMMARY_HOST_TOOLTIP_COPY
+              }
+            />
+          )}
+        </>
+      );
+    }
+
+    return (
       <Typography>
         <span className={classes.provisioningText}>
           Your hostname will appear here once it is available.

--- a/packages/manager/src/features/Databases/DatabaseDetail/ConnectionDetailsHostRows.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/ConnectionDetailsHostRows.tsx
@@ -1,0 +1,135 @@
+import { TooltipIcon, Typography } from '@linode/ui';
+import * as React from 'react';
+
+import { CopyTooltip } from 'src/components/CopyTooltip/CopyTooltip';
+
+import {
+  SUMMARY_HOST_TOOLTIP_COPY,
+  SUMMARY_PRIVATE_HOST_COPY,
+  SUMMARY_PRIVATE_HOST_LEGACY_COPY,
+} from '../constants';
+import { getReadOnlyHost, isLegacyDatabase } from '../utilities';
+import ConnectionDetailsRow from './ConnectionDetailsRow';
+import { useStyles } from './DatabaseSummary/DatabaseSummaryConnectionDetails.style';
+
+import type { Database } from '@linode/api-v4/lib/databases/types';
+
+interface ConnectionDetailsHostRowsProps {
+  database: Database;
+}
+
+/**
+ * This component is responsible for conditionally rendering the Private Host, Public Host, and Read-only Host rows that get displayed in
+ * the Connection Details tables that appear in the Database Summary and Networking tabs */
+const ConnectionDetailsHostRows = (props: ConnectionDetailsHostRowsProps) => {
+  const { database } = props;
+  const { classes } = useStyles();
+
+  const sxTooltipIcon = {
+    marginLeft: '4px',
+    padding: '0px',
+  };
+
+  const hostTooltipComponentProps = {
+    tooltip: {
+      style: {
+        minWidth: 285,
+      },
+    },
+  };
+
+  const isLegacy = isLegacyDatabase(database);
+  const hasVPC = Boolean(database?.private_network?.vpc_id);
+  const hasPublicVPC = hasVPC && database?.private_network?.public_access;
+
+  const getHostContent = (
+    mode: 'default' | 'private' | 'public' = 'default'
+  ) => {
+    const hasPrimaryHostname = !!database.hosts?.primary;
+    let primaryHostName = database.hosts?.primary;
+
+    if (mode === 'public' && hasPrimaryHostname) {
+      // Remove 'private-' substring at the beginning of the hostname and replace it with 'public-'
+      const privateStrIndex = database.hosts.primary.indexOf('-');
+      const baseHostName = database.hosts.primary.slice(privateStrIndex + 1);
+      primaryHostName = `public-${baseHostName}`;
+    }
+
+    return hasPrimaryHostname ? (
+      <>
+        {primaryHostName}
+        <CopyTooltip
+          className={classes.inlineCopyToolTip}
+          text={primaryHostName}
+        />
+        {!isLegacy && (
+          <TooltipIcon
+            componentsProps={hostTooltipComponentProps}
+            status="info"
+            sxTooltipIcon={sxTooltipIcon}
+            text={
+              mode === 'private'
+                ? SUMMARY_PRIVATE_HOST_COPY
+                : SUMMARY_HOST_TOOLTIP_COPY
+            }
+          />
+        )}
+      </>
+    ) : (
+      <Typography>
+        <span className={classes.provisioningText}>
+          Your hostname will appear here once it is available.
+        </span>
+      </Typography>
+    );
+  };
+
+  const getReadOnlyHostContent = () => {
+    const defaultValue = isLegacy ? '-' : 'N/A';
+    const value = getReadOnlyHost(database) || defaultValue;
+    const hasHost = value !== '-' && value !== 'N/A';
+    return (
+      <>
+        {value}
+        {value && hasHost && (
+          <CopyTooltip className={classes.inlineCopyToolTip} text={value} />
+        )}
+        {isLegacy && (
+          <TooltipIcon
+            status="info"
+            sxTooltipIcon={sxTooltipIcon}
+            text={SUMMARY_PRIVATE_HOST_LEGACY_COPY}
+          />
+        )}
+        {!isLegacy && hasHost && (
+          <TooltipIcon
+            componentsProps={hostTooltipComponentProps}
+            status="info"
+            sxTooltipIcon={sxTooltipIcon}
+            text={SUMMARY_HOST_TOOLTIP_COPY}
+          />
+        )}
+      </>
+    );
+  };
+
+  return (
+    <>
+      <ConnectionDetailsRow label={hasVPC ? 'Private Host' : 'Host'}>
+        {getHostContent(hasVPC ? 'private' : 'default')}
+      </ConnectionDetailsRow>
+      {hasPublicVPC && (
+        <ConnectionDetailsRow label="Public Host">
+          {getHostContent('public')}
+        </ConnectionDetailsRow>
+      )}
+      <ConnectionDetailsRow
+        label={isLegacy ? 'Private Network Host' : 'Read-only Host'}
+      >
+        {getReadOnlyHostContent()}
+      </ConnectionDetailsRow>
+    </>
+  );
+};
+
+export default ConnectionDetailsHostRows;

--- a/packages/manager/src/features/Databases/DatabaseDetail/ConnectionDetailsHostRows.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/ConnectionDetailsHostRows.tsx
@@ -9,7 +9,7 @@ import {
   SUMMARY_PRIVATE_HOST_LEGACY_COPY,
 } from '../constants';
 import { getReadOnlyHost, isLegacyDatabase } from '../utilities';
-import ConnectionDetailsRow from './ConnectionDetailsRow';
+import { ConnectionDetailsRow } from './ConnectionDetailsRow';
 import { useStyles } from './DatabaseSummary/DatabaseSummaryConnectionDetails.style';
 
 import type { Database } from '@linode/api-v4/lib/databases/types';
@@ -21,7 +21,9 @@ interface ConnectionDetailsHostRowsProps {
 /**
  * This component is responsible for conditionally rendering the Private Host, Public Host, and Read-only Host rows that get displayed in
  * the Connection Details tables that appear in the Database Summary and Networking tabs */
-const ConnectionDetailsHostRows = (props: ConnectionDetailsHostRowsProps) => {
+export const ConnectionDetailsHostRows = (
+  props: ConnectionDetailsHostRowsProps
+) => {
   const { database } = props;
   const { classes } = useStyles();
 
@@ -131,5 +133,3 @@ const ConnectionDetailsHostRows = (props: ConnectionDetailsHostRowsProps) => {
     </>
   );
 };
-
-export default ConnectionDetailsHostRows;

--- a/packages/manager/src/features/Databases/DatabaseDetail/ConnectionDetailsRow.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/ConnectionDetailsRow.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
-import ConnectionDetailsRow from './ConnectionDetailsRow';
+import { ConnectionDetailsRow } from './ConnectionDetailsRow';
 
 describe('ConnectionDetailsRow', () => {
   it('should render provided label and children', async () => {

--- a/packages/manager/src/features/Databases/DatabaseDetail/ConnectionDetailsRow.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/ConnectionDetailsRow.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import ConnectionDetailsRow from './ConnectionDetailsRow';
+
+describe('ConnectionDetailsRow', () => {
+  it('should render provided label and children', async () => {
+    const { getByText } = renderWithTheme(
+      <ConnectionDetailsRow label="Test Label">
+        <p>Test Children Prop</p>
+      </ConnectionDetailsRow>
+    );
+    const testLabel = getByText('Test Label');
+    const testChildrenProp = getByText('Test Children Prop');
+
+    expect(testLabel).toBeInTheDocument();
+    expect(testChildrenProp).toBeInTheDocument();
+  });
+});

--- a/packages/manager/src/features/Databases/DatabaseDetail/ConnectionDetailsRow.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/ConnectionDetailsRow.tsx
@@ -1,0 +1,31 @@
+import { Grid } from '@mui/material';
+import * as React from 'react';
+
+import {
+  StyledLabelTypography,
+  StyledValueGrid,
+} from './DatabaseSummary/DatabaseSummaryClusterConfiguration.style';
+
+interface ConnectionDetailsRowProps {
+  children: React.ReactNode;
+  label: string;
+}
+
+const ConnectionDetailsRow = (props: ConnectionDetailsRowProps) => {
+  const { children, label } = props;
+  return (
+    <>
+      <Grid
+        size={{
+          md: 4,
+          xs: 3,
+        }}
+      >
+        <StyledLabelTypography>{label}</StyledLabelTypography>
+      </Grid>
+      <StyledValueGrid size={{ md: 8, xs: 9 }}>{children}</StyledValueGrid>
+    </>
+  );
+};
+
+export default ConnectionDetailsRow;

--- a/packages/manager/src/features/Databases/DatabaseDetail/ConnectionDetailsRow.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/ConnectionDetailsRow.tsx
@@ -11,7 +11,7 @@ interface ConnectionDetailsRowProps {
   label: string;
 }
 
-const ConnectionDetailsRow = (props: ConnectionDetailsRowProps) => {
+export const ConnectionDetailsRow = (props: ConnectionDetailsRowProps) => {
   const { children, label } = props;
   return (
     <>
@@ -27,5 +27,3 @@ const ConnectionDetailsRow = (props: ConnectionDetailsRowProps) => {
     </>
   );
 };
-
-export default ConnectionDetailsRow;

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseNetworking/DatabaseManageNetworking.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseNetworking/DatabaseManageNetworking.tsx
@@ -6,7 +6,6 @@ import {
   ErrorState,
   Typography,
 } from '@linode/ui';
-import { Grid } from '@mui/material';
 import React from 'react';
 import { makeStyles } from 'tss-react/mui';
 
@@ -14,12 +13,9 @@ import { Link } from 'src/components/Link';
 import { useFlags } from 'src/hooks/useFlags';
 
 import { MANAGE_NETWORKING_LEARN_MORE_LINK } from '../../constants';
-import { getReadOnlyHost } from '../../utilities';
-import {
-  StyledGridContainer,
-  StyledLabelTypography,
-  StyledValueGrid,
-} from '../DatabaseSummary/DatabaseSummaryClusterConfiguration.style';
+import ConnectionDetailsHostRows from '../ConnectionDetailsHostRows';
+import ConnectionDetailsRow from '../ConnectionDetailsRow';
+import { StyledGridContainer } from '../DatabaseSummary/DatabaseSummaryClusterConfiguration.style';
 import DatabaseManageNetworkingDrawer from './DatabaseManageNetworkingDrawer';
 import { DatabaseNetworkingUnassignVPCDialog } from './DatabaseNetworkingUnassignVPCDialog';
 
@@ -64,10 +60,6 @@ export const DatabaseManageNetworking = ({ database }: Props) => {
         flexDirection: 'column',
       },
     },
-    provisioningText: {
-      font: theme.font.normal,
-      fontStyle: 'italic',
-    },
   }));
 
   const flags = useFlags();
@@ -80,8 +72,6 @@ export const DatabaseManageNetworking = ({ database }: Props) => {
   const vpcId = Number(database.private_network?.vpc_id);
   const hasVPCConfigured = Boolean(vpcId);
   const gridContainerSize = { lg: 7, md: 10 };
-  const gridValueSize = { md: 8, xs: 9 };
-  const gridLabelSize = { md: 4, xs: 3 };
 
   const {
     data: vpcs,
@@ -98,12 +88,6 @@ export const DatabaseManageNetworking = ({ database }: Props) => {
     (subnet) => subnet.id === database?.private_network?.subnet_id
   );
   const hasVPCs = Boolean(vpcs && vpcs.length > 0);
-
-  const readOnlyHost = () => {
-    const defaultValue = 'N/A';
-    const value = getReadOnlyHost(database) || defaultValue;
-    return <span>{value}</span>;
-  };
 
   const onManageAccess = () => {
     setIsManageNetworkingDrawerOpen(true);
@@ -158,54 +142,26 @@ export const DatabaseManageNetworking = ({ database }: Props) => {
       </div>
 
       <StyledGridContainer container size={gridContainerSize} spacing={0}>
-        <Grid size={gridLabelSize}>
-          <StyledLabelTypography>Connection Type</StyledLabelTypography>
-        </Grid>
-        <StyledValueGrid size={gridValueSize}>
+        <ConnectionDetailsRow label="Connection Type">
           {hasVPCConfigured ? 'VPC' : 'Public'}
-        </StyledValueGrid>
+        </ConnectionDetailsRow>
+
         {hasVPCConfigured && (
           <>
-            <Grid size={gridLabelSize}>
-              <StyledLabelTypography>VPC</StyledLabelTypography>
-            </Grid>
-            <StyledValueGrid size={gridValueSize}>
+            <ConnectionDetailsRow label="VPC">
               {currentVPC?.label}
-            </StyledValueGrid>
-            <Grid size={gridLabelSize}>
-              <StyledLabelTypography>Subnet</StyledLabelTypography>
-            </Grid>
-            <StyledValueGrid size={gridValueSize}>
+            </ConnectionDetailsRow>
+            <ConnectionDetailsRow label="Subnet">
               {`${currentSubnet?.label} (${currentSubnet?.ipv4})`}
-            </StyledValueGrid>
+            </ConnectionDetailsRow>
           </>
         )}
 
-        <Grid size={gridLabelSize}>
-          <StyledLabelTypography>Host</StyledLabelTypography>
-        </Grid>
-        <StyledValueGrid size={gridValueSize}>
-          {database.hosts?.primary ? (
-            database.hosts?.primary
-          ) : (
-            <span className={classes.provisioningText}>
-              Your hostname will appear here once it is available.
-            </span>
-          )}
-        </StyledValueGrid>
-        <Grid size={gridLabelSize}>
-          <StyledLabelTypography>Read-only Host</StyledLabelTypography>
-        </Grid>
-        <StyledValueGrid size={gridValueSize}>{readOnlyHost()}</StyledValueGrid>
+        <ConnectionDetailsHostRows database={database} />
         {hasVPCConfigured && (
-          <>
-            <Grid size={gridLabelSize}>
-              <StyledLabelTypography>Public Access</StyledLabelTypography>
-            </Grid>
-            <StyledValueGrid size={gridValueSize}>
-              {database?.private_network?.public_access ? 'Yes' : 'No'}
-            </StyledValueGrid>
-          </>
+          <ConnectionDetailsRow label="Public Access">
+            {database?.private_network?.public_access ? 'Yes' : 'No'}
+          </ConnectionDetailsRow>
         )}
       </StyledGridContainer>
 

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseNetworking/DatabaseManageNetworking.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseNetworking/DatabaseManageNetworking.tsx
@@ -13,8 +13,8 @@ import { Link } from 'src/components/Link';
 import { useFlags } from 'src/hooks/useFlags';
 
 import { MANAGE_NETWORKING_LEARN_MORE_LINK } from '../../constants';
-import ConnectionDetailsHostRows from '../ConnectionDetailsHostRows';
-import ConnectionDetailsRow from '../ConnectionDetailsRow';
+import { ConnectionDetailsHostRows } from '../ConnectionDetailsHostRows';
+import { ConnectionDetailsRow } from '../ConnectionDetailsRow';
 import { StyledGridContainer } from '../DatabaseSummary/DatabaseSummaryClusterConfiguration.style';
 import DatabaseManageNetworkingDrawer from './DatabaseManageNetworkingDrawer';
 import { DatabaseNetworkingUnassignVPCDialog } from './DatabaseNetworkingUnassignVPCDialog';

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
@@ -141,59 +141,40 @@ export const DatabaseSummaryConnectionDetails = (props: Props) => {
     </>
   );
 
-  const getConnectionTypeContent = () => {
-    return (
-      <>
-        <Box
-          sx={(theme: Theme) => ({
-            marginRight: theme.spacingFunction(20),
-          })}
-        >
-          {hasVPC ? 'VPC' : 'Public'}
-        </Box>
-        <Link to={`/databases/${database?.engine}/${database?.id}/networking`}>
-          View Details
-        </Link>
-      </>
-    );
-  };
-
-  const getCredentialsContent = () => {
-    return (
-      <>
-        {password}
-        {showCredentials && credentialsLoading ? (
-          <div className={classes.progressCtn}>
-            <CircleProgress noPadding size="xs" />
-          </div>
-        ) : credentialsError ? (
-          <>
-            <span className={classes.error}>Error retrieving credentials.</span>
-            {credentialsBtn(() => getDatabaseCredentials(), 'Retry')}
-          </>
-        ) : (
-          credentialsBtn(
-            handleShowPasswordClick,
-            showCredentials && credentials ? 'Hide' : 'Show'
-          )
-        )}
-        {disableShowBtn && (
-          <TooltipIcon
-            status="info"
-            sxTooltipIcon={sxTooltipIcon}
-            text={
-              database.status === 'provisioning'
-                ? 'Your Database Cluster is currently provisioning.'
-                : 'Your root password is unavailable when your Database Cluster has failed.'
-            }
-          />
-        )}
-        {showCredentials && credentials && (
-          <CopyTooltip className={classes.inlineCopyToolTip} text={password} />
-        )}
-      </>
-    );
-  };
+  const CredentialsContent = (
+    <>
+      {password}
+      {showCredentials && credentialsLoading ? (
+        <div className={classes.progressCtn}>
+          <CircleProgress noPadding size="xs" />
+        </div>
+      ) : credentialsError ? (
+        <>
+          <span className={classes.error}>Error retrieving credentials.</span>
+          {credentialsBtn(() => getDatabaseCredentials(), 'Retry')}
+        </>
+      ) : (
+        credentialsBtn(
+          handleShowPasswordClick,
+          showCredentials && credentials ? 'Hide' : 'Show'
+        )
+      )}
+      {disableShowBtn && (
+        <TooltipIcon
+          status="info"
+          sxTooltipIcon={sxTooltipIcon}
+          text={
+            database.status === 'provisioning'
+              ? 'Your Database Cluster is currently provisioning.'
+              : 'Your root password is unavailable when your Database Cluster has failed.'
+          }
+        />
+      )}
+      {showCredentials && credentials && (
+        <CopyTooltip className={classes.inlineCopyToolTip} text={password} />
+      )}
+    </>
+  );
 
   return (
     <>
@@ -203,7 +184,7 @@ export const DatabaseSummaryConnectionDetails = (props: Props) => {
       <StyledGridContainer container size={{ lg: 7, md: 10 }} spacing={0}>
         <ConnectionDetailsRow label="Username">{username}</ConnectionDetailsRow>
         <ConnectionDetailsRow label="Password">
-          {getCredentialsContent()}
+          {CredentialsContent}
         </ConnectionDetailsRow>
         <ConnectionDetailsRow label="Database name">
           {isLegacy ? database.engine : 'defaultdb'}
@@ -217,7 +198,18 @@ export const DatabaseSummaryConnectionDetails = (props: Props) => {
         </ConnectionDetailsRow>
         {displayConnectionType && (
           <ConnectionDetailsRow label="Connection Type">
-            {getConnectionTypeContent()}
+            <Box
+              sx={(theme: Theme) => ({
+                marginRight: theme.spacingFunction(20),
+              })}
+            >
+              {hasVPC ? 'VPC' : 'Public'}
+            </Box>
+            <Link
+              to={`/databases/${database?.engine}/${database?.id}/networking`}
+            >
+              View Details
+            </Link>
           </ConnectionDetailsRow>
         )}
       </StyledGridContainer>

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
@@ -14,8 +14,8 @@ import { useFlags } from 'src/hooks/useFlags';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 
 import { isDefaultDatabase } from '../../utilities';
-import ConnectionDetailsHostRows from '../ConnectionDetailsHostRows';
-import ConnectionDetailsRow from '../ConnectionDetailsRow';
+import { ConnectionDetailsHostRows } from '../ConnectionDetailsHostRows';
+import { ConnectionDetailsRow } from '../ConnectionDetailsRow';
 import { StyledGridContainer } from './DatabaseSummaryClusterConfiguration.style';
 import { useStyles } from './DatabaseSummaryConnectionDetails.style';
 

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
@@ -2,7 +2,6 @@ import { getSSLFields } from '@linode/api-v4/lib/databases/databases';
 import { useDatabaseCredentialsQuery } from '@linode/queries';
 import { Box, CircleProgress, TooltipIcon, Typography } from '@linode/ui';
 import { downloadFile } from '@linode/utilities';
-import Grid from '@mui/material/Grid';
 import { Button } from 'akamai-cds-react-components';
 import { useSnackbar } from 'notistack';
 import * as React from 'react';
@@ -14,12 +13,10 @@ import { DB_ROOT_USERNAME } from 'src/constants';
 import { useFlags } from 'src/hooks/useFlags';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 
-import { getReadOnlyHost, isDefaultDatabase } from '../../utilities';
-import {
-  StyledGridContainer,
-  StyledLabelTypography,
-  StyledValueGrid,
-} from './DatabaseSummaryClusterConfiguration.style';
+import { isDefaultDatabase } from '../../utilities';
+import ConnectionDetailsHostRows from '../ConnectionDetailsHostRows';
+import ConnectionDetailsRow from '../ConnectionDetailsRow';
+import { StyledGridContainer } from './DatabaseSummaryClusterConfiguration.style';
 import { useStyles } from './DatabaseSummaryConnectionDetails.style';
 
 import type { Database, SSLFields } from '@linode/api-v4/lib/databases/types';
@@ -34,15 +31,13 @@ const sxTooltipIcon = {
   padding: '0px',
 };
 
-const privateHostCopy =
-  'A private network host and a private IP can only be used to access a Database Cluster from Linodes in the same data center and will not incur transfer costs.';
-
 export const DatabaseSummaryConnectionDetails = (props: Props) => {
   const { database } = props;
   const { classes } = useStyles();
   const { enqueueSnackbar } = useSnackbar();
   const flags = useFlags();
   const isLegacy = database.platform !== 'rdbms-default';
+  const hasVPC = Boolean(database?.private_network?.vpc_id);
   const displayConnectionType =
     flags.databaseVpc && isDefaultDatabase(database);
 
@@ -66,16 +61,6 @@ export const DatabaseSummaryConnectionDetails = (props: Props) => {
 
   const password =
     showCredentials && credentials ? credentials?.password : '••••••••••';
-
-  const hostTooltipComponentProps = {
-    tooltip: {
-      style: {
-        minWidth: 285,
-      },
-    },
-  };
-  const HOST_TOOLTIP_COPY =
-    'Use the IPv6 address (AAAA record) for this hostname to avoid network transfer charges when connecting to this database from Linodes within the same region.';
 
   const handleShowPasswordClick = () => {
     setShowPassword((showCredentials) => !showCredentials);
@@ -117,35 +102,6 @@ export const DatabaseSummaryConnectionDetails = (props: Props) => {
   const disableShowBtn = ['failed', 'provisioning'].includes(database.status);
   const disableDownloadCACertificateBtn = database.status === 'provisioning';
 
-  const readOnlyHost = () => {
-    const defaultValue = isLegacy ? '-' : 'N/A';
-    const value = getReadOnlyHost(database) || defaultValue;
-    const hasHost = value !== '-' && value !== 'N/A';
-    return (
-      <>
-        {value}
-        {value && hasHost && (
-          <CopyTooltip className={classes.inlineCopyToolTip} text={value} />
-        )}
-        {isLegacy && (
-          <TooltipIcon
-            status="info"
-            sxTooltipIcon={sxTooltipIcon}
-            text={privateHostCopy}
-          />
-        )}
-        {!isLegacy && hasHost && (
-          <TooltipIcon
-            componentsProps={hostTooltipComponentProps}
-            status="info"
-            sxTooltipIcon={sxTooltipIcon}
-            text={HOST_TOOLTIP_COPY}
-          />
-        )}
-      </>
-    );
-  };
-
   const credentialsBtn = (handleClick: () => void, btnText: string) => {
     return (
       <Button
@@ -185,170 +141,84 @@ export const DatabaseSummaryConnectionDetails = (props: Props) => {
     </>
   );
 
+  const getConnectionTypeContent = () => {
+    return (
+      <>
+        <Box
+          sx={(theme: Theme) => ({
+            marginRight: theme.spacingFunction(20),
+          })}
+        >
+          {hasVPC ? 'VPC' : 'Public'}
+        </Box>
+        <Link to={`/databases/${database?.engine}/${database?.id}/networking`}>
+          View Details
+        </Link>
+      </>
+    );
+  };
+
+  const getCredentialsContent = () => {
+    return (
+      <>
+        {password}
+        {showCredentials && credentialsLoading ? (
+          <div className={classes.progressCtn}>
+            <CircleProgress noPadding size="xs" />
+          </div>
+        ) : credentialsError ? (
+          <>
+            <span className={classes.error}>Error retrieving credentials.</span>
+            {credentialsBtn(() => getDatabaseCredentials(), 'Retry')}
+          </>
+        ) : (
+          credentialsBtn(
+            handleShowPasswordClick,
+            showCredentials && credentials ? 'Hide' : 'Show'
+          )
+        )}
+        {disableShowBtn && (
+          <TooltipIcon
+            status="info"
+            sxTooltipIcon={sxTooltipIcon}
+            text={
+              database.status === 'provisioning'
+                ? 'Your Database Cluster is currently provisioning.'
+                : 'Your root password is unavailable when your Database Cluster has failed.'
+            }
+          />
+        )}
+        {showCredentials && credentials && (
+          <CopyTooltip className={classes.inlineCopyToolTip} text={password} />
+        )}
+      </>
+    );
+  };
+
   return (
     <>
       <Typography className={classes.header} variant="h3">
         Connection Details
       </Typography>
       <StyledGridContainer container size={{ lg: 7, md: 10 }} spacing={0}>
-        <Grid
-          size={{
-            md: 4,
-            xs: 3,
-          }}
-        >
-          <StyledLabelTypography>Username</StyledLabelTypography>
-        </Grid>
-        <StyledValueGrid size={{ md: 8, xs: 9 }}>{username}</StyledValueGrid>
-        <Grid
-          size={{
-            md: 4,
-            xs: 3,
-          }}
-        >
-          <StyledLabelTypography>Password</StyledLabelTypography>
-        </Grid>
-        <StyledValueGrid size={{ md: 8, xs: 9 }}>
-          {password}
-          {showCredentials && credentialsLoading ? (
-            <div className={classes.progressCtn}>
-              <CircleProgress noPadding size="xs" />
-            </div>
-          ) : credentialsError ? (
-            <>
-              <span className={classes.error}>
-                Error retrieving credentials.
-              </span>
-              {credentialsBtn(() => getDatabaseCredentials(), 'Retry')}
-            </>
-          ) : (
-            credentialsBtn(
-              handleShowPasswordClick,
-              showCredentials && credentials ? 'Hide' : 'Show'
-            )
-          )}
-          {disableShowBtn && (
-            <TooltipIcon
-              status="info"
-              sxTooltipIcon={sxTooltipIcon}
-              text={
-                database.status === 'provisioning'
-                  ? 'Your Database Cluster is currently provisioning.'
-                  : 'Your root password is unavailable when your Database Cluster has failed.'
-              }
-            />
-          )}
-          {showCredentials && credentials && (
-            <CopyTooltip
-              className={classes.inlineCopyToolTip}
-              text={password}
-            />
-          )}
-        </StyledValueGrid>
-        <Grid
-          size={{
-            md: 4,
-            xs: 3,
-          }}
-        >
-          <StyledLabelTypography>Database name</StyledLabelTypography>
-        </Grid>
-        <StyledValueGrid size={{ md: 8, xs: 9 }}>
+        <ConnectionDetailsRow label="Username">{username}</ConnectionDetailsRow>
+        <ConnectionDetailsRow label="Password">
+          {getCredentialsContent()}
+        </ConnectionDetailsRow>
+        <ConnectionDetailsRow label="Database name">
           {isLegacy ? database.engine : 'defaultdb'}
-        </StyledValueGrid>
-        <Grid
-          size={{
-            md: 4,
-            xs: 3,
-          }}
-        >
-          <StyledLabelTypography>Host</StyledLabelTypography>
-        </Grid>
-        <StyledValueGrid size={{ md: 8, xs: 9 }}>
-          {database.hosts?.primary ? (
-            <>
-              {database.hosts?.primary}
-              <CopyTooltip
-                className={classes.inlineCopyToolTip}
-                text={database.hosts?.primary}
-              />
-              {!isLegacy && (
-                <TooltipIcon
-                  componentsProps={hostTooltipComponentProps}
-                  status="info"
-                  sxTooltipIcon={sxTooltipIcon}
-                  text={HOST_TOOLTIP_COPY}
-                />
-              )}
-            </>
-          ) : (
-            <Typography>
-              <span className={classes.provisioningText}>
-                Your hostname will appear here once it is available.
-              </span>
-            </Typography>
-          )}
-        </StyledValueGrid>
-        <Grid
-          size={{
-            md: 4,
-            xs: 3,
-          }}
-        >
-          <StyledLabelTypography>
-            {isLegacy ? 'Private Network Host' : 'Read-only Host'}
-          </StyledLabelTypography>
-        </Grid>
-        <StyledValueGrid size={{ md: 8, xs: 9 }}>
-          {readOnlyHost()}
-        </StyledValueGrid>
-        <Grid
-          size={{
-            md: 4,
-            xs: 3,
-          }}
-        >
-          <StyledLabelTypography>Port</StyledLabelTypography>
-        </Grid>
-        <StyledValueGrid size={{ md: 8, xs: 9 }}>
+        </ConnectionDetailsRow>
+        <ConnectionDetailsHostRows database={database} />
+        <ConnectionDetailsRow label="Port">
           {database.port}
-        </StyledValueGrid>
-        <Grid
-          size={{
-            md: 4,
-            xs: 3,
-          }}
-        >
-          <StyledLabelTypography>SSL</StyledLabelTypography>
-        </Grid>
-        <StyledValueGrid size={{ md: 8, xs: 9 }}>
+        </ConnectionDetailsRow>
+        <ConnectionDetailsRow label="SSL">
           {database.ssl_connection ? 'ENABLED' : 'DISABLED'}
-        </StyledValueGrid>
+        </ConnectionDetailsRow>
         {displayConnectionType && (
-          <>
-            <Grid
-              size={{
-                md: 4,
-                xs: 3,
-              }}
-            >
-              <StyledLabelTypography>Connection Type</StyledLabelTypography>
-            </Grid>
-            <StyledValueGrid size={{ md: 8, xs: 9 }}>
-              <Box
-                sx={(theme: Theme) => ({
-                  marginRight: theme.spacingFunction(20),
-                })}
-              >
-                {database?.private_network?.vpc_id ? 'VPC' : 'Public'}
-              </Box>
-              <Link
-                to={`/databases/${database?.engine}/${database?.id}/networking`}
-              >
-                View Details
-              </Link>
-            </StyledValueGrid>
-          </>
+          <ConnectionDetailsRow label="Connection Type">
+            {getConnectionTypeContent()}
+          </ConnectionDetailsRow>
         )}
       </StyledGridContainer>
       <div className={classes.actionBtnsCtn}>

--- a/packages/manager/src/features/Databases/constants.ts
+++ b/packages/manager/src/features/Databases/constants.ts
@@ -53,6 +53,15 @@ export const BACKUPS_INVALID_TIME_VALIDATON_TEXT =
 export const BACKUPS_UNABLE_TO_RESTORE_TEXT =
   'You can restore a backup after the first backup is completed.';
 
+export const SUMMARY_HOST_TOOLTIP_COPY =
+  'Use the IPv6 address (AAAA record) for this hostname to avoid network transfer charges when connecting to this database from Linodes within the same region.';
+
+export const SUMMARY_PRIVATE_HOST_COPY =
+  "The private hostname resolves to an internal IP address and can only be used to access the database cluster from other Linode instances within the same VPC. This connection is secured and doesn't incur transfer costs.";
+
+export const SUMMARY_PRIVATE_HOST_LEGACY_COPY =
+  'A private network host and a private IP can only be used to access a Database Cluster from Linodes in the same data center and will not incur transfer costs.';
+
 // Links
 export const LEARN_MORE_LINK_LEGACY =
   'https://techdocs.akamai.com/cloud-computing/docs/manage-access-controls';

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -195,9 +195,17 @@ const makeMockDatabase = (params: PathParams): Database => {
     db.ssl_connection = true;
   }
   const database = databaseFactory.build(db);
+
   if (database.platform !== 'rdbms-default') {
     delete database.private_network;
   }
+
+  if (database.platform === 'rdbms-default' && !!database.private_network) {
+    // When a database is configured with a VPC, the primary host is prepended with 'private-'
+    const privateHost = `private-${database.hosts.primary}`;
+    database.hosts.primary = privateHost;
+  }
+
   return database;
 };
 


### PR DESCRIPTION
## Description 📝
This pull request updates the behavior for the `hostname` field that appears in the `Connection Details` tables in the Database Details Summary and Networking tabs. It also refactors these tables so that they're easier to manage via shared components.

**This following changes were made in this pull request:**

**1. Refactoring the Connection Details tables that appear in the Database Summary and Networking tabs**
  - They now use shared components so they're easier to manage conditionally. 
  - The structure and usage is the same for the rows used in the two tables (ie. render a label and content). The content is the only part that varies and now that's passed down from the parent to a shared component or handled in it's own component entirely (More information on on this below)
  
**2. Updating the logic for the `Host` field so that it displays different variations based on the Database Cluster VPC** configuration. 
- This can now be displayed as `Host`, `Private Host`, or `Public Host` based on the configuration.
- This is controlled by the new `ConnectionDetailsHostRows` shared component (See shared components list below)

**3. For the `Hostname` fields, the display behavior is now synced.** 
- The information tooltip and copy icon that appear for these hostname fields in DatabaseSummary `Connection Details` table now also appear for those same fields in the Networking tab table.

The behavior for all fields except for the hostname fields should still be the same. The only change for them is that the row label and content is now passed down to the `ConnectionDetailsRow` component (For more info, see the shared components list below).

Shared components created in DBaaS for this PR:
 - **ConnectionDetailsRow** - Displays the row label and content. The label and content are provided from the parent component.
 - **ConnectionDetailsHostRows** - Responsible for displaying the different variations of the Hostname fields (ie `Host`, `Private Host`, `Public Host`) using the `ConnectionDetailsRow`

## Changes  🔄

List any change(s) relevant to the reviewer.

- Refactoring the Connection Details tables that appear in the Database Summary and Networking tabs
- Updating the logic for the `Host` field so that it displays different variations based on the Database Cluster VPC configuration. 
- For the `Hostname` fields, the behavior for these fields is now synced. The tooltip and copy icon that appear in the Summary tab also appear for those same field in the Networking connection details table.

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [x] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

10/07/25

## Preview 📷

**Note:** The before and after screenshots in each scenario show the Connection details tables in the Database Details Summary and Networking tab.

**Scenario 1: Database Cluster with No VPC Configured displays `Host` field**
**Summary:**
| Before  | After   |
| ------- | ------- |
|  ![BEFORE-db-summary-no-vpc](https://github.com/user-attachments/assets/7bffea09-97a7-4967-baa9-271e6f637b0e) |  ![AFTER-db-summary-no-vpc](https://github.com/user-attachments/assets/f15cc8c8-bb5f-4004-8ed3-b69ce2a16fc5) |

**Networking:**
| Before  | After   |
| ------- | ------- |
| ![BEFORE-db-networking-no-vpc](https://github.com/user-attachments/assets/2c49f271-e3bb-48ff-a538-c8e8305bd334)  |  ![AFTER-db-networking-no-vpc](https://github.com/user-attachments/assets/24b841ed-2cbc-4096-97dc-5e0c6da00395) |

**Scenario 2. Database Cluster with VPC configured and Public Access set to `false` displays `Private Host` field**
**Summary:**
| Before  | After   |
| ------- | ------- |
| ![BEFORE-db-summary-vpc-public-false](https://github.com/user-attachments/assets/56127ced-c9d6-4355-b550-f0a07fb21847) | ![AFTER-db-summary-vpc-public-false](https://github.com/user-attachments/assets/7ac799e4-abea-46c0-b436-22cad11e7345) |

**Networking:**
| Before  | After   |
| ------- | ------- |
| ![BEFORE-db-networking-vpc-public-false](https://github.com/user-attachments/assets/dfa54f3b-b722-45f4-b8cd-948117177659) | ![AFTER-db-networking-vpc-public-false](https://github.com/user-attachments/assets/6fd569be-1bc1-462e-b9ca-0f2a118f4fd3) |

**Scenario 3. Database Cluster with VPC configured and Public Access set to `true` displays both the `Private Host` and `Public Host` fields**
**Summary:**
| Before  | After   |
| ------- | ------- |
|  ![BEFORE-db-summary-vpc-public-true](https://github.com/user-attachments/assets/7b241ee8-c26a-496a-8775-2315586db1b1) |  ![AFTER-db-summary-vpc-public-true](https://github.com/user-attachments/assets/5d6ce844-1330-4f9c-9e90-f689908490d1) |

**Networking:**
| Before  | After   |
| ------- | ------- |
|  ![BEFORE-db-networking-vpc-public-true](https://github.com/user-attachments/assets/ca537aeb-ee3a-40c8-967a-ef4ffe11cae9) |  ![AFTER-db-networking-vpc-public-true](https://github.com/user-attachments/assets/3c38d6f7-b6d2-4997-9ff5-b52efdf39031) |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Have the `databaseVpc`  feature flag enabled
- Have access to the Databases tab with the ability to create a Database Cluster
- Have VPC and subnets created for a region 
- This should be tested using the staging environment and you'll need to make 3 database clusters for the different scenarios below.
- We'll also want to compare the tables in staging to your local with these 3 clusters so you'll need to have both running with to see staging data.
**Note 1:** I'll provide mock data steps, so you can skip these if you prefer to use mock data.
**Note 2:**  If creating databases, I suggest giving these databases names to indicate the state so they're easy to distinguish (ie. database-with-vpc-public)
- Create a Database with no VPC configuration.
- Create a Database assigning a VPC/Subnet with the `Enable public access` field checkbox `checked`
- Create a Database assigning a VPC/Subnet with the `Enable public access` field checkbox `unchecked`

### Reproduction steps

(How to reproduce the issue, if applicable)

- **N/A**

### Verification steps

(How to verify changes)

**Note:** The `Readonly Host` field is always displayed so it rendering isn't part of these scenarios for the hostname field changes. Only whether the icons for it display in networking.

**Note:** You can use mock data to test the scenarios below. For mock data, you'll need to modify the database instance response to response to reflect each Database VPC configuration scenario. If you created the database clusters in staging, you can skip the mock data configuration steps.

**Scenario 1. Database Cluster with No VPC Configured displays `Host` field**
- [ ] For mock data, no changes are needed as the `private_network` property returned from the database instances request is null by default in the [database.ts file on line 244](https://github.com/linode/manager/blob/develop/packages/manager/src/factories/databases.ts#L244) to:
- [ ] Access the details for this database cluster and view the Summary tab.
- [ ] Verify that, in the `Connection Details` table, the `Host` field is displayed above `Read-only Host` (See Before/After screenshots above)
- [ ] Access the Networking tab and, in the `Manage Networking` section connection details table.
- [ ] Verify that the `Host` field is displayed above `Read-only Host`.
- [ ] Verify that the info tooltip and copy icons are displayed to the right of both the  `Host` and `Read-only Host` field values as they appear for those fields in the in the `Summary` tab.

**Scenario 2. Database Cluster with VPC configured and Public Access set to false displays `Private Host` field**
- [ ] Modify the mock data for a database instance by updating the `private_network` property in the [database.ts file on line 244](https://github.com/linode/manager/blob/develop/packages/manager/src/factories/databases.ts#L244) to:
```javascript
private_network: {
  vpc_id: 1,
  subnet_id: 1,
  public_access: false,
},
```
- [ ] Access the details for this database cluster and view the Summary tab.
- [ ] Verify that, in the `Connection Details` table, the `Private Host` field is displayed above `Read-only Host` (See Before/After screenshots above)
- [ ] Access the Networking tab and, in the `Manage Networking` section connection details table. 
- [ ] Verify that the `Private Host` field is displayed displayed above `Read-only Host`.
- [ ] Verify that the info tooltip and copy icons are displayed to the right of both the `Host` and `Read-only Host` field values as they appear for those fields in the in the `Summary` tab.

**Scenario 3. Database Cluster with VPC configured and Public Access set to true displays both the `Private Host` and `Public Host` fields**
- [ ] Modify the mock data for a database instance by updating the `private_network` property in the [database.ts file on line 244](https://github.com/linode/manager/blob/develop/packages/manager/src/factories/databases.ts#L244) to:
```javascript
private_network: {
  vpc_id: 1,
  subnet_id: 1,
  public_access: true,
},
```
- [ ] Access the details for this database cluster and view the Summary tab.
- [ ] Verify that, in the `Connection Details` table, both the `Private Host` and `Public Host` fields are displayed above `Read-only Host` in that order (See Before/After screenshots above)
- [ ] Verify that for the `Public Host` field, the hostname value starts with `public-` instead of `private-` which is shown in the `Private Host` field hostname value.
- [ ] Access the Networking tab and, in the `Manage Networking` section connection details table.
- [ ] Verify that both the `Private Host` and `Public Host` fields are displayed above `Read-only Host` in that order.
- [ ] Verify that the info tooltip and copy icons are displayed to the right of both the `Private Host`, `Public Host` and `Read-only Host` field values as they appear for those fields in the in the `Summary` tab.

**4. Verify that the other non host-name fields still behave the same way after the refactor**
- [ ] Have local host running and set it to use staging data. 
- [ ] Open the actual staging environment open in a separate tab.
- [ ] Using the database clusters created for the scenarios above, access the Database Details and view the Summary Tab for both windows.
- [ ] Verify that the fields for the `Connection Details` table in the Summary render the same way except for the `Host`, `Private Host`, and/or `Public Host` and `Read-only Host` fields where the display behavior has been updated in this PR.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

-->