### PR TITLE
chore: [M3-10651] - Fix CODEOWNERS rule assignment priority

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,15 @@
+# Default Team
+# This is a catch all: any change that is not captured by a codeowner rule
+# below will result in`@linode/cloud-manager-code-reviewers` being assigned
+# for PR review.
+* @linode/cloud-manager-code-reviewers
+
+# Cypress E2E Tests
+# This is also a catch all: any change to E2E tests outside of the team-owned
+# files and directories will result in `@linode/frontend-sdet` being assigned
+# for PR review.
+/packages/manager/cypress/ @linode/frontend-sdet
+
 # UI Package
 /packages/ui @linode/ui-platform-design-systems
 
@@ -36,9 +48,3 @@
 /packages/manager/cypress/e2e/core/databases @linode/dbaas-ui
 /packages/manager/cypress/support/constants/databases.ts @linode/dbaas-ui
 /packages/manager/cypress/support/intercepts/databases.ts @linode/dbaas-ui
-
-# Cypress E2E Tests
-/packages/manager/cypress/ @linode/frontend-sdet
-
-# Default Team
-* @linode/cloud-manager-code-reviewers


### PR DESCRIPTION
## Description 📝

This moves two of our broader rules (`*` and `/packages/manager/cypress/`) to the top of the `CODEOWNERS` file.

Per GitHub's documentation, [only the last matched CODEOWNERS rule is applied](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#:~:text=If%20you%20want%20to%20match%20two%20or%20more%20code%20owners%20with%20the%20same%20pattern%2C%20all%20the%20code%20owners%20must%20be%20on%20the%20same%20line.%20If%20the%20code%20owners%20are%20not%20on%20the%20same%20line%2C%20the%20pattern%20matches%20only%20the%20last%20mentioned%20code%20owner.) for a given path, so having the wildcard `*` rule at the end resulted in every file being owned by the _Cloud Manager Code Reviewers_ team.

We might want to re-evaluate our rules in case we want to e.g. have multiple code owners for certain paths, but this change should at least resolve the issue with every PR being assigned to the code reviewers team.

Note: there are other errors being reported on the CODEOWNERS file that this PR does not address. They seem to relate to the way our teams are set up but I'm unable to view or change those settings so I'm 100% sure.

## Changes  🔄

- Move `*` and Cypress code owner rules to top of file

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [x] No customers / Not applicable

## Target release date 🗓️

N/A

### Verification steps
🤷‍♂️

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
