### PR TITLE
fix: [M3-10619] - Display tax ids for pdf generation

### DIFF
--- a/packages/manager/.changeset/pr-12942-fixed-1759355205373.md
+++ b/packages/manager/.changeset/pr-12942-fixed-1759355205373.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Always show tax id's when available irrespective of date filtering ([#12942](https://github.com/linode/manager/pull/12942))

--- a/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
@@ -229,27 +229,22 @@ export const printInvoice = async (
       taxes && taxes?.date ? dateConversion(taxes.date) : Infinity;
 
     /**
-     * Users who have identified their country as one of the ones targeted by
-     * one of our tax policies will have a `taxes` with at least a .date.
-     * Customers with no country, or from a country we don't have a tax policy
-     * for, will have a `taxes` of {}, and the following logic will skip them.
+     * Tax data is served from LaunchDarkly feature flags and displayed on invoices.
+     * Country-level tax IDs (like EU VAT, Japanese JCT, etc.) are always displayed
+     * when available, regardless of invoice date.
      *
-     * If taxes.date is defined, and the invoice we're about to print is after
-     * that date, we want to add the customer's tax ID to the invoice.
+     * Provincial/state-level tax IDs still use date filtering to determine when
+     * they should be applied based on local tax policy implementation dates.
      *
-     * If in addition to the above, taxes is defined, it means
-     * we have a corporate tax ID for the country and should display that in the left
-     * side of the header.
+     * The source of truth for all tax data is LaunchDarkly, with examples:
      *
-     * The source of truth for all tax banners is LaunchDarkly, but as an example,
-     * as of 2/20/2020 we have the following cases:
-     *
-     * VAT: Applies only to EU countries; started from 6/1/2019 and we have an EU tax id
-     *  - [M3-8277] For EU customers, invoices will include VAT for B2C transactions and exclude VAT for B2B transactions. Both VAT numbers will be shown on the invoice template for EU countries.
-     * GMT: Applies to both Australia and India, but we only have a tax ID for Australia.
+     * EU VAT: Shows both EU VAT number and Switzerland VAT for B2B customers
+     * Japanese JCT: Shows Japan JCT tax ID and QI Registration number
+     * US/CA: Shows federal tax IDs and state-specific tax IDs when applicable
      */
     const hasTax = !taxes?.date ? true : convertedInvoiceDate > TaxStartDate;
-    const countryTax = hasTax ? taxes?.country_tax : undefined;
+    // Country-level tax IDs are always displayed when available
+    const countryTax = taxes?.country_tax;
     const provincialTax = hasTax
       ? taxes?.provincial_tax_ids?.[account.state]
       : undefined;


### PR DESCRIPTION
## Description 📝
Customers reported that they are unable to view the EU VAT and Swiss VAT on invoices issued in cloud manager since 1st of September.

## Cause
The PDF generator appears to have date-based filtering logic that was preventing tax IDs from displaying. The logic would set `countryTax` to `undefined` when `hasTax` was `false` (based on invoice date vs tax start date). The actual availability of tax data is controlled by LaunchDarkly flag configuration, not by date filtering in the code.

## Changes  🔄
- Always show tax id's when available

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [x] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️
Next release

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <img width="764" height="272" alt="Screenshot 2025-10-01 at 5 36 42 PM" src="https://github.com/user-attachments/assets/0cad3dc3-accb-4704-a9d1-3a00f351c829" /> | <img width="754" height="258" alt="Screenshot 2025-10-01 at 4 23 17 PM" src="https://github.com/user-attachments/assets/4a4c2751-f24a-4b70-9291-c292c42e1268" /> |

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

-->