### PR TITLE
upcoming: [DPS-34980] Fix Destination Name autocomplete in stream form not filtering correctly

### DIFF
--- a/packages/manager/.changeset/pr-12944-upcoming-features-1759397682222.md
+++ b/packages/manager/.changeset/pr-12944-upcoming-features-1759397682222.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Fix Destination Name autocomplete in Create Stream form not filtering correctly ([#12944](https://github.com/linode/manager/pull/12944))

--- a/packages/manager/src/features/Delivery/Streams/StreamForm/Delivery/StreamFormDelivery.tsx
+++ b/packages/manager/src/features/Delivery/Streams/StreamForm/Delivery/StreamFormDelivery.tsx
@@ -149,9 +149,9 @@ export const StreamFormDelivery = () => {
             )}
             placeholder="Create or Select Destination Name"
             renderOption={(props, option) => {
-              const { key, ...optionProps } = props;
+              const { id, ...optionProps } = props;
               return (
-                <li key={key} {...optionProps}>
+                <li {...optionProps} key={id}>
                   {option.create ? (
                     <>
                       <strong>Create&nbsp;</strong> &quot;{option.label}&quot;

--- a/packages/manager/src/features/Delivery/Streams/StreamsLanding.tsx
+++ b/packages/manager/src/features/Delivery/Streams/StreamsLanding.tsx
@@ -253,7 +253,7 @@ export const StreamsLanding = () => {
               {streams?.data.map((stream) => (
                 <StreamTableRow key={stream.id} stream={stream} {...handlers} />
               ))}
-              {streams?.results === 0 && <TableRowEmpty colSpan={6} />}
+              {streams?.results === 0 && <TableRowEmpty colSpan={7} />}
             </TableBody>
           </Table>
           <PaginationFooter


### PR DESCRIPTION
## Description 📝
Destination Name autocomplete wasn't correctly filtering existing Destination Names

## Changes  🔄
- change key in Destination Name autocomplete 


### Scope 🚢

 Upon production release, changes in this PR will be visible to:
- [x] No customers / Not applicable

## Target release date 🗓️

October 2025

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![before](https://github.com/user-attachments/assets/b9c354c5-7087-42c4-ace8-3eb27b156481)|![after](https://github.com/user-attachments/assets/b40b5e5e-8813-4390-83bf-028a53bfbb96)|

## How to test 🧪

### Prerequisites
- Open Local Dev Tools
- Enable MSW, set Base Preset to CRUD
- Apply


### Reproduction steps

(How to reproduce the issue, if applicable)

- Create at least two Destinations with the same name
- Try to filter the Destination Names in Create Stream form

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>