### PR TITLE
test [M3-10521]: Fix failing "alerts-create.spec.ts" test in DevCloud

### DIFF
--- a/packages/manager/cypress/e2e/core/linodes/alerts-create.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/alerts-create.spec.ts
@@ -143,6 +143,7 @@ describe('Create flow when beta alerts enabled by region and feature flag', func
         // cURL tab
         ui.tabList.findTabByTitle('cURL').should('be.visible').click();
         cy.contains('alert').should('not.exist');
+        ui.button.findByTitle('Close').scrollIntoView();
         ui.button
           .findByTitle('Close')
           .should('be.visible')
@@ -318,6 +319,7 @@ describe('Create flow when beta alerts enabled by region and feature flag', func
           cy.contains('system_alerts');
           cy.contains('user_alerts');
         });
+        ui.button.findByTitle('Close').scrollIntoView();
         ui.button
           .findByTitle('Close')
           .should('be.visible')


### PR DESCRIPTION
## Description 📝

One of the tests in alerts-create.spec.ts was failing bc the relevant button was below the fold when the code snippet window opened.

Test now passes in devcloud, and it still passes in dev environment.

## Changes  🔄

Fix is to append .scrollIntoView() to the button. I added it in another place where the same button is retrieved even tho that test is not failing (yet). 

I am fairly confident that the fix will remove the flakiness, as i can get the test to pass in cypress by manually scrolling the window so that the button is above the fold. 

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [x] No customers / Not applicable
 

## How to test 🧪

pnpm run cy:run -s cypress/e2e/core/linodes/alerts-create.spec.ts 
<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

-->