### PR TITLE
test: [M3-10520] - Fix failing maintenance policy test in DevCloud related to hardcoded region ID

### DIFF
--- a/packages/manager/cypress/e2e/core/linodes/maintenance-policy-region-support.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/maintenance-policy-region-support.spec.ts
@@ -16,7 +16,7 @@ import { linodeCreatePage } from 'support/ui/pages';
 import { cleanUp } from 'support/util/cleanup';
 import { createTestLinode } from 'support/util/linodes';
 import { randomLabel } from 'support/util/random';
-import { extendRegion } from 'support/util/regions';
+import { chooseRegion, extendRegion } from 'support/util/regions';
 
 import {
   MAINTENANCE_POLICY_NOT_AVAILABLE_IN_REGION_TEXT,
@@ -182,7 +182,7 @@ describe('maintenance policy region support - Linode Details > Settings', () => 
     // eu-central is known to support maintenance policies
     const linodeCreatePayload = createLinodeRequestFactory.build({
       label: randomLabel(),
-      region: 'eu-central', // Frankfurt, DE - known to support maintenance policies
+      region: chooseRegion({ capabilities: ['Maintenance Policy'] }).id,
     });
 
     cy.defer(() => createTestLinode(linodeCreatePayload)).then((linode) => {


### PR DESCRIPTION
## Description 📝

Fix failing maintenance policy test in DevCloud related to hardcoded region ID

## Changes  🔄

List any change(s) relevant to the reviewer.
- Replace hard-coded region ID 'eu-central' with `chooseRegion()`

## How to test 🧪
```
pnpm cy:run -s "cypress/e2e/core/linodes/maintenance-policy-region-support.spec.ts"
```