### PR TITLE
fix: [M3-10619] - PDF generation fix

### DIFF
--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -20,6 +20,9 @@ export const App = withDocumentTitleProvider(
       window.location.pathname === '/oauth/callback' ||
       window.location.pathname === '/admin/callback';
 
+    const { isLoading } = useInitialRequests();
+    const { areFeatureFlagsLoading } = useSetupFeatureFlags();
+
     if (isAuthCallback) {
       return (
         <ErrorBoundaryFallback>
@@ -28,9 +31,6 @@ export const App = withDocumentTitleProvider(
         </ErrorBoundaryFallback>
       );
     }
-
-    const { isLoading } = useInitialRequests();
-    const { areFeatureFlagsLoading } = useSetupFeatureFlags();
 
     if (isLoading || areFeatureFlagsLoading) {
       return <SplashScreen />;

--- a/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
@@ -229,22 +229,27 @@ export const printInvoice = async (
       taxes && taxes?.date ? dateConversion(taxes.date) : Infinity;
 
     /**
-     * Tax data is served from LaunchDarkly feature flags and displayed on invoices.
-     * Country-level tax IDs (like EU VAT, Japanese JCT, etc.) are always displayed
-     * when available, regardless of invoice date.
+     * Users who have identified their country as one of the ones targeted by
+     * one of our tax policies will have a `taxes` with at least a .date.
+     * Customers with no country, or from a country we don't have a tax policy
+     * for, will have a `taxes` of {}, and the following logic will skip them.
      *
-     * Provincial/state-level tax IDs still use date filtering to determine when
-     * they should be applied based on local tax policy implementation dates.
+     * If taxes.date is defined, and the invoice we're about to print is after
+     * that date, we want to add the customer's tax ID to the invoice.
      *
-     * The source of truth for all tax data is LaunchDarkly, with examples:
+     * If in addition to the above, taxes is defined, it means
+     * we have a corporate tax ID for the country and should display that in the left
+     * side of the header.
      *
-     * EU VAT: Shows both EU VAT number and Switzerland VAT for B2B customers
-     * Japanese JCT: Shows Japan JCT tax ID and QI Registration number
-     * US/CA: Shows federal tax IDs and state-specific tax IDs when applicable
+     * The source of truth for all tax banners is LaunchDarkly, but as an example,
+     * as of 2/20/2020 we have the following cases:
+     *
+     * VAT: Applies only to EU countries; started from 6/1/2019 and we have an EU tax id
+     *  - [M3-8277] For EU customers, invoices will include VAT for B2C transactions and exclude VAT for B2B transactions. Both VAT numbers will be shown on the invoice template for EU countries.
+     * GMT: Applies to both Australia and India, but we only have a tax ID for Australia.
      */
     const hasTax = !taxes?.date ? true : convertedInvoiceDate > TaxStartDate;
-    // Country-level tax IDs are always displayed when available
-    const countryTax = taxes?.country_tax;
+    const countryTax = hasTax ? taxes?.country_tax : undefined;
     const provincialTax = hasTax
       ? taxes?.provincial_tax_ids?.[account.state]
       : undefined;

--- a/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
@@ -244,7 +244,7 @@ export const printInvoice = async (
      */
     const hasTax = !taxes?.date ? true : convertedInvoiceDate > TaxStartDate;
     // Country-level tax IDs are always displayed when available
-    const countryTax = hasTax ? taxes?.country_tax : undefined;
+    const countryTax = taxes?.country_tax;
     const provincialTax = hasTax
       ? taxes?.provincial_tax_ids?.[account.state]
       : undefined;

--- a/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
@@ -244,7 +244,7 @@ export const printInvoice = async (
      */
     const hasTax = !taxes?.date ? true : convertedInvoiceDate > TaxStartDate;
     // Country-level tax IDs are always displayed when available
-    const countryTax = taxes?.country_tax;
+    const countryTax = hasTax ? taxes?.country_tax : undefined;
     const provincialTax = hasTax
       ? taxes?.provincial_tax_ids?.[account.state]
       : undefined;


### PR DESCRIPTION
## Description 📝
Hooks cannot be after conditional code causing the first page load for fetching launch darkly configs to be `undefined`.

## Testing
- In incognito, log into cloud manager
- Change country code to any country in EU
- Download a PDF and observe the tax id's are NOT visible
- Reload the page and try again, observe that they ARE visible

This is because of the placement of the hooks where LD configs would not load on initial app load