### PR TITLE
feat: [UIE-9329] - IAM RBAC: refetch entities

### DIFF
--- a/packages/manager/.changeset/pr-12958-fixed-1759747213086.md
+++ b/packages/manager/.changeset/pr-12958-fixed-1759747213086.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+IAM RBAC: refetch entities endpoint ([#12958](https://github.com/linode/manager/pull/12958))

--- a/packages/manager/src/queries/entities/entities.ts
+++ b/packages/manager/src/queries/entities/entities.ts
@@ -19,6 +19,7 @@ export const useAllAccountEntities = ({
   useQuery<AccountEntity[], APIError[]>({
     enabled,
     ...entitiesQueries.all(params, filter),
+    ...queryPresets.shortLived,
   });
 
 export const useAccountEntities = (params: Params, filter: Filter) =>


### PR DESCRIPTION
## Description 📝

This PR fixes the issue when new created entities are not showed in the select while assigning new role

## Changes  🔄

List any change(s) relevant to the reviewer.

- Ensured that newly created entities are included in the options list when navigating via the navbar (not when opening a new tab)

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [x] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

10/21

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Use IAM account

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] Navigate to /iam/users/{username}/roles to fetch the entities.
- [ ] Go the StackScripts page using the navbar.
- [ ] Create a new StackScript.
- [ ] Go the Assigned Roles Page for a user the navbar.
- [ ] Click the "Assign New Role" button.
- [ ] Select the "stackscript_viewer" role.
- [ ] ...

### Verification steps

(How to verify changes)

- [ ] New created entities are available in the select


<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>