### PR TITLE
upcoming: [DI-27318] - Dimension Filter customization for Object Storage Alerts

### DIFF
--- a/packages/manager/src/factories/cloudpulse/alerts.ts
+++ b/packages/manager/src/factories/cloudpulse/alerts.ts
@@ -312,3 +312,51 @@ export const firewallMetricRulesFactory =
       },
     ],
   });
+
+export const objectStorageMetricCriteria =
+  Factory.Sync.makeFactory<AlertDefinitionMetricCriteria>({
+    label: 'All requests',
+    metric: 'obj_requests_num',
+    unit: 'Count',
+    aggregate_function: 'sum',
+    operator: 'gt',
+    threshold: 1000,
+    dimension_filters: [
+      {
+        label: 'Endpoint',
+        dimension_label: 'endpoint',
+        operator: 'eq',
+        value: 'us-iad-1.linodeobjects.com',
+      },
+      {
+        label: 'Endpoint',
+        dimension_label: 'endpoint',
+        operator: 'in',
+        value: 'ap-west-1.linodeobjects.com,us-iad-1.linodeobjects.com',
+      },
+    ],
+  });
+
+export const objectStorageMetricRules: MetricDefinition[] = [
+  {
+    label: 'All requests',
+    metric_type: 'gauge',
+    metric: 'obj_requests_num',
+    unit: 'Count',
+    scrape_interval: '60s',
+    is_alertable: true,
+    available_aggregate_functions: ['sum'],
+    dimensions: [
+      {
+        label: 'Endpoint',
+        dimension_label: 'endpoint',
+        values: [],
+      },
+      {
+        label: 'Request type',
+        dimension_label: 'request_type',
+        values: ['head', 'get', 'put', 'delete', 'list', 'other'],
+      },
+    ],
+  },
+];

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterValue/DimensionFilterAutocomplete.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterValue/DimensionFilterAutocomplete.test.tsx
@@ -8,15 +8,17 @@ import { renderWithTheme } from 'src/utilities/testHelpers';
 import { DimensionFilterAutocomplete } from './DimensionFilterAutocomplete';
 
 import type { Item } from '../../../constants';
+import type { DimensionFilterAutocompleteProps } from './constants';
 
 const mockOptions: Item<string, string>[] = [
-  { label: 'TCP', value: 'tcp' },
-  { label: 'UDP', value: 'udp' },
+  { label: 'Tcp', value: 'tcp' },
+  { label: 'Udp', value: 'udp' },
 ];
 
 describe('<DimensionFilterAutocomplete />', () => {
-  const defaultProps = {
+  const defaultProps: DimensionFilterAutocompleteProps = {
     name: `rule_criteria.rules.${0}.dimension_filters.%{0}.value`,
+    dimensionLabel: 'protocol',
     disabled: false,
     errorText: '',
     fieldOnBlur: vi.fn(),
@@ -24,9 +26,11 @@ describe('<DimensionFilterAutocomplete />', () => {
     fieldValue: 'tcp',
     multiple: false,
     placeholderText: 'Select a value',
-    values: mockOptions,
-    isLoading: false,
-    isError: false,
+    scope: null,
+    entities: [],
+    selectedRegions: [],
+    serviceType: 'firewall',
+    values: mockOptions.map((o) => o.value),
   };
 
   it('renders with label and placeholder', () => {
@@ -94,9 +98,6 @@ describe('<DimensionFilterAutocomplete />', () => {
     );
 
     await user.click(screen.getByRole('button', { name: 'Open' }));
-    expect(
-      screen.getByRole('option', { name: mockOptions[1].label })
-    ).toBeVisible();
     await user.click(
       screen.getByRole('option', { name: mockOptions[1].label })
     );
@@ -107,51 +108,30 @@ describe('<DimensionFilterAutocomplete />', () => {
       <DimensionFilterAutocomplete
         {...defaultProps}
         fieldOnChange={fieldOnChange}
-        fieldValue={fieldOnChange.mock.calls[0][0]} // simulate form state update
+        fieldValue={fieldOnChange.mock.calls[0][0]}
         multiple
       />
     );
 
     await user.click(screen.getByRole('button', { name: 'Open' }));
-    expect(
-      screen.getByRole('option', { name: mockOptions[0].label })
-    ).toBeVisible();
     await user.click(
       screen.getByRole('option', { name: mockOptions[0].label })
     );
 
-    // Assert both values were selected
     expect(fieldOnChange).toHaveBeenCalledWith(
       `${mockOptions[1].value},${mockOptions[0].value}`
     );
   });
 
-  it('should show loading state when API is loading', async () => {
+  it('should render the error message', () => {
     renderWithTheme(
       <DimensionFilterAutocomplete
         {...defaultProps}
+        errorText={'Failed to fetch the values.'}
         fieldValue={null}
-        isError={false}
-        isLoading={true}
         multiple
       />
     );
-
-    expect(await screen.findByTestId('circle-progress')).toBeVisible();
-  });
-
-  it('should render error message when API call fails', () => {
-    renderWithTheme(
-      <DimensionFilterAutocomplete
-        {...defaultProps}
-        errorText={undefined}
-        fieldValue={null}
-        isError={true}
-        isLoading={false}
-        multiple
-      />
-    );
-
     expect(screen.getByText('Failed to fetch the values.')).toBeVisible();
   });
 });

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterValue/FirewallDimensionFilterAutocomplete.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterValue/FirewallDimensionFilterAutocomplete.test.tsx
@@ -1,0 +1,244 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { vi } from 'vitest';
+
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { FirewallDimensionFilterAutocomplete } from './FirewallDimensionFilterAutocomplete';
+
+const queryMocks = vi.hoisted(() => ({
+  useRegionsQuery: vi.fn(),
+  useFirewallFetchOptions: vi.fn(),
+}));
+
+vi.mock('@linode/queries', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useRegionsQuery: queryMocks.useRegionsQuery.mockReturnValue({ data: [] }),
+}));
+
+vi.mock('./useFirewallFetchOptions', () => ({
+  ...vi.importActual('./useFirewallFetchOptions'),
+  useFirewallFetchOptions: queryMocks.useFirewallFetchOptions,
+}));
+
+import type { DimensionFilterAutocompleteProps } from './constants';
+
+describe('<FirewallDimensionFilterAutocomplete />', () => {
+  const defaultProps: DimensionFilterAutocompleteProps = {
+    name: 'dimension-filter',
+    dimensionLabel: 'linode_id',
+    disabled: false,
+    errorText: undefined,
+    fieldOnBlur: vi.fn(),
+    fieldOnChange: vi.fn(),
+    fieldValue: null,
+    multiple: false,
+    placeholderText: 'Select value',
+    entities: [],
+    scope: 'account',
+    serviceType: 'firewall',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders with options when values are provided', () => {
+    queryMocks.useFirewallFetchOptions.mockReturnValue({
+      values: [
+        { label: 'Linode-1', value: '1' },
+        { label: 'Linode-2', value: '2' },
+      ],
+      isLoading: false,
+      isError: false,
+    });
+
+    renderWithTheme(<FirewallDimensionFilterAutocomplete {...defaultProps} />);
+    expect(screen.getByLabelText(/Value/i)).toBeVisible();
+    expect(screen.getByPlaceholderText('Select value')).toBeVisible();
+  });
+
+  it('calls fieldOnBlur when input is blurred', async () => {
+    queryMocks.useFirewallFetchOptions.mockReturnValue({
+      values: [],
+      isLoading: false,
+      isError: false,
+    });
+
+    const user = userEvent.setup();
+    renderWithTheme(<FirewallDimensionFilterAutocomplete {...defaultProps} />);
+    const input = screen.getByRole('combobox');
+    await user.click(input);
+    await user.tab();
+    expect(defaultProps.fieldOnBlur).toHaveBeenCalled();
+  });
+
+  it('disables the Autocomplete when disabled is true', () => {
+    queryMocks.useFirewallFetchOptions.mockReturnValue({
+      values: [],
+      isLoading: false,
+      isError: false,
+    });
+
+    renderWithTheme(
+      <FirewallDimensionFilterAutocomplete {...defaultProps} disabled />
+    );
+    expect(screen.getByRole('combobox')).toBeDisabled();
+  });
+
+  it('renders error text from props', () => {
+    queryMocks.useFirewallFetchOptions.mockReturnValue({
+      values: [],
+      isLoading: false,
+      isError: false,
+    });
+
+    renderWithTheme(
+      <FirewallDimensionFilterAutocomplete
+        {...defaultProps}
+        errorText="Custom error"
+      />
+    );
+    expect(screen.getByText('Custom error')).toBeVisible();
+  });
+
+  it('renders API error text when isError is true', async () => {
+    queryMocks.useFirewallFetchOptions.mockReturnValue({
+      values: [],
+      isLoading: false,
+      isError: true,
+    });
+
+    renderWithTheme(<FirewallDimensionFilterAutocomplete {...defaultProps} />);
+    expect(
+      await screen.findByText('Failed to fetch the values.')
+    ).toBeVisible();
+  });
+
+  it('shows loading state when fetching values', () => {
+    queryMocks.useFirewallFetchOptions.mockReturnValue({
+      values: [],
+      isLoading: true,
+      isError: false,
+    });
+
+    renderWithTheme(<FirewallDimensionFilterAutocomplete {...defaultProps} />);
+    expect(screen.getByTestId('circle-progress')).toBeVisible();
+  });
+
+  it('calls fieldOnChange with correct value when selecting an option (single)', async () => {
+    queryMocks.useFirewallFetchOptions.mockReturnValue({
+      values: [{ label: 'Linode-1', value: '1' }],
+      isLoading: false,
+      isError: false,
+    });
+
+    const user = userEvent.setup();
+    const fieldOnChange = vi.fn();
+    renderWithTheme(
+      <FirewallDimensionFilterAutocomplete
+        {...defaultProps}
+        fieldOnChange={fieldOnChange}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    await user.click(screen.getByRole('option', { name: /Linode-1/ }));
+    expect(fieldOnChange).toHaveBeenCalledWith('1');
+  });
+
+  it('calls fieldOnChange with multiple values when multiple=true', async () => {
+    queryMocks.useFirewallFetchOptions.mockReturnValue({
+      values: [
+        { label: 'Linode-1', value: '1' },
+        { label: 'Linode-2', value: '2' },
+      ],
+      isLoading: false,
+      isError: false,
+    });
+
+    const user = userEvent.setup();
+    const fieldOnChange = vi.fn();
+
+    const { rerender } = renderWithTheme(
+      <FirewallDimensionFilterAutocomplete
+        {...defaultProps}
+        fieldOnChange={fieldOnChange}
+        fieldValue={null}
+        multiple
+      />
+    );
+
+    // Select first option
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    await user.click(screen.getByRole('option', { name: /Linode-1/ }));
+    expect(fieldOnChange).toHaveBeenCalledWith('1');
+
+    // Rerender with updated form state
+    rerender(
+      <FirewallDimensionFilterAutocomplete
+        {...defaultProps}
+        fieldOnChange={fieldOnChange}
+        fieldValue={fieldOnChange.mock.calls[0][0]}
+        multiple
+      />
+    );
+
+    // Select second option
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    await user.click(screen.getByRole('option', { name: /Linode-2/ }));
+
+    expect(fieldOnChange).toHaveBeenCalledWith('1,2');
+  });
+
+  it('renders and selects option correctly for account scope with dimensionLabel=linode_id', async () => {
+    queryMocks.useFirewallFetchOptions.mockReturnValue({
+      values: [{ label: 'Linode-Account-1', value: 'acc-1' }],
+      isLoading: false,
+      isError: false,
+    });
+
+    const user = userEvent.setup();
+    renderWithTheme(
+      <FirewallDimensionFilterAutocomplete
+        {...defaultProps}
+        dimensionLabel="linode_id"
+        scope="account"
+      />
+    );
+
+    const input = await screen.findByRole('combobox');
+    expect(input).toBeVisible();
+
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    expect(
+      await screen.findByRole('option', { name: 'Linode-Account-1' })
+    ).toBeVisible();
+  });
+
+  it('renders and selects option correctly for account scope with dimensionLabel=region_id', async () => {
+    queryMocks.useFirewallFetchOptions.mockReturnValue({
+      values: [{ label: 'us-east', value: 'us-east' }],
+      isLoading: false,
+      isError: false,
+    });
+
+    const user = userEvent.setup();
+    renderWithTheme(
+      <FirewallDimensionFilterAutocomplete
+        {...defaultProps}
+        dimensionLabel="region_id"
+        scope="account"
+      />
+    );
+
+    const input = await screen.findByRole('combobox');
+    expect(input).toBeVisible();
+
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    expect(
+      await screen.findByRole('option', { name: 'us-east' })
+    ).toBeVisible();
+  });
+});

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterValue/FirewallDimensionFilterAutocomplete.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterValue/FirewallDimensionFilterAutocomplete.tsx
@@ -1,11 +1,9 @@
+import { useRegionsQuery } from '@linode/queries';
 import { Autocomplete } from '@linode/ui';
-import React, { useMemo } from 'react';
+import React from 'react';
 
-import {
-  getStaticOptions,
-  handleValueChange,
-  resolveSelectedValues,
-} from './utils';
+import { useFirewallFetchOptions } from './useFirewallFetchOptions';
+import { handleValueChange, resolveSelectedValues } from './utils';
 
 import type { DimensionFilterAutocompleteProps } from './constants';
 
@@ -13,10 +11,14 @@ import type { DimensionFilterAutocompleteProps } from './constants';
  * Renders an Autocomplete input field for the DimensionFilter value field.
  * This component supports both single and multiple selection based on config.
  */
-export const DimensionFilterAutocomplete = (
+export const FirewallDimensionFilterAutocomplete = (
   props: DimensionFilterAutocompleteProps
 ) => {
   const {
+    dimensionLabel,
+    serviceType,
+    scope,
+    entities,
     multiple,
     name,
     fieldOnChange,
@@ -25,24 +27,29 @@ export const DimensionFilterAutocomplete = (
     placeholderText,
     errorText,
     fieldValue,
-    serviceType,
-    dimensionLabel,
-    values,
   } = props;
 
-  const options = useMemo(
-    () => getStaticOptions(serviceType, dimensionLabel ?? '', values ?? []),
-    [dimensionLabel, serviceType, values]
-  );
+  const { data: regions } = useRegionsQuery();
+  const { values, isLoading, isError } = useFirewallFetchOptions({
+    dimensionLabel,
+    regions,
+    entities,
+    serviceType,
+    type: 'alerts',
+    scope,
+  });
   return (
     <Autocomplete
       data-qa-dimension-filter={`${name}-value`}
       data-testid="value"
       disabled={disabled}
-      errorText={errorText}
+      errorText={
+        errorText ?? (isError ? 'Failed to fetch the values.' : undefined)
+      }
       isOptionEqualToValue={(option, value) => value.value === option.value}
       label="Value"
       limitTags={1}
+      loading={!disabled && isLoading && !isError}
       multiple={multiple}
       onBlur={fieldOnBlur}
       onChange={(_, selected, operation) => {
@@ -53,10 +60,10 @@ export const DimensionFilterAutocomplete = (
         );
         fieldOnChange(newValue);
       }}
-      options={options}
+      options={values}
       placeholder={placeholderText}
       sx={{ flex: 1 }}
-      value={resolveSelectedValues(options, fieldValue, multiple ?? false)}
+      value={resolveSelectedValues(values, fieldValue, multiple ?? false)}
     />
   );
 };

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterValue/ObjectStorageDimensionFilterAutocomplete.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterValue/ObjectStorageDimensionFilterAutocomplete.test.tsx
@@ -1,0 +1,222 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { vi } from 'vitest';
+
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { ObjectStorageDimensionFilterAutocomplete } from './ObjectStorageDimensionFilterAutocomplete';
+
+vi.mock('@linode/queries', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useRegionsQuery: queryMocks.useRegionsQuery.mockReturnValue({ data: [] }),
+}));
+
+vi.mock('./useObjectStorageFetchOptions', () => ({
+  ...vi.importActual('./useObjectStorageFetchOptions'),
+  useObjectStorageFetchOptions: queryMocks.useObjectStorageFetchOptions,
+}));
+
+const queryMocks = vi.hoisted(() => ({
+  useRegionsQuery: vi.fn(),
+  useObjectStorageFetchOptions: vi.fn(),
+}));
+
+import type { DimensionFilterAutocompleteProps } from './constants';
+
+describe('<ObjectStorageDimensionFilterAutocomplete />', () => {
+  const defaultProps: DimensionFilterAutocompleteProps = {
+    name: 'dimension-filter',
+    dimensionLabel: 'endpoint',
+    disabled: false,
+    errorText: undefined,
+    fieldOnBlur: vi.fn(),
+    fieldOnChange: vi.fn(),
+    fieldValue: null,
+    multiple: false,
+    placeholderText: 'Select endpoint',
+    entities: ['bucket-1'],
+    scope: 'entity',
+    selectedRegions: ['us-east'],
+    serviceType: 'objectstorage',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders with options when values are provided', () => {
+    queryMocks.useObjectStorageFetchOptions.mockReturnValue({
+      values: [
+        {
+          label: 'us-east-1.linodeobjects.com',
+          value: 'us-east-1.linodeobjects.com',
+        },
+        {
+          label: 'us-west-1.linodeobjects.com',
+          value: 'us-west-1.linodeobjects.com',
+        },
+      ],
+      isLoading: false,
+      isError: false,
+    });
+
+    renderWithTheme(
+      <ObjectStorageDimensionFilterAutocomplete {...defaultProps} />
+    );
+    expect(screen.getByLabelText(/Value/i)).toBeVisible();
+    expect(screen.getByPlaceholderText('Select endpoint')).toBeVisible();
+  });
+
+  it('calls fieldOnBlur when input is blurred', async () => {
+    queryMocks.useObjectStorageFetchOptions.mockReturnValue({
+      values: [],
+      isLoading: false,
+      isError: false,
+    });
+
+    const user = userEvent.setup();
+    renderWithTheme(
+      <ObjectStorageDimensionFilterAutocomplete {...defaultProps} />
+    );
+    const input = screen.getByRole('combobox');
+    await user.click(input);
+    await user.tab();
+    expect(defaultProps.fieldOnBlur).toHaveBeenCalled();
+  });
+
+  it('disables the Autocomplete when disabled is true', () => {
+    queryMocks.useObjectStorageFetchOptions.mockReturnValue({
+      values: [],
+      isLoading: false,
+      isError: false,
+    });
+
+    renderWithTheme(
+      <ObjectStorageDimensionFilterAutocomplete {...defaultProps} disabled />
+    );
+    expect(screen.getByRole('combobox')).toBeDisabled();
+  });
+
+  it('renders error text from props', () => {
+    queryMocks.useObjectStorageFetchOptions.mockReturnValue({
+      values: [],
+      isLoading: false,
+      isError: false,
+    });
+
+    renderWithTheme(
+      <ObjectStorageDimensionFilterAutocomplete
+        {...defaultProps}
+        errorText="Something went wrong"
+      />
+    );
+    expect(screen.getByText('Something went wrong')).toBeVisible();
+  });
+
+  it('renders API error text when isError is true', async () => {
+    queryMocks.useObjectStorageFetchOptions.mockReturnValue({
+      values: [],
+      isLoading: false,
+      isError: true,
+    });
+
+    renderWithTheme(
+      <ObjectStorageDimensionFilterAutocomplete {...defaultProps} />
+    );
+    expect(
+      await screen.findByText('Failed to fetch Object Storage endpoints.')
+    ).toBeVisible();
+  });
+
+  it('shows loading state when fetching values', () => {
+    queryMocks.useObjectStorageFetchOptions.mockReturnValue({
+      values: [],
+      isLoading: true,
+      isError: false,
+    });
+
+    renderWithTheme(
+      <ObjectStorageDimensionFilterAutocomplete {...defaultProps} />
+    );
+    expect(screen.getByTestId('circle-progress')).toBeVisible();
+  });
+
+  it('calls fieldOnChange with correct value when selecting an option (single)', async () => {
+    queryMocks.useObjectStorageFetchOptions.mockReturnValue({
+      values: [
+        {
+          label: 'us-east-1.linodeobjects.com',
+          value: 'us-east-1.linodeobjects.com',
+        },
+      ],
+      isLoading: false,
+      isError: false,
+    });
+
+    const user = userEvent.setup();
+    const fieldOnChange = vi.fn();
+    renderWithTheme(
+      <ObjectStorageDimensionFilterAutocomplete
+        {...defaultProps}
+        fieldOnChange={fieldOnChange}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    await user.click(screen.getByRole('option', { name: /us-east-1/ }));
+    expect(fieldOnChange).toHaveBeenCalledWith('us-east-1.linodeobjects.com');
+  });
+
+  it('calls fieldOnChange with multiple values when multiple=true', async () => {
+    queryMocks.useObjectStorageFetchOptions.mockReturnValue({
+      values: [
+        {
+          label: 'us-east-1.linodeobjects.com',
+          value: 'us-east-1.linodeobjects.com',
+        },
+        {
+          label: 'us-west-1.linodeobjects.com',
+          value: 'us-west-1.linodeobjects.com',
+        },
+      ],
+      isLoading: false,
+      isError: false,
+    });
+
+    const user = userEvent.setup();
+    const fieldOnChange = vi.fn();
+
+    const { rerender } = renderWithTheme(
+      <ObjectStorageDimensionFilterAutocomplete
+        {...defaultProps}
+        fieldOnChange={fieldOnChange}
+        fieldValue={null}
+        multiple
+      />
+    );
+
+    // Select first option
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    await user.click(screen.getByRole('option', { name: /us-east-1/ }));
+    expect(fieldOnChange).toHaveBeenCalledWith('us-east-1.linodeobjects.com');
+
+    // Rerender with updated form state
+    rerender(
+      <ObjectStorageDimensionFilterAutocomplete
+        {...defaultProps}
+        fieldOnChange={fieldOnChange}
+        fieldValue={fieldOnChange.mock.calls[0][0]}
+        multiple
+      />
+    );
+
+    // Select second option
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    await user.click(screen.getByRole('option', { name: /us-west-1/ }));
+
+    expect(fieldOnChange).toHaveBeenCalledWith(
+      'us-east-1.linodeobjects.com,us-west-1.linodeobjects.com'
+    );
+  });
+});

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterValue/ObjectStorageDimensionFilterAutocomplete.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterValue/ObjectStorageDimensionFilterAutocomplete.tsx
@@ -1,22 +1,20 @@
+import { useRegionsQuery } from '@linode/queries';
 import { Autocomplete } from '@linode/ui';
-import React, { useMemo } from 'react';
+import React from 'react';
 
-import {
-  getStaticOptions,
-  handleValueChange,
-  resolveSelectedValues,
-} from './utils';
+import { useObjectStorageFetchOptions } from './useObjectStorageFetchOptions';
+import { handleValueChange, resolveSelectedValues } from './utils';
 
 import type { DimensionFilterAutocompleteProps } from './constants';
 
 /**
- * Renders an Autocomplete input field for the DimensionFilter value field.
- * This component supports both single and multiple selection based on config.
+ * Autocomplete for Object Storage endpoints.
  */
-export const DimensionFilterAutocomplete = (
+export const ObjectStorageDimensionFilterAutocomplete = (
   props: DimensionFilterAutocompleteProps
 ) => {
   const {
+    dimensionLabel,
     multiple,
     name,
     fieldOnChange,
@@ -24,25 +22,37 @@ export const DimensionFilterAutocomplete = (
     fieldOnBlur,
     placeholderText,
     errorText,
+    entities,
     fieldValue,
+    scope,
+    selectedRegions,
     serviceType,
-    dimensionLabel,
-    values,
   } = props;
 
-  const options = useMemo(
-    () => getStaticOptions(serviceType, dimensionLabel ?? '', values ?? []),
-    [dimensionLabel, serviceType, values]
-  );
+  const { data: regions } = useRegionsQuery();
+  const { values, isLoading, isError } = useObjectStorageFetchOptions({
+    entities,
+    dimensionLabel,
+    regions,
+    type: 'alerts',
+    scope,
+    selectedRegions,
+    serviceType,
+  });
+
   return (
     <Autocomplete
       data-qa-dimension-filter={`${name}-value`}
       data-testid="value"
       disabled={disabled}
-      errorText={errorText}
+      errorText={
+        errorText ??
+        (isError ? 'Failed to fetch Object Storage endpoints.' : undefined)
+      }
       isOptionEqualToValue={(option, value) => value.value === option.value}
       label="Value"
       limitTags={1}
+      loading={!disabled && isLoading && !isError}
       multiple={multiple}
       onBlur={fieldOnBlur}
       onChange={(_, selected, operation) => {
@@ -53,10 +63,10 @@ export const DimensionFilterAutocomplete = (
         );
         fieldOnChange(newValue);
       }}
-      options={options}
+      options={values}
       placeholder={placeholderText}
       sx={{ flex: 1 }}
-      value={resolveSelectedValues(options, fieldValue, multiple ?? false)}
+      value={resolveSelectedValues(values, fieldValue, multiple ?? false)}
     />
   );
 };

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterValue/ValueFieldRenderer.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterValue/ValueFieldRenderer.tsx
@@ -1,6 +1,5 @@
-import { useRegionsQuery } from '@linode/queries';
 import { TextField } from '@linode/ui';
-import React, { useMemo } from 'react';
+import React from 'react';
 
 import {
   MULTISELECT_PLACEHOLDER_TEXT,
@@ -9,8 +8,9 @@ import {
   valueFieldConfig,
 } from './constants';
 import { DimensionFilterAutocomplete } from './DimensionFilterAutocomplete';
-import { useFetchOptions } from './useFetchOptions';
-import { getOperatorGroup, getStaticOptions } from './utils';
+import { FirewallDimensionFilterAutocomplete } from './FirewallDimensionFilterAutocomplete';
+import { ObjectStorageDimensionFilterAutocomplete } from './ObjectStorageDimensionFilterAutocomplete';
+import { getOperatorGroup } from './utils';
 
 import type { OperatorGroup, ValueFieldConfig } from './constants';
 import type {
@@ -53,7 +53,6 @@ interface ValueFieldRendererProps {
    * Callback fired when the value changes.
    */
   onChange: (value: string | string[]) => void;
-
   /**
    * The operator used in the current filter. Used to determine the type of input to show.
    */
@@ -70,7 +69,6 @@ interface ValueFieldRendererProps {
    * Service type of the alert
    */
   serviceType?: CloudPulseServiceType | null;
-
   /**
    * The currently selected value for the input field.
    */
@@ -96,6 +94,7 @@ export const ValueFieldRenderer = (props: ValueFieldRendererProps) => {
     operator,
     value,
     values,
+    selectedRegions,
   } = props;
   // Use operator group for config lookup
   const operatorGroup = getOperatorGroup(operator);
@@ -111,25 +110,7 @@ export const ValueFieldRenderer = (props: ValueFieldRendererProps) => {
     // 3. No dimension-specific config & values present → use *
     dimensionConfig = valueFieldConfig['*'];
   }
-  const { data: regions } = useRegionsQuery();
   const config = dimensionConfig[operatorGroup];
-  const customFetchItems = useFetchOptions({
-    dimensionLabel,
-    regions,
-    entities,
-    serviceType,
-    type: 'alerts',
-    scope,
-  });
-  const staticOptions = useMemo(
-    () =>
-      getStaticOptions(
-        serviceType ?? undefined,
-        dimensionLabel ?? '',
-        values ?? []
-      ),
-    [dimensionLabel, serviceType, values]
-  );
   if (!config) return null;
 
   if (config.type === 'textfield') {
@@ -158,25 +139,60 @@ export const ValueFieldRenderer = (props: ValueFieldRendererProps) => {
     const autocompletePlaceholder = config.multiple
       ? MULTISELECT_PLACEHOLDER_TEXT
       : SINGLESELECT_PLACEHOLDER_TEXT;
-    const { values, isLoading, isError } = config.useCustomFetch
-      ? customFetchItems
-      : { values: staticOptions, isLoading: false, isError: false };
-    return (
-      <DimensionFilterAutocomplete
-        disabled={disabled}
-        errorText={errorText}
-        fieldOnBlur={onBlur}
-        fieldOnChange={onChange}
-        fieldValue={value}
-        isError={isError}
-        isLoading={isLoading}
-        multiple={config.multiple}
-        name={name}
-        placeholderText={config.placeholder ?? autocompletePlaceholder}
-        values={values}
-      />
-    );
-  }
 
+    switch (config.useCustomFetch) {
+      case 'firewall':
+        return (
+          <FirewallDimensionFilterAutocomplete
+            dimensionLabel={dimensionLabel}
+            disabled={disabled}
+            entities={entities}
+            errorText={errorText}
+            fieldOnBlur={onBlur}
+            fieldOnChange={onChange}
+            fieldValue={value}
+            multiple={config.multiple}
+            name={name}
+            placeholderText={config.placeholder ?? autocompletePlaceholder}
+            scope={scope}
+            serviceType={serviceType ?? null}
+          />
+        );
+      case 'objectstorage':
+        return (
+          <ObjectStorageDimensionFilterAutocomplete
+            dimensionLabel={dimensionLabel}
+            disabled={disabled}
+            entities={entities ?? []}
+            errorText={errorText}
+            fieldOnBlur={onBlur}
+            fieldOnChange={onChange}
+            fieldValue={value}
+            multiple={config.multiple}
+            name={name}
+            placeholderText={config.placeholder ?? autocompletePlaceholder}
+            scope={scope}
+            selectedRegions={selectedRegions}
+            serviceType={serviceType ?? null}
+          />
+        );
+      default:
+        return (
+          <DimensionFilterAutocomplete
+            dimensionLabel={dimensionLabel}
+            disabled={disabled}
+            errorText={errorText}
+            fieldOnBlur={onBlur}
+            fieldOnChange={onChange}
+            fieldValue={value}
+            multiple={config.multiple}
+            name={name}
+            placeholderText={config.placeholder ?? autocompletePlaceholder}
+            serviceType={serviceType ?? null}
+            values={values}
+          />
+        );
+    }
+  }
   return null;
 };

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterValue/constants.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterValue/constants.ts
@@ -16,6 +16,11 @@ import {
 } from '../../../constants';
 
 import type { Item } from '../../../constants';
+import type {
+  AlertDefinitionScope,
+  CloudPulseServiceType,
+  Region,
+} from '@linode/api-v4';
 
 export const MULTISELECT_PLACEHOLDER_TEXT = 'Select Values';
 export const TEXTFIELD_PLACEHOLDER_TEXT = 'Enter a Value';
@@ -96,7 +101,7 @@ export interface AutocompleteConfig extends BaseConfig {
   /**
    * Flag to use a custom fetch function instead of the static options.
    */
-  useCustomFetch?: boolean;
+  useCustomFetch?: string;
 }
 
 /**
@@ -155,7 +160,7 @@ export const valueFieldConfig: ValueFieldConfigMap = {
     eq_neq: {
       type: 'autocomplete',
       multiple: false,
-      useCustomFetch: true,
+      useCustomFetch: 'firewall',
     },
     startswith_endswith: {
       type: 'textfield',
@@ -164,7 +169,7 @@ export const valueFieldConfig: ValueFieldConfigMap = {
     in: {
       type: 'autocomplete',
       multiple: true,
-      useCustomFetch: true,
+      useCustomFetch: 'firewall',
     },
     '*': {
       type: 'textfield',
@@ -175,7 +180,7 @@ export const valueFieldConfig: ValueFieldConfigMap = {
     eq_neq: {
       type: 'autocomplete',
       multiple: false,
-      useCustomFetch: true,
+      useCustomFetch: 'firewall',
     },
     startswith_endswith: {
       type: 'textfield',
@@ -185,7 +190,7 @@ export const valueFieldConfig: ValueFieldConfigMap = {
     in: {
       type: 'autocomplete',
       multiple: true,
-      useCustomFetch: true,
+      useCustomFetch: 'firewall',
     },
     '*': {
       type: 'textfield',
@@ -252,7 +257,7 @@ export const valueFieldConfig: ValueFieldConfigMap = {
     eq_neq: {
       type: 'autocomplete',
       multiple: false,
-      useCustomFetch: true,
+      useCustomFetch: 'firewall',
     },
     startswith_endswith: {
       type: 'textfield',
@@ -262,7 +267,28 @@ export const valueFieldConfig: ValueFieldConfigMap = {
     in: {
       type: 'autocomplete',
       multiple: true,
-      useCustomFetch: true,
+      useCustomFetch: 'firewall',
+    },
+    '*': {
+      type: 'textfield',
+      inputType: 'text',
+    },
+  },
+  endpoint: {
+    eq_neq: {
+      type: 'autocomplete',
+      multiple: false,
+      useCustomFetch: 'objectstorage',
+    },
+    startswith_endswith: {
+      type: 'textfield',
+      placeholder: 'e.g., us-east-1.linodeobjects.com',
+      inputType: 'text',
+    },
+    in: {
+      type: 'autocomplete',
+      multiple: true,
+      useCustomFetch: 'objectstorage',
     },
     '*': {
       type: 'textfield',
@@ -311,4 +337,94 @@ export interface FetchOptions {
   isError: boolean;
   isLoading: boolean;
   values: Item<string, string>[];
+}
+
+export interface FetchOptionsProps {
+  /**
+   * The dimension label determines the filtering logic and return type.
+   */
+  dimensionLabel: null | string;
+  /**
+   * List of firewall entity IDs to filter on.
+   */
+  entities?: string[];
+  /**
+   * List of regions to filter on.
+   */
+  regions?: Region[];
+  /**
+   * Scope of fetching: account (all resources) or entity (filtered subset).
+   */
+  scope?: AlertDefinitionScope | null;
+  /**
+   * List of user selected regions for region scope.
+   */
+  selectedRegions?: null | string[];
+  /**
+   * Service to apply specific transformations to dimension values.
+   */
+  serviceType?: CloudPulseServiceType | null;
+  /**
+   * The type of monitoring to filter on.
+   */
+  type: 'alerts' | 'metrics';
+}
+
+export interface DimensionFilterAutocompleteProps {
+  /**
+   * The current selected dimension label.
+   */
+  dimensionLabel: null | string;
+  /**
+   * Whether the autocomplete input should be disabled.
+   */
+  disabled: boolean;
+  /**
+   * List of entity IDs selected in the entity scope.
+   */
+  entities?: string[];
+  /**
+   * Optional error message to display beneath the input.
+   */
+  errorText?: string;
+  /**
+   * Handler function called on input blur.
+   */
+  fieldOnBlur: () => void;
+  /**
+   * Callback triggered when the user selects a new value(s).
+   */
+  fieldOnChange: (newValue: string | string[]) => void;
+  /**
+   * Current raw string value (or null) from the form state.
+   */
+  fieldValue: null | string;
+  /**
+   * To control single-select/multi-select in the Autocomplete.
+   */
+  multiple?: boolean;
+  /**
+   * Name of the field set in the form.
+   */
+  name: string;
+  /**
+   * Placeholder text to display when no selection is made.
+   */
+  placeholderText: string;
+  /**
+   * Scope of the alert to handle all use-cases.
+   */
+  scope?: AlertDefinitionScope | null;
+  /**
+   * List of selected regions under the region scope.
+   */
+  selectedRegions?: null | string[];
+  /**
+   * Service type of the alert.
+   */
+  serviceType: CloudPulseServiceType | null;
+  /**
+   * The list of pre-defined values for static options.
+   */
+  values?: null | string[];
 }

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterValue/useFirewallFetchOptions.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterValue/useFirewallFetchOptions.ts
@@ -11,45 +11,16 @@ import {
   getVPCSubnets,
 } from './utils';
 
-import type { FetchOptions } from './constants';
-import type {
-  AlertDefinitionScope,
-  CloudPulseServiceType,
-  Filter,
-  Region,
-} from '@linode/api-v4';
-interface FetchOptionsProps {
-  /**
-   * The dimension label determines the filtering logic and return type.
-   */
-  dimensionLabel: null | string;
-  /**
-   * List of firewall entity IDs to filter on.
-   */
-  entities?: string[];
-  /**
-   * List of regions to filter on.
-   */
-  regions?: Region[];
-  /**
-   * Scope of fetching: account (all resources) or entity (filtered subset).
-   */
-  scope?: AlertDefinitionScope | null;
-  /**
-   * Service to apply specific transformations to dimension values.
-   */
-  serviceType?: CloudPulseServiceType | null;
-  /**
-   * The type of monitoring to filter on.
-   */
-  type: 'alerts' | 'metrics';
-}
+import type { FetchOptions, FetchOptionsProps } from './constants';
+import type { Filter } from '@linode/api-v4';
 
 /**
  * Custom hook to return selectable options based on the dimension type.
  * Handles fetching and transforming data for edge-cases.
  */
-export function useFetchOptions(props: FetchOptionsProps): FetchOptions {
+export function useFirewallFetchOptions(
+  props: FetchOptionsProps
+): FetchOptions {
   const { dimensionLabel, regions, entities, serviceType, type, scope } = props;
 
   const supportedRegionIds =
@@ -85,7 +56,6 @@ export function useFetchOptions(props: FetchOptionsProps): FetchOptions {
     filterLabels.includes(dimensionLabel ?? ''),
     'firewall'
   );
-
   // Decide firewall resource IDs based on scope
   const filteredFirewallParentEntityIds = useMemo(() => {
     const selectedEntities =

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterValue/useObjectStorageFetchOptions.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterValue/useObjectStorageFetchOptions.ts
@@ -1,0 +1,64 @@
+import { useResourcesQuery } from 'src/queries/cloudpulse/resources';
+
+import {
+  getEndpointOptions,
+  getOfflineRegionFilteredResources,
+} from '../../../Utils/AlertResourceUtils';
+import { filterRegionByServiceType } from '../../../Utils/utils';
+import { scopeBasedFilteredBuckets } from './utils';
+
+import type { FetchOptions, FetchOptionsProps } from './constants';
+/**
+ * Fetch selectable options for Object Storage dimensions (currently endpoints only).
+ */
+export function useObjectStorageFetchOptions(
+  props: FetchOptionsProps
+): FetchOptions {
+  const { dimensionLabel, regions, entities, type, scope, selectedRegions } =
+    props;
+
+  const {
+    data: buckets,
+    isLoading,
+    isError,
+  } = useResourcesQuery(dimensionLabel === 'endpoint', 'objectstorage');
+
+  if (dimensionLabel !== 'endpoint') {
+    return { values: [], isLoading: false, isError: false };
+  }
+
+  // Offline filter buckets by supported regions
+  const supportedRegionIds =
+    (regions &&
+      filterRegionByServiceType(type, regions, 'objectstorage').map(
+        ({ id }) => id
+      )) ||
+    [];
+  const regionFilteredBuckets = getOfflineRegionFilteredResources(
+    buckets ?? [],
+    supportedRegionIds
+  );
+
+  // Filtering the buckets based on the scope
+  const filteredBuckets = scopeBasedFilteredBuckets({
+    scope: scope ?? null,
+    buckets: regionFilteredBuckets,
+    entities,
+    selectedRegions,
+  });
+
+  // Build endpoint list from the filtered buckets
+  const endpoints: string[] = getEndpointOptions(filteredBuckets, true, []);
+
+  // Convert to <Item<string,string>>[]
+  const values = endpoints.map((endpoint) => ({
+    label: endpoint,
+    value: endpoint,
+  }));
+
+  return {
+    values,
+    isLoading,
+    isError,
+  };
+}

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterValue/utils.test.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterValue/utils.test.ts
@@ -9,6 +9,7 @@ import {
   getStaticOptions,
   handleValueChange,
   resolveSelectedValues,
+  scopeBasedFilteredBuckets,
 } from './utils';
 
 import type { Linode } from '@linode/api-v4';
@@ -103,7 +104,7 @@ describe('Utils', () => {
     });
 
     it('should return empty array if input is null', () => {
-      expect(getStaticOptions('linode', 'dim', null)).toEqual([]);
+      expect(getStaticOptions('linode', 'dim', [])).toEqual([]);
     });
   });
 
@@ -187,6 +188,96 @@ describe('Utils', () => {
           value: 'us-west',
         },
       ]);
+    });
+  });
+
+  describe('scopeBasedFilteredBuckets', () => {
+    const buckets: CloudPulseResources[] = [
+      { label: 'bucket-1', id: 'bucket-1', region: 'us-east' },
+      { label: 'bucket-2', id: 'bucket-2', region: 'us-west' },
+      { label: 'bucket-3', id: 'bucket-3', region: 'eu-central' },
+    ];
+
+    it('returns all buckets for account scope', () => {
+      const result = scopeBasedFilteredBuckets({
+        scope: 'account',
+        buckets,
+      });
+      expect(result).toEqual(buckets);
+    });
+
+    it('filters buckets by entity IDs for entity scope', () => {
+      const result = scopeBasedFilteredBuckets({
+        scope: 'entity',
+        buckets,
+        entities: ['bucket-1', 'bucket-3'],
+      });
+      expect(result).toEqual([
+        { id: 'bucket-1', label: 'bucket-1', region: 'us-east' },
+        { id: 'bucket-3', label: 'bucket-3', region: 'eu-central' },
+      ]);
+    });
+
+    it('returns empty array if no entities match for entity scope', () => {
+      const result = scopeBasedFilteredBuckets({
+        scope: 'entity',
+        buckets,
+        entities: ['bucket-99'],
+      });
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array if entities is undefined for entity scope', () => {
+      const result = scopeBasedFilteredBuckets({
+        scope: 'entity',
+        buckets,
+      });
+      expect(result).toEqual([]);
+    });
+
+    it('filters buckets by region IDs for region scope', () => {
+      const result = scopeBasedFilteredBuckets({
+        scope: 'region',
+        buckets,
+        selectedRegions: ['us-east', 'eu-central'],
+      });
+      expect(result).toEqual([
+        { id: 'bucket-1', label: 'bucket-1', region: 'us-east' },
+        { id: 'bucket-3', label: 'bucket-3', region: 'eu-central' },
+      ]);
+    });
+
+    it('returns empty array if no regions match for region scope', () => {
+      const result = scopeBasedFilteredBuckets({
+        scope: 'region',
+        buckets,
+        selectedRegions: ['ap-south'],
+      });
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array if selectedRegions is undefined for region scope', () => {
+      const result = scopeBasedFilteredBuckets({
+        scope: 'region',
+        buckets,
+      });
+      expect(result).toEqual([]);
+    });
+
+    it('returns all buckets for null scope', () => {
+      const result = scopeBasedFilteredBuckets({
+        scope: null,
+        buckets,
+      });
+      expect(result).toEqual(buckets);
+    });
+
+    it('returns all buckets for unrecognized scope', () => {
+      const result = scopeBasedFilteredBuckets({
+        scope: null,
+        buckets,
+      });
+      expect(result).toEqual(buckets);
     });
   });
 });

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterValue/utils.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/DimensionFilterValue/utils.ts
@@ -3,6 +3,7 @@ import { transformDimensionValue } from '../../../Utils/utils';
 import type { Item } from '../../../constants';
 import type { OperatorGroup } from './constants';
 import type {
+  AlertDefinitionScope,
   CloudPulseServiceType,
   DimensionFilterOperatorType,
   Linode,
@@ -77,9 +78,9 @@ export const getOperatorGroup = (
  * @returns - List of label/value option objects.
  */
 export const getStaticOptions = (
-  serviceType: CloudPulseServiceType | undefined,
+  serviceType: CloudPulseServiceType | null,
   dimensionLabel: string,
-  values: null | string[]
+  values: string[]
 ): Item<string, string>[] => {
   return (
     values?.map((val: string) => ({
@@ -90,7 +91,7 @@ export const getStaticOptions = (
 };
 
 /**
- * Filters firewall resources and returns matching entity IDs.
+ * Filters firewall resources and returns matching parent entity IDs.
  * @param firewallResources - List of firewall resource objects.
  * @param entities - List of target firewall entity IDs.
  * @returns - Flattened array of matching entity IDs.
@@ -152,4 +153,52 @@ export const getVPCSubnets = (vpcs: VPC[]): Item<string, string>[] => {
       value: String(subnetId),
     }))
   );
+};
+
+interface ScopeBasedFilteredBucketsProps {
+  /**
+   * The full list of available CloudPulse resources (buckets).
+   */
+  buckets: CloudPulseResources[];
+  /**
+   * A list of entity IDs (bucket IDs) to filter by when scope is `entity`.
+   */
+  entities?: string[];
+  /**
+   * The scope of the alert definition (`account`, `entity`, `region`, or `null`).
+   */
+  scope: AlertDefinitionScope | null;
+  /**
+   * A list of region IDs to filter by when scope is `region`.
+   */
+  selectedRegions?: null | string[];
+}
+
+/**
+ * Filters a list of Object Storage buckets based on the given alert definition scope.
+ *
+ * @param props - Object containing filter parameters.
+ * @returns A filtered list of buckets based on the provided scope.
+ */
+export const scopeBasedFilteredBuckets = (
+  props: ScopeBasedFilteredBucketsProps
+): CloudPulseResources[] => {
+  const { scope, buckets, selectedRegions, entities } = props;
+
+  switch (scope) {
+    case 'account':
+      return buckets;
+    case 'entity':
+      return entities
+        ? buckets.filter((bucket) => entities.includes(bucket.id))
+        : [];
+    case 'region':
+      return selectedRegions
+        ? buckets.filter((bucket) =>
+            selectedRegions.includes(bucket.region ?? '')
+          )
+        : [];
+    default:
+      return buckets;
+  }
 };

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseRegionSelect.tsx
@@ -6,7 +6,7 @@ import { RegionSelect } from 'src/components/RegionSelect/RegionSelect';
 import { useFlags } from 'src/hooks/useFlags';
 import { useResourcesQuery } from 'src/queries/cloudpulse/resources';
 
-import { useFetchOptions } from '../Alerts/CreateAlert/Criteria/DimensionFilterValue/useFetchOptions';
+import { useFirewallFetchOptions } from '../Alerts/CreateAlert/Criteria/DimensionFilterValue/useFirewallFetchOptions';
 import { filterRegionByServiceType } from '../Alerts/Utils/utils';
 import {
   LINODE_REGION,
@@ -85,7 +85,7 @@ export const CloudPulseRegionSelect = React.memo(
       values: linodeRegions,
       isLoading: isLinodeRegionIdLoading,
       isError: isLinodeRegionIdError,
-    } = useFetchOptions({
+    } = useFirewallFetchOptions({
       dimensionLabel: filterKey,
       entities: selectedEntities,
       regions,

--- a/packages/manager/src/features/CloudPulse/shared/DimensionTransform.ts
+++ b/packages/manager/src/features/CloudPulse/shared/DimensionTransform.ts
@@ -34,4 +34,7 @@ export const DIMENSION_TRANSFORM_CONFIG: Partial<
   nodebalancer: {
     protocol: TRANSFORMS.uppercase,
   },
+  objectstorage: {
+    endpoint: TRANSFORMS.original,
+  },
 };

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -92,6 +92,8 @@ import {
   objectStorageClusterFactory,
   objectStorageEndpointsFactory,
   objectStorageKeyFactory,
+  objectStorageMetricCriteria,
+  objectStorageMetricRules,
   objectStorageOverageTypeFactory,
   objectStorageTypeFactory,
   paymentFactory,
@@ -3030,7 +3032,13 @@ export const handlers = [
             type: 'user',
             label: 'object-storage -testing',
             service_type: 'objectstorage',
-            entity_ids: ['obj-bucket-804.ap-west.linodeobjects.com'],
+            entity_ids: [
+              'obj-bucket-804.ap-west.linodeobjects.com',
+              'obj-bucket-230.us-iad.linodeobjects.com',
+            ],
+            rule_criteria: {
+              rules: [objectStorageMetricCriteria.build()],
+            },
           })
         );
       }
@@ -3069,6 +3077,20 @@ export const handlers = [
             rule_criteria: {
               rules: [firewallMetricRulesFactory.build()],
             },
+          })
+        );
+      }
+      if (params.id === '550' && params.serviceType === 'objectstorage') {
+        return HttpResponse.json(
+          alertFactory.build({
+            id: 550,
+            label: 'object-storage -testing',
+            type: 'user',
+            rule_criteria: {
+              rules: [objectStorageMetricCriteria.build()],
+            },
+            service_type: 'objectstorage',
+            entity_ids: ['obj-bucket-804.ap-west.linodeobjects.com'],
           })
         );
       }
@@ -3125,7 +3147,9 @@ export const handlers = [
           label: 'Object Storage',
           service_type: 'objectstorage',
           regions: 'us-iad,us-east',
-          alert: serviceAlertFactory.build({ scope: ['entity'] }),
+          alert: serviceAlertFactory.build({
+            scope: ['entity', 'account', 'region'],
+          }),
         }),
         serviceTypesFactory.build({
           label: 'Block Storage',
@@ -3154,7 +3178,10 @@ export const handlers = [
       alert: serviceAlertFactory.build({
         evaluation_period_seconds: [300],
         polling_interval_seconds: [300],
-        scope: ['entity'],
+        scope:
+          serviceType === 'objectstorage'
+            ? ['entity', 'account', 'region']
+            : ['entity'],
       }),
     });
 
@@ -3503,6 +3530,9 @@ export const handlers = [
       }
       if (params.serviceType === 'nodebalancer') {
         return HttpResponse.json(nodebalancerMetricsResponse);
+      }
+      if (params.serviceType === 'objectstorage') {
+        return HttpResponse.json({ data: objectStorageMetricRules });
       }
       return HttpResponse.json(response);
     }


### PR DESCRIPTION
## Description 📝
 - Support for custom fetching for the Endpoint Dimension Filter in Object Storage Alerts
 - Minor changes and separation of logic in ValueFieldRenderer component

## Changes  🔄

List any change(s) relevant to the reviewer.

- Standalone DimensionFilterValue components (`DimensionFilterAutocomplete`, `FirewallDimensionFilterAutocomplete`, `ObjectStorageDimensionFilterAutocomplete`) depending on the use-case ( Avoids fetching irrelevant hooks for some serviceTypes)
- New `useObjectStorageFetchOptions `hook for endpoints dimension filter
- Utils for scope related filtering for object storage endpoints dimension filter
- Unit Tests for the components and utils
- Unified Interfaces for DimensionFilterAutocompleteProps and FetchOptionsProps

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [x] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

15th October

## Preview 📷

| Scope |  Screen Recording  |
| ------- | ------- |
| Account scope | <video src="https://github.com/user-attachments/assets/225c87f8-bfe8-4d41-855f-12d4fe4aeb2e"/> |
| Region scope | <video src="https://github.com/user-attachments/assets/c183e429-198c-40ef-a37a-d2d4ac035df2"/> | 
| Entity scope | <video src="https://github.com/user-attachments/assets/00dfb2f2-8396-43a2-a4d3-eb61d8610f17"/> |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Under Monitor , Click on Alerts.
#### To test Create Alert flow
   - Click on Create Alerts button 
   - Choose different scope variants and verify the changes.
 
#### To test the Show-Details and Edit Alert flow
   - In serverHandler.ts, [L3024-L3036](https://github.com/santoshp210-akamai/manager/blob/6cc7fe91d8d93cd50c9508cf7b786e4e12546363/packages/manager/src/mocks/serverHandlers.ts#L3024-L3036)
   
   - Change the following lines of code :
   
```ts
           alertFactory.build({
            id: 550,
            label: 'object-storage -testing',
            type: 'user',
            rule_criteria: {
              rules: [objectStorageMetricCriteria.build()],
            },
            service_type: 'objectstorage',
            entity_ids: [
              'obj-bucket-804.ap-west.linodeobjects.com',
              'obj-bucket-230.us-iad.linodeobjects.com',
            ],
          })
```

   - To this for region scope
      
      
```ts
           alertFactory.build({
            id: 550,
            label: 'object-storage -testing',
            type: 'user',
            scope: 'region',
            regions: ['ap-west-1.linodeobjects.com', 'us-iad-1.linodeobjects.com']
            rule_criteria: {
              rules: [objectStorageMetricCriteria.build()],
            },
            service_type: 'objectstorage',
          })
```
   - To this for account scope
      
```ts
          alertFactory.build({
            id: 550,
            label: 'object-storage -testing',
            type: 'user',
            scope: 'account',
            rule_criteria: {
              rules: [objectStorageMetricCriteria.build()],
            },
            service_type: 'objectstorage',
          })
```
  - In the Alerts List, search for  `object-storage -testing` Alert. 
  - In the action menu of that Alert click on Show-Details/Edit to test Show-Details/Edit respectively

### Verification steps

(How to verify changes)

- [ ] The existing firewall dimension filters features are working as expected
- [ ] The object storage dimension filters customization in Create Alert flow is working for all the scopes
- [ ] The object storage dimension filters customization in Edit Alert flow is working for all the scopes
- [ ] The object storage dimension filters customization in Show Details Alert flow is working for all the scopes

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>