### PR TITLE
upcoming: [DI-27110] - Added preference support to ACLP group by

### DIFF
--- a/packages/api-v4/src/cloudpulse/types.ts
+++ b/packages/api-v4/src/cloudpulse/types.ts
@@ -111,6 +111,7 @@ export interface AclpConfig {
 
 export interface AclpWidget {
   aggregateFunction: string;
+  groupBy?: string[];
   label: string;
   size: number;
   timeGranularity: TimeGranularity;

--- a/packages/manager/src/features/CloudPulse/GroupBy/CloudPulseGroupByDrawer.tsx
+++ b/packages/manager/src/features/CloudPulse/GroupBy/CloudPulseGroupByDrawer.tsx
@@ -28,7 +28,7 @@ export interface GroupByDrawerProps {
   /**
    * Callback function triggered when apply button is clicked
    */
-  onApply: (value: GroupByOption[]) => void;
+  onApply: (value: GroupByOption[], savePref?: boolean) => void;
   /**
    * Callback function triggered when cancel button is clicked
    */
@@ -96,7 +96,7 @@ export const CloudPulseGroupByDrawer = React.memo(
         0,
         Math.min(defaultValue.length, GROUP_BY_SELECTION_LIMIT)
       );
-      onApply(value);
+      onApply(value, false);
       setSelectedValue(value);
     }, [serviceType]);
     const handleClose = () => {

--- a/packages/manager/src/features/CloudPulse/GroupBy/GlobalFilterGroupByRenderer.test.tsx
+++ b/packages/manager/src/features/CloudPulse/GroupBy/GlobalFilterGroupByRenderer.test.tsx
@@ -86,7 +86,7 @@ describe('Global Group By Renderer Component', () => {
     const drawer = screen.getByTestId('drawer');
     expect(drawer).toBeInTheDocument();
 
-    expect(handleChange).toHaveBeenCalledWith([]);
+    expect(handleChange).toHaveBeenCalledWith([], undefined);
   });
 
   it('Should not open drawer but group by icon should be enabled', async () => {
@@ -131,7 +131,10 @@ describe('Global Group By Renderer Component', () => {
     const drawer = screen.getByTestId('drawer');
     expect(drawer).toBeInTheDocument();
 
-    expect(handleChange).toHaveBeenCalledWith([defaultValue[0].value]);
+    expect(handleChange).toHaveBeenCalledWith(
+      [defaultValue[0].value],
+      undefined
+    );
 
     defaultValue.forEach((value) => {
       const option = screen.getByRole('button', { name: value.label });

--- a/packages/manager/src/features/CloudPulse/GroupBy/GlobalFilterGroupByRenderer.test.tsx
+++ b/packages/manager/src/features/CloudPulse/GroupBy/GlobalFilterGroupByRenderer.test.tsx
@@ -86,7 +86,7 @@ describe('Global Group By Renderer Component', () => {
     const drawer = screen.getByTestId('drawer');
     expect(drawer).toBeInTheDocument();
 
-    expect(handleChange).toHaveBeenCalledWith([], undefined);
+    expect(handleChange).toHaveBeenCalledWith([], false);
   });
 
   it('Should not open drawer but group by icon should be enabled', async () => {
@@ -131,10 +131,7 @@ describe('Global Group By Renderer Component', () => {
     const drawer = screen.getByTestId('drawer');
     expect(drawer).toBeInTheDocument();
 
-    expect(handleChange).toHaveBeenCalledWith(
-      [defaultValue[0].value],
-      undefined
-    );
+    expect(handleChange).toHaveBeenCalledWith([defaultValue[0].value], false);
 
     defaultValue.forEach((value) => {
       const option = screen.getByRole('button', { name: value.label });

--- a/packages/manager/src/features/CloudPulse/GroupBy/GlobalFilterGroupByRenderer.tsx
+++ b/packages/manager/src/features/CloudPulse/GroupBy/GlobalFilterGroupByRenderer.tsx
@@ -9,13 +9,21 @@ import { GLOBAL_GROUP_BY_MESSAGE } from './constants';
 import { useGlobalDimensions } from './utils';
 
 import type { GroupByOption } from './CloudPulseGroupByDrawer';
-import type { Dashboard } from '@linode/api-v4';
+import type { Dashboard, FilterValue } from '@linode/api-v4';
 
 interface GlobalFilterGroupByRendererProps {
   /**
    * Callback to handle the selected values
    */
-  handleChange: (selectedValue: string[]) => void;
+  handleChange: (selectedValue: string[], savePref?: boolean) => void;
+  /**
+   * User's saved group by preference
+   */
+  preference?: FilterValue;
+  /**
+   * Indicates whether to save the selected group by options to user preferences
+   */
+  savePreferences?: boolean;
   /**
    * Currently selected dashboard
    */
@@ -25,12 +33,14 @@ interface GlobalFilterGroupByRendererProps {
 export const GlobalFilterGroupByRenderer = (
   props: GlobalFilterGroupByRendererProps
 ) => {
-  const { selectedDashboard, handleChange } = props;
+  const { selectedDashboard, handleChange, preference, savePreferences } =
+    props;
   const [isSelected, setIsSelected] = React.useState(false);
 
   const { options, defaultValue, isLoading } = useGlobalDimensions(
     selectedDashboard?.id,
-    selectedDashboard?.service_type
+    selectedDashboard?.service_type,
+    preference as string[]
   );
 
   const [open, setOpen] = React.useState(false);
@@ -42,10 +52,13 @@ export const GlobalFilterGroupByRenderer = (
       } else {
         setIsSelected(true);
       }
-      handleChange(selectedValue.map(({ value }) => value));
+      handleChange(
+        selectedValue.map(({ value }) => value),
+        savePreferences
+      );
       setOpen(false);
     },
-    [handleChange]
+    [handleChange, savePreferences]
   );
 
   const onCancel = React.useCallback(() => {

--- a/packages/manager/src/features/CloudPulse/GroupBy/GlobalFilterGroupByRenderer.tsx
+++ b/packages/manager/src/features/CloudPulse/GroupBy/GlobalFilterGroupByRenderer.tsx
@@ -50,7 +50,7 @@ export const GlobalFilterGroupByRenderer = (
   const [open, setOpen] = React.useState(false);
 
   const onApply = React.useCallback(
-    (selectedValue: GroupByOption[]) => {
+    (selectedValue: GroupByOption[], savePref?: boolean) => {
       if (selectedValue.length === 0) {
         setIsSelected(false);
       } else {
@@ -58,7 +58,7 @@ export const GlobalFilterGroupByRenderer = (
       }
       handleChange(
         selectedValue.map(({ value }) => value),
-        savePreferences
+        savePref ?? savePreferences
       );
       setOpen(false);
     },

--- a/packages/manager/src/features/CloudPulse/GroupBy/GlobalFilterGroupByRenderer.tsx
+++ b/packages/manager/src/features/CloudPulse/GroupBy/GlobalFilterGroupByRenderer.tsx
@@ -19,7 +19,7 @@ interface GlobalFilterGroupByRendererProps {
   /**
    * User's saved group by preference
    */
-  preference?: FilterValue;
+  preferenceGroupBy?: FilterValue;
   /**
    * Indicates whether to save the selected group by options to user preferences
    */
@@ -33,14 +33,18 @@ interface GlobalFilterGroupByRendererProps {
 export const GlobalFilterGroupByRenderer = (
   props: GlobalFilterGroupByRendererProps
 ) => {
-  const { selectedDashboard, handleChange, preference, savePreferences } =
-    props;
+  const {
+    selectedDashboard,
+    handleChange,
+    preferenceGroupBy,
+    savePreferences,
+  } = props;
   const [isSelected, setIsSelected] = React.useState(false);
 
   const { options, defaultValue, isLoading } = useGlobalDimensions(
     selectedDashboard?.id,
     selectedDashboard?.service_type,
-    preference as string[]
+    preferenceGroupBy as string[]
   );
 
   const [open, setOpen] = React.useState(false);

--- a/packages/manager/src/features/CloudPulse/GroupBy/WidgetFilterGroupByRenderer.test.tsx
+++ b/packages/manager/src/features/CloudPulse/GroupBy/WidgetFilterGroupByRenderer.test.tsx
@@ -85,7 +85,7 @@ describe('Widget Group By Renderer', () => {
     const title = screen.getByText('Group By');
     expect(title).toBeInTheDocument();
 
-    expect(handleChange).toHaveBeenCalledWith([], undefined);
+    expect(handleChange).toHaveBeenCalledWith([], false);
   });
 
   it('Should not open drawer but group by icon should be enabled', async () => {
@@ -120,10 +120,7 @@ describe('Widget Group By Renderer', () => {
     const drawer = screen.getByTestId('drawer');
     expect(drawer).toBeInTheDocument();
 
-    expect(handleChange).toHaveBeenCalledWith(
-      [defaultValue[0].value],
-      undefined
-    );
+    expect(handleChange).toHaveBeenCalledWith([defaultValue[0].value], false);
 
     defaultValue.forEach((value) => {
       const option = screen.getByRole('button', { name: value.label });

--- a/packages/manager/src/features/CloudPulse/GroupBy/WidgetFilterGroupByRenderer.test.tsx
+++ b/packages/manager/src/features/CloudPulse/GroupBy/WidgetFilterGroupByRenderer.test.tsx
@@ -85,7 +85,7 @@ describe('Widget Group By Renderer', () => {
     const title = screen.getByText('Group By');
     expect(title).toBeInTheDocument();
 
-    expect(handleChange).toHaveBeenCalledWith([]);
+    expect(handleChange).toHaveBeenCalledWith([], undefined);
   });
 
   it('Should not open drawer but group by icon should be enabled', async () => {
@@ -120,7 +120,10 @@ describe('Widget Group By Renderer', () => {
     const drawer = screen.getByTestId('drawer');
     expect(drawer).toBeInTheDocument();
 
-    expect(handleChange).toHaveBeenCalledWith([defaultValue[0].value]);
+    expect(handleChange).toHaveBeenCalledWith(
+      [defaultValue[0].value],
+      undefined
+    );
 
     defaultValue.forEach((value) => {
       const option = screen.getByRole('button', { name: value.label });

--- a/packages/manager/src/features/CloudPulse/GroupBy/WidgetFilterGroupByRenderer.tsx
+++ b/packages/manager/src/features/CloudPulse/GroupBy/WidgetFilterGroupByRenderer.tsx
@@ -31,7 +31,7 @@ interface WidgetFilterGroupByRendererProps {
   /**
    * User's saved group by preference
    */
-  preference?: string[];
+  preferenceGroupBy?: string[];
   /**
    * Indicates whether to save the selected group by options to user preferences
    */
@@ -52,7 +52,7 @@ export const WidgetFilterGroupByRenderer = (
     label,
     handleChange,
     savePreferences,
-    preference,
+    preferenceGroupBy,
   } = props;
   const [isSelected, setIsSelected] = React.useState(false);
 
@@ -67,7 +67,7 @@ export const WidgetFilterGroupByRenderer = (
     serviceType,
     globalDimensions,
     metric,
-    preference
+    preferenceGroupBy
   );
   const [open, setOpen] = React.useState(false);
   const onCancel = React.useCallback(() => {

--- a/packages/manager/src/features/CloudPulse/GroupBy/WidgetFilterGroupByRenderer.tsx
+++ b/packages/manager/src/features/CloudPulse/GroupBy/WidgetFilterGroupByRenderer.tsx
@@ -74,7 +74,7 @@ export const WidgetFilterGroupByRenderer = (
     setOpen(false);
   }, []);
   const onApply = React.useCallback(
-    (selectedValue: GroupByOption[]) => {
+    (selectedValue: GroupByOption[], savePref?: boolean) => {
       if (selectedValue.length === 0) {
         setIsSelected(false);
       } else {
@@ -82,7 +82,7 @@ export const WidgetFilterGroupByRenderer = (
       }
       handleChange(
         selectedValue.map(({ value }) => value),
-        savePreferences
+        savePref ?? savePreferences
       );
       setOpen(false);
     },

--- a/packages/manager/src/features/CloudPulse/GroupBy/WidgetFilterGroupByRenderer.tsx
+++ b/packages/manager/src/features/CloudPulse/GroupBy/WidgetFilterGroupByRenderer.tsx
@@ -19,7 +19,7 @@ interface WidgetFilterGroupByRendererProps {
   /**
    * Callback function to handle the selected values
    */
-  handleChange: (selectedValue: string[]) => void;
+  handleChange: (selectedValue: string[], savePreferences?: boolean) => void;
   /**
    * Label for the widget metric
    */
@@ -29,6 +29,14 @@ interface WidgetFilterGroupByRendererProps {
    */
   metric: string;
   /**
+   * User's saved group by preference
+   */
+  preference?: string[];
+  /**
+   * Indicates whether to save the selected group by options to user preferences
+   */
+  savePreferences?: boolean;
+  /**
    * Service type of the selected dashboard
    */
   serviceType: CloudPulseServiceType;
@@ -37,7 +45,15 @@ interface WidgetFilterGroupByRendererProps {
 export const WidgetFilterGroupByRenderer = (
   props: WidgetFilterGroupByRendererProps
 ) => {
-  const { metric, dashboardId, serviceType, label, handleChange } = props;
+  const {
+    metric,
+    dashboardId,
+    serviceType,
+    label,
+    handleChange,
+    savePreferences,
+    preference,
+  } = props;
   const [isSelected, setIsSelected] = React.useState(false);
 
   const { isLoading: globalDimensionLoading, options: globalDimensions } =
@@ -46,7 +62,13 @@ export const WidgetFilterGroupByRenderer = (
     isLoading: widgetDimensionLoading,
     options: widgetDimensions,
     defaultValue,
-  } = useWidgetDimension(dashboardId, serviceType, globalDimensions, metric);
+  } = useWidgetDimension(
+    dashboardId,
+    serviceType,
+    globalDimensions,
+    metric,
+    preference
+  );
   const [open, setOpen] = React.useState(false);
   const onCancel = React.useCallback(() => {
     setOpen(false);
@@ -58,10 +80,13 @@ export const WidgetFilterGroupByRenderer = (
       } else {
         setIsSelected(true);
       }
-      handleChange(selectedValue.map(({ value }) => value));
+      handleChange(
+        selectedValue.map(({ value }) => value),
+        savePreferences
+      );
       setOpen(false);
     },
-    [handleChange]
+    [handleChange, savePreferences]
   );
 
   const isDisabled =

--- a/packages/manager/src/features/CloudPulse/GroupBy/utils.test.ts
+++ b/packages/manager/src/features/CloudPulse/GroupBy/utils.test.ts
@@ -85,7 +85,7 @@ describe('useGlobalDimensions method test', () => {
     expect(result).toEqual({ options: [], defaultValue: [], isLoading: true });
   });
 
-  it('should return empty options and defaultValue if no common dimensions', () => {
+  it('should return non-empty options and defaultValue if no common dimensions', () => {
     queryMocks.useCloudPulseDashboardByIdQuery.mockReturnValue({
       data: dashboardFactory.build(),
       isLoading: false,
@@ -100,6 +100,26 @@ describe('useGlobalDimensions method test', () => {
     expect(result).toEqual({
       options: [defaultOption, { label: 'Dim 2', value: 'Dim 2' }],
       defaultValue: [],
+      isLoading: false,
+    });
+  });
+
+  it('should return non-empty options and defaultValue from preferences', () => {
+    queryMocks.useCloudPulseDashboardByIdQuery.mockReturnValue({
+      data: dashboardFactory.build(),
+      isLoading: false,
+    });
+    queryMocks.useGetCloudPulseMetricDefinitionsByServiceType.mockReturnValue({
+      data: {
+        data: metricDefinitions,
+      },
+      isLoading: false,
+    });
+    const preference = ['Dim 2'];
+    const result = useGlobalDimensions(1, 'linode', preference);
+    expect(result).toEqual({
+      options: [defaultOption, { label: 'Dim 2', value: 'Dim 2' }],
+      defaultValue: [{ label: 'Dim 2', value: 'Dim 2' }],
       isLoading: false,
     });
   });
@@ -156,6 +176,32 @@ describe('useWidgetDimension method test', () => {
 
     expect(result.options).toHaveLength(1);
     expect(result.defaultValue).toHaveLength(0);
+    expect(result.isLoading).toBe(false);
+  });
+
+  it('should return non-empty options and non-empty default value from preferences', () => {
+    queryMocks.useCloudPulseDashboardByIdQuery.mockReturnValue({
+      data: dashboardFactory.build(),
+      isLoading: false,
+    });
+
+    queryMocks.useGetCloudPulseMetricDefinitionsByServiceType.mockReturnValue({
+      data: {
+        data: metricDefinitions,
+      },
+      isLoading: false,
+    });
+    const preferences = ['Dim 2'];
+    const result = useWidgetDimension(
+      1,
+      'linode',
+      [{ label: 'Dim 1', value: 'Dim 1' }],
+      'Metric 1',
+      preferences
+    );
+
+    expect(result.options).toHaveLength(1);
+    expect(result.defaultValue).toHaveLength(1);
     expect(result.isLoading).toBe(false);
   });
 });

--- a/packages/manager/src/features/CloudPulse/GroupBy/utils.ts
+++ b/packages/manager/src/features/CloudPulse/GroupBy/utils.ts
@@ -40,7 +40,8 @@ interface MetricDimension {
  */
 export const useGlobalDimensions = (
   dashboardId: number | undefined,
-  serviceType: CloudPulseServiceType | undefined
+  serviceType: CloudPulseServiceType | undefined,
+  preference?: string[]
 ): GroupByDimension => {
   const { data: dashboard, isLoading: dashboardLoading } =
     useCloudPulseDashboardByIdQuery(dashboardId);
@@ -60,7 +61,7 @@ export const useGlobalDimensions = (
   ];
 
   const commonGroups = getCommonGroups(
-    dashboard?.group_by ?? [],
+    preference ? preference : (dashboard?.group_by ?? []),
     commonDimensions
   );
   return {
@@ -99,7 +100,8 @@ export const useWidgetDimension = (
   dashboardId: number | undefined,
   serviceType: CloudPulseServiceType | undefined,
   globalDimensions: GroupByOption[],
-  metric: string | undefined
+  metric: string | undefined,
+  preference?: string[]
 ): GroupByDimension => {
   const { data: dashboard, isLoading: dashboardLoading } =
     useCloudPulseDashboardByIdQuery(dashboardId);
@@ -120,9 +122,10 @@ export const useWidgetDimension = (
         label,
         value: dimension_label,
       })) ?? [];
-  const defaultGroupBy =
-    dashboard?.widgets.find((widget) => widget.metric === metric)?.group_by ??
-    [];
+  const defaultGroupBy = preference
+    ? preference
+    : (dashboard?.widgets.find((widget) => widget.metric === metric)
+        ?.group_by ?? []);
   const options = metricDimensions.filter(
     (metricDimension) =>
       !globalDimensions.some(

--- a/packages/manager/src/features/CloudPulse/GroupBy/utils.ts
+++ b/packages/manager/src/features/CloudPulse/GroupBy/utils.ts
@@ -82,10 +82,18 @@ export const getCommonGroups = (
   commonDimensions: GroupByOption[]
 ): GroupByOption[] => {
   if (groupBy.length === 0 || commonDimensions.length === 0) return [];
-
-  return commonDimensions.filter((group) => {
-    return groupBy.includes(group.value);
-  });
+  const commonGroups: GroupByOption[] = [];
+  // To maintain the order of groupBy from dashboard config or preferences
+  for (let index = 0; index < groupBy.length; index++) {
+    const group = groupBy[index];
+    const commonGroup = commonDimensions.find(
+      (dimension) => dimension.value === group
+    );
+    if (commonGroup) {
+      commonGroups.push(commonGroup);
+    }
+  }
+  return commonGroups;
 };
 
 /**
@@ -126,6 +134,7 @@ export const useWidgetDimension = (
     ? preference
     : (dashboard?.widgets.find((widget) => widget.metric === metric)
         ?.group_by ?? []);
+
   const options = metricDimensions.filter(
     (metricDimension) =>
       !globalDimensions.some(
@@ -133,9 +142,17 @@ export const useWidgetDimension = (
       )
   );
 
-  const defaultValue = options.filter((options) =>
-    defaultGroupBy.includes(options.value)
-  );
+  // To maintain the order of groupBy from dashboard config or preferences
+  const defaultValue: GroupByOption[] = [];
+
+  for (let index = 0; index < defaultGroupBy.length; index++) {
+    const groupBy = defaultGroupBy[index];
+
+    const defaultOption = options.find((option) => option.value === groupBy);
+    if (defaultOption) {
+      defaultValue.push(defaultOption);
+    }
+  }
 
   return {
     options,

--- a/packages/manager/src/features/CloudPulse/Overview/GlobalFilters.tsx
+++ b/packages/manager/src/features/CloudPulse/Overview/GlobalFilters.tsx
@@ -163,7 +163,7 @@ export const GlobalFilters = React.memo((props: GlobalFilterProperties) => {
             </CloudPulseTooltip>
             <GlobalFilterGroupByRenderer
               handleChange={onGroupByChange}
-              preference={preferences?.[GROUP_BY]}
+              preferenceGroupBy={preferences?.[GROUP_BY]}
               savePreferences
               selectedDashboard={selectedDashboard}
             />

--- a/packages/manager/src/features/CloudPulse/Overview/GlobalFilters.tsx
+++ b/packages/manager/src/features/CloudPulse/Overview/GlobalFilters.tsx
@@ -14,6 +14,7 @@ import { CloudPulseTooltip } from '../shared/CloudPulseTooltip';
 import { convertToGmt } from '../Utils/CloudPulseDateTimePickerUtils';
 import {
   DASHBOARD_ID,
+  GROUP_BY,
   REFRESH,
   RESOURCE_FILTER_MAP,
   TIME_DURATION,
@@ -105,6 +106,17 @@ export const GlobalFilters = React.memo((props: GlobalFilterProperties) => {
     RESOURCE_FILTER_MAP[selectedDashboard?.service_type ?? ''] ?? {}
   );
 
+  const onGroupByChange = React.useCallback(
+    (selectedValues: string[], savePref: boolean = false) => {
+      if (savePref) {
+        updatePreferences({ [GROUP_BY]: selectedValues });
+      }
+
+      handleGroupByChange(selectedValues);
+    },
+    []
+  );
+
   return (
     <GridLegacy container>
       <GridLegacy item xs={12}>
@@ -150,7 +162,9 @@ export const GlobalFilters = React.memo((props: GlobalFilterProperties) => {
               </IconButton>
             </CloudPulseTooltip>
             <GlobalFilterGroupByRenderer
-              handleChange={handleGroupByChange}
+              handleChange={onGroupByChange}
+              preference={preferences?.[GROUP_BY]}
+              savePreferences
               selectedDashboard={selectedDashboard}
             />
           </Box>

--- a/packages/manager/src/features/CloudPulse/Utils/constants.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/constants.ts
@@ -22,6 +22,8 @@ export const TIME_DURATION = 'dateTimeDuration';
 
 export const AGGREGATE_FUNCTION = 'aggregateFunction';
 
+export const GROUP_BY = 'groupBy';
+
 export const SIZE = 'size';
 
 export const LABEL = 'label';

--- a/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.test.tsx
@@ -51,6 +51,7 @@ const props: CloudPulseWidgetProperties = {
   widget: widgetFactory.build({
     label: 'CPU Utilization',
   }),
+  globalFilterGroupBy: [],
 };
 
 const queryMocks = vi.hoisted(() => ({

--- a/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.tsx
+++ b/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.tsx
@@ -12,7 +12,12 @@ import {
   generateGraphData,
   getCloudPulseMetricRequest,
 } from '../Utils/CloudPulseWidgetUtils';
-import { AGGREGATE_FUNCTION, SIZE, TIME_GRANULARITY } from '../Utils/constants';
+import {
+  AGGREGATE_FUNCTION,
+  GROUP_BY,
+  SIZE,
+  TIME_GRANULARITY,
+} from '../Utils/constants';
 import { constructAdditionalRequestFilters } from '../Utils/FilterBuilder';
 import { generateCurrentUnit } from '../Utils/unitConversion';
 import { useAclpPreference } from '../Utils/UserPreference';
@@ -82,6 +87,11 @@ export interface CloudPulseWidgetProperties {
   errorLabel?: string;
 
   /**
+   * Group by selected on global filter
+   */
+  globalFilterGroupBy: string[];
+
+  /**
    * Jwe token fetching status check
    */
   isJweTokenFetching: boolean;
@@ -120,11 +130,11 @@ export interface CloudPulseWidgetProperties {
    * this should come from dashboard, which maintains map for service types in a separate API call
    */
   unit: string;
-
   /**
    * color index to be selected from available them if not theme is provided by user
    */
   useColorIndex?: number;
+
   /**
    * this comes from dashboard, has inbuilt metrics, agg_func,group_by,filters,gridsize etc , also helpful in publishing any changes
    */
@@ -148,11 +158,13 @@ export const CloudPulseWidget = (props: CloudPulseWidgetProperties) => {
   const { data: profile } = useProfile();
 
   const [widget, setWidget] = React.useState<Widgets>({ ...props.widget });
-  const [groupBy, setGroupBy] = React.useState<string[]>([]);
-
+  const [groupBy, setGroupBy] = React.useState<string[] | undefined>(
+    props.widget.group_by
+  );
   const theme = useTheme();
 
   const {
+    globalFilterGroupBy,
     additionalFilters,
     ariaLabel,
     authToken,
@@ -251,6 +263,11 @@ export const CloudPulseWidget = (props: CloudPulseWidgetProperties) => {
     []
   );
   const handleGroupByChange = React.useCallback((selectedGroupBy: string[]) => {
+    if (savePref) {
+      updatePreferences(widget.label, {
+        [GROUP_BY]: selectedGroupBy,
+      });
+    }
     setGroupBy(selectedGroupBy);
   }, []);
   const {
@@ -266,7 +283,7 @@ export const CloudPulseWidget = (props: CloudPulseWidgetProperties) => {
         entityIds,
         resources,
         widget,
-        groupBy: [...(widgetProp.group_by ?? []), ...groupBy],
+        groupBy: [...globalFilterGroupBy, ...(groupBy ?? [])],
         linodeRegion,
         region,
         serviceType,
@@ -295,7 +312,7 @@ export const CloudPulseWidget = (props: CloudPulseWidgetProperties) => {
       status,
       unit,
       serviceType,
-      groupBy: [...(widgetProp.group_by ?? []), ...groupBy],
+      groupBy: [...globalFilterGroupBy, ...(groupBy ?? [])],
       metricLabel: availableMetrics?.label,
     });
 
@@ -377,6 +394,7 @@ export const CloudPulseWidget = (props: CloudPulseWidgetProperties) => {
                   handleChange={handleGroupByChange}
                   label={widget.label}
                   metric={widget.metric}
+                  preference={groupBy}
                   serviceType={serviceType}
                 />
                 <ZoomIcon

--- a/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.tsx
+++ b/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.tsx
@@ -394,7 +394,7 @@ export const CloudPulseWidget = (props: CloudPulseWidgetProperties) => {
                   handleChange={handleGroupByChange}
                   label={widget.label}
                   metric={widget.metric}
-                  preference={groupBy}
+                  preferenceGroupBy={groupBy}
                   serviceType={serviceType}
                 />
                 <ZoomIcon

--- a/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.tsx
+++ b/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.tsx
@@ -262,14 +262,17 @@ export const CloudPulseWidget = (props: CloudPulseWidgetProperties) => {
     },
     []
   );
-  const handleGroupByChange = React.useCallback((selectedGroupBy: string[]) => {
-    if (savePref) {
-      updatePreferences(widget.label, {
-        [GROUP_BY]: selectedGroupBy,
-      });
-    }
-    setGroupBy(selectedGroupBy);
-  }, []);
+  const handleGroupByChange = React.useCallback(
+    (selectedGroupBy: string[], savePreferences?: boolean) => {
+      if (savePreferences) {
+        updatePreferences(widget.label, {
+          [GROUP_BY]: selectedGroupBy,
+        });
+      }
+      setGroupBy(selectedGroupBy);
+    },
+    []
+  );
   const {
     data: metricsList,
     error,
@@ -395,6 +398,7 @@ export const CloudPulseWidget = (props: CloudPulseWidgetProperties) => {
                   label={widget.label}
                   metric={widget.metric}
                   preferenceGroupBy={groupBy}
+                  savePreferences={savePref}
                   serviceType={serviceType}
                 />
                 <ZoomIcon

--- a/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidgetRenderer.tsx
+++ b/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidgetRenderer.tsx
@@ -92,10 +92,11 @@ export const RenderWidgets = React.memo(
         timeStamp: manualRefreshTimeStamp,
         unit: widget.unit ?? '%',
         dashboardId: dashboard.id,
+        globalFilterGroupBy: groupBy,
         widget: {
           ...widget,
           time_granularity: autoIntervalOption,
-          group_by: groupBy.length === 0 ? undefined : groupBy,
+          group_by: undefined,
         },
       };
       if (savePref) {
@@ -122,11 +123,13 @@ export const RenderWidgets = React.memo(
           time_granularity: {
             ...(pref.timeGranularity ?? autoIntervalOption),
           },
+          group_by: pref.groupBy,
         };
       } else {
         return {
           ...widgetObj,
           time_granularity: autoIntervalOption,
+          group_by: undefined,
         };
       }
     };


### PR DESCRIPTION
## Description 📝

Added preference support to ACLP group by

## Changes  🔄

List any change(s) relevant to the reviewer.

1. Updated GlobaFilterGroupByRenderer & WidgetFilterGroupByRenderer to use preference value
2. Updated GlobalFilter & CloudPulseWIdget to update group by preference

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

October, 21st

## Preview 📷

**Include a screenshot `<img src="" />` or video `<video src="" />` of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: For changes requiring multiple steps to validate, prefer a video for clarity.

| Before  | After   |
| ------- | ------- |
|<video src="https://github.com/user-attachments/assets/a0bc1e69-8922-4677-99ba-ded3c6ab25ed"/>|<video src="https://github.com/user-attachments/assets/48d718aa-a006-4f66-8b76-afce364be151"/>|

## How to test 🧪

### Prerequisites

1. If you have aclp access, then you can verify through UI
2. Switch to mock user, and verify through preference API call or by passing default group by list to GlobalFilterGroupByRenderer and WidgetFilterGroupByRenderer components.

### Verification steps

(How to verify changes)

- [] Select some group by from global filters and refresh that page, you'll notice those values will be selected by default
- [] Select some group by from widget filters and refresh that page, you'll notice those values will be selected by default
- [] Select group by in some order, you'll notice on refresh of the page, select order will be same

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

