### PR TITLE
fix: [DI-27690] - Time will not update on changing timezone with custom date

### DIFF
--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseDateTimePickerUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseDateTimePickerUtils.ts
@@ -2,6 +2,7 @@
  * Utility functions for handling date and time operations for CloudPulse.
  */
 
+import { DateTimeRangePicker } from '@linode/ui';
 import { DateTime } from 'luxon';
 
 import type { DateTimeWithPreset } from '@linode/api-v4';
@@ -19,7 +20,7 @@ export const defaultTimeDuration = (timezone?: string): DateTimeWithPreset => {
 
   return {
     end: date.toISO() ?? '',
-    preset: 'last hour',
+    preset: DateTimeRangePicker.PRESET_LABELS.LAST_HOUR,
     start: date.minus({ hours: 1 }).toISO() ?? '',
     timeZone: timezone,
   };
@@ -58,36 +59,36 @@ export function getTimeFromPreset(
   let startDate: string;
   let endDate: string;
   switch (preset) {
-    case 'last 7 days':
+    case DateTimeRangePicker.PRESET_LABELS.LAST_7_DAYS:
       startDate = today.minus({ days: 7 }).toISO() ?? start;
       endDate = today.toISO() ?? end;
       break;
 
-    case 'last 12 hours':
+    case DateTimeRangePicker.PRESET_LABELS.LAST_12_HOURS:
       startDate = today.minus({ hours: 12 }).toISO() ?? start;
       endDate = today.toISO() ?? end;
       break;
-    case 'last 30 days':
+    case DateTimeRangePicker.PRESET_LABELS.LAST_30_DAYS:
       startDate = today.minus({ days: 30 }).toISO() ?? start;
       endDate = today.toISO() ?? end;
       break;
-    case 'last 30 minutes':
+    case DateTimeRangePicker.PRESET_LABELS.LAST_30_MINUTES:
       startDate = today.minus({ minutes: 30 }).toISO() ?? start;
       endDate = today.toISO() ?? end;
       break;
-    case 'last day':
+    case DateTimeRangePicker.PRESET_LABELS.LAST_DAY:
       startDate = today.minus({ days: 1 }).toISO() ?? start;
       endDate = today.toISO() ?? end;
       break;
-    case 'last hour':
+    case DateTimeRangePicker.PRESET_LABELS.LAST_HOUR:
       startDate = today.minus({ hours: 1 }).toISO() ?? start;
       endDate = today.toISO() ?? end;
       break;
-    case 'last month':
+    case DateTimeRangePicker.PRESET_LABELS.LAST_MONTH:
       startDate = today.minus({ months: 1 }).startOf('month').toISO() ?? start;
       endDate = today.minus({ months: 1 }).endOf('month').toISO() ?? end;
       break;
-    case 'this month':
+    case DateTimeRangePicker.PRESET_LABELS.THIS_MONTH:
       startDate = today.startOf('month').toISO() ?? start;
       endDate = today.toISO() ?? end;
       break;
@@ -95,7 +96,7 @@ export function getTimeFromPreset(
       // Reset to provided values or empty strings if none provided
       startDate = start;
       endDate = end;
-      selectedPreset = 'reset';
+      selectedPreset = DateTimeRangePicker.PRESET_LABELS.RESET;
   }
 
   return {

--- a/packages/ui/src/components/DatePicker/DateTimeRangePicker/DateTimeRangePicker.tsx
+++ b/packages/ui/src/components/DatePicker/DateTimeRangePicker/DateTimeRangePicker.tsx
@@ -94,9 +94,9 @@ type TimeZoneStrategy = {
 };
 
 const strategies: Record<string, TimeZoneStrategy> = {
-  'last month': { keepStartTime: true, keepEndTime: true },
-  reset: { keepStartTime: true, keepEndTime: true },
-  'this month': { keepStartTime: true, keepEndTime: false },
+  'Last month': { keepStartTime: true, keepEndTime: true },
+  Reset: { keepStartTime: true, keepEndTime: true },
+  'This month': { keepStartTime: true, keepEndTime: false },
   default: { keepStartTime: false, keepEndTime: false },
 };
 


### PR DESCRIPTION
## Description 📝

Time will not update on changing timezone with custom date

## Changes  🔄

List any change(s) relevant to the reviewer.

1. Updated strategy keys in datetime range picker for presets
2. Updated CloudPulseDateTimeRangePicker utils to use preset constant instead of hardcoding values

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

21st October

## Preview 📷

**Include a screenshot `<img src="" />` or video `<video src="" />` of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: For changes requiring multiple steps to validate, prefer a video for clarity.

| Before  | After   |
| ------- | ------- |
|<video src="https://github.com/user-attachments/assets/47f61449-ab70-4d61-b42b-28bf3d81fc1f"/>|<video src="https://github.com/user-attachments/assets/a00fdda3-79e7-4adb-a2e9-5cd0f6181ebf"/>|

## How to test 🧪

### Prerequisites

1. Clone current linode/develop branch
2. Go to metrics tab

### Reproduction steps

1. Select date picker
2. Select custom date and time
3. Change time zone. You'll notice that time also changing which should not happen

### Verification steps

(How to verify changes)

- [ ] Change timezone after selecting custom date and time. You'll notice, time is not changing

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>