### PR TITLE
upcoming: [UIE-9434] - Create feature flag for generational compute plans

### DIFF
--- a/packages/manager/.changeset/pr-13054-upcoming-features-1762273666682.md
+++ b/packages/manager/.changeset/pr-13054-upcoming-features-1762273666682.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Feature flag for new Generational Compute Plans ([#13054](https://github.com/linode/manager/pull/13054))

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -31,6 +31,7 @@ const options: { flag: keyof Flags; label: string }[] = [
   { flag: 'cloudNat', label: 'Cloud NAT' },
   { flag: 'disableLargestGbPlans', label: 'Disable Largest GB Plans' },
   { flag: 'gecko2', label: 'Gecko' },
+  { flag: 'generationalPlans', label: 'Generational compute plans' },
   { flag: 'limitsEvolution', label: 'Limits Evolution' },
   { flag: 'linodeDiskEncryption', label: 'Linode Disk Encryption (LDE)' },
   { flag: 'linodeInterfaces', label: 'Linode Interfaces' },

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -192,6 +192,7 @@ export interface Flags {
   dbaasV2MonitorMetrics: BetaFeatureFlag;
   disableLargestGbPlans: boolean;
   gecko2: GeckoFeatureFlag;
+  generationalPlans: boolean;
   gpuv2: GpuV2;
   iam: BetaFeatureFlag;
   iamDelegation: BaseFeatureFlag;

--- a/packages/manager/src/utilities/linodes.test.ts
+++ b/packages/manager/src/utilities/linodes.test.ts
@@ -6,6 +6,7 @@ import { http, HttpResponse, server } from 'src/mocks/testServer';
 
 import {
   addMaintenanceToLinodes,
+  useIsGenerationalPlansEnabled,
   useIsLinodeCloneFirewallEnabled,
   useIsLinodeInterfacesEnabled,
 } from './linodes';
@@ -76,5 +77,27 @@ describe('useIsLinodeCloneFirewallEnabled', () => {
     });
 
     expect(result.current?.isLinodeCloneFirewallEnabled).toBe(false);
+  });
+});
+
+describe('useIsGenerationalPlansEnabled', () => {
+  it('returns isGenerationalPlansEnabled: true if the feature is enabled', () => {
+    const options = { flags: { generationalPlans: true } };
+
+    const { result } = renderHook(() => useIsGenerationalPlansEnabled(), {
+      wrapper: (ui) => wrapWithTheme(ui, options),
+    });
+
+    expect(result.current?.isGenerationalPlansEnabled).toBe(true);
+  });
+
+  it('returns isGenerationalPlansEnabled: false if the feature is NOT enabled', () => {
+    const options = { flags: { generationalPlans: false } };
+
+    const { result } = renderHook(() => useIsGenerationalPlansEnabled(), {
+      wrapper: (ui) => wrapWithTheme(ui, options),
+    });
+
+    expect(result.current?.isGenerationalPlansEnabled).toBe(false);
   });
 });

--- a/packages/manager/src/utilities/linodes.ts
+++ b/packages/manager/src/utilities/linodes.ts
@@ -88,3 +88,15 @@ export const useIsLinodeCloneFirewallEnabled = () => {
     isLinodeCloneFirewallEnabled: Boolean(flags.linodeCloneFirewall),
   };
 };
+
+/**
+ * Returns whether or not features related to the Generational Compute Plans
+ * should be enabled.
+ */
+export const useIsGenerationalPlansEnabled = () => {
+  const flags = useFlags();
+
+  return {
+    isGenerationalPlansEnabled: Boolean(flags.generationalPlans),
+  };
+};


### PR DESCRIPTION
## Description 📝

Create a new boolean feature flag to show generational compute plans.
```
generationalPlans: boolean
```

## Changes  🔄

List any change(s) relevant to the reviewer.

- Introduced `generationalPlans` feature flag
- Added it to FeatureFlagTool and to our dev tool

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [x] No customers / Not applicable

## How to test 🧪

- Confirm a toggle for "Generational compute plans" is present in our dev tool
- (optional) Filter network requests for "LaunchDarkly" and observe the presence of a "generationalPlans" object that has a false value

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>