### PR TITLE
Upcoming: [UIE-9538]- Disable premium plan tab if corresponding g7 dedicated plans are available

### DIFF
--- a/packages/manager/.changeset/pr-13081-upcoming-features-1762935895154.md
+++ b/packages/manager/.changeset/pr-13081-upcoming-features-1762935895154.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Disable premium plan tab if corresponding g7 dedicated plans are available ([#13081](https://github.com/linode/manager/pull/13081))

--- a/packages/manager/cypress/e2e/core/linodes/clone-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/clone-linode.spec.ts
@@ -70,6 +70,7 @@ describe('clone linode', () => {
   beforeEach(() => {
     mockAppendFeatureFlags({
       linodeInterfaces: { enabled: false },
+      generationalPlansv2: { enabled: false, allowedPlans: [] },
     });
   });
 

--- a/packages/manager/cypress/e2e/core/linodes/plan-selection.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/plan-selection.spec.ts
@@ -86,6 +86,14 @@ const mockGPUType = [
   }),
 ];
 
+const mockPremiumType = [
+  linodeTypeFactory.build({
+    class: 'premium',
+    id: 'premium-8',
+    label: 'Premium 8GB',
+  }),
+];
+
 const mockAcceleratedType = [
   linodeTypeFactory.build({
     class: 'accelerated',
@@ -99,6 +107,7 @@ const mockLinodeTypes = [
   ...mockHighMemoryLinodeTypes,
   ...mockSharedLinodeTypes,
   ...mockGPUType,
+  ...mockPremiumType,
   ...mockAcceleratedType,
 ];
 
@@ -225,7 +234,7 @@ describe('displays linode plans panel based on availability', () => {
       cy.get(notices.unavailable).should('be.visible');
 
       cy.findByRole('table', { name: planSelectionTable }).within(() => {
-        cy.findAllByRole('row').should('have.length', 2);
+        cy.findAllByRole('row').should('have.length', 3);
         cy.get('[id="g7-premium-64"]').should('be.disabled');
         cy.findAllByTestId('disabled-plan-tooltip').should('have.length', 0);
       });
@@ -355,7 +364,7 @@ describe('displays kubernetes plans panel based on availability', () => {
       cy.get(notices.unavailable).should('be.visible');
 
       cy.findByRole('table', { name: planSelectionTable }).within(() => {
-        cy.findAllByRole('row').should('have.length', 2);
+        cy.findAllByRole('row').should('have.length', 3);
         cy.get('[data-qa-plan-row="Premium 512 GB"]').should(
           'have.attr',
           'disabled'

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -35,7 +35,7 @@ const options: { flag: keyof Flags; label: string }[] = [
     label: 'Firewall Rulesets & Prefixlists',
   },
   { flag: 'gecko2', label: 'Gecko' },
-  { flag: 'generationalPlans', label: 'Generational compute plans' },
+  { flag: 'generationalPlansv2', label: 'Generational compute plans' },
   { flag: 'limitsEvolution', label: 'Limits Evolution' },
   { flag: 'linodeDiskEncryption', label: 'Linode Disk Encryption (LDE)' },
   { flag: 'linodeInterfaces', label: 'Linode Interfaces' },

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -202,7 +202,7 @@ export interface Flags {
   disableLargestGbPlans: boolean;
   firewallRulesetsPrefixlists: boolean;
   gecko2: GeckoFeatureFlag;
-  generationalPlans: boolean;
+  generationalPlansv2: GenerationalPlansFlag;
   gpuv2: GpuV2;
   iam: BetaFeatureFlag;
   iamDelegation: BaseFeatureFlag;
@@ -386,3 +386,7 @@ export type AclpServices = {
     metrics?: AclpFlag;
   };
 };
+
+interface GenerationalPlansFlag extends BaseFeatureFlag {
+  allowedPlans: string[];
+}

--- a/packages/manager/src/features/Linodes/LinodeCreate/Plan.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Plan.tsx
@@ -4,6 +4,7 @@ import { useController, useWatch } from 'react-hook-form';
 
 import { DocsLink } from 'src/components/DocsLink/DocsLink';
 import { PlansPanel } from 'src/features/components/PlansPanel/PlansPanel';
+import { useShouldDisablePremiumPlansTab } from 'src/features/components/PlansPanel/utils';
 import { usePermissions } from 'src/features/IAM/hooks/usePermissions';
 import { sendLinodeCreateFlowDocsClickEvent } from 'src/utilities/analytics/customEventAnalytics';
 import { sendLinodeCreateFormInputEvent } from 'src/utilities/analytics/formEventAnalytics';
@@ -32,6 +33,9 @@ export const Plan = () => {
     <PlansPanel
       data-qa-select-plan
       disabled={!permissions.create_linode}
+      disabledTabs={
+        useShouldDisablePremiumPlansTab({ types }) ? ['premium'] : undefined
+      }
       docsLink={
         <DocsLink
           href="https://techdocs.akamai.com/cloud-computing/docs/how-to-choose-a-compute-instance-plan"
@@ -55,6 +59,11 @@ export const Plan = () => {
       selectedId={field.value}
       selectedRegionID={regionId}
       showLimits
+      tabDisabledMessage={
+        useShouldDisablePremiumPlansTab({ types })
+          ? 'Premium CPUs are now called Dedicated G7 Plans.'
+          : undefined
+      }
       types={types?.map(extendType) ?? []} // @todo don't extend type
     />
   );

--- a/packages/manager/src/features/Linodes/LinodeCreate/Plan.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Plan.tsx
@@ -29,13 +29,15 @@ export const Plan = () => {
 
   const { data: permissions } = usePermissions('account', ['create_linode']);
 
+  const shouldDisablePremiumPlansTab = useShouldDisablePremiumPlansTab({
+    types,
+  });
+
   return (
     <PlansPanel
       data-qa-select-plan
       disabled={!permissions.create_linode}
-      disabledTabs={
-        useShouldDisablePremiumPlansTab({ types }) ? ['premium'] : undefined
-      }
+      disabledTabs={shouldDisablePremiumPlansTab ? ['premium'] : undefined}
       docsLink={
         <DocsLink
           href="https://techdocs.akamai.com/cloud-computing/docs/how-to-choose-a-compute-instance-plan"
@@ -60,7 +62,7 @@ export const Plan = () => {
       selectedRegionID={regionId}
       showLimits
       tabDisabledMessage={
-        useShouldDisablePremiumPlansTab({ types })
+        shouldDisablePremiumPlansTab
           ? 'Premium CPUs are now called Dedicated G7 Plans.'
           : undefined
       }

--- a/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
+++ b/packages/manager/src/features/components/PlansPanel/PlansPanel.tsx
@@ -26,6 +26,7 @@ import {
   planTabInfoContent,
   replaceOrAppendPlaceholder512GbPlans,
   useIsAcceleratedPlansEnabled,
+  useShouldDisablePremiumPlansTab,
 } from './utils';
 
 import type { PlanSelectionType } from './types';
@@ -111,6 +112,10 @@ export const PlansPanel = (props: PlansPanelProps) => {
     Boolean(flags.soldOutChips) && Boolean(selectedRegionID)
   );
 
+  const shouldDisablePremiumPlansTab = useShouldDisablePremiumPlansTab({
+    types,
+  });
+
   const _types = types.filter((type) => {
     if (!isAcceleratedLinodePlansEnabled && type.class === 'accelerated') {
       return false;
@@ -162,7 +167,7 @@ export const PlansPanel = (props: PlansPanelProps) => {
 
   const isDatabaseResize = flow === 'database' && isResize;
 
-  const tabs = Object.keys(plans).map(
+  const tabs = Object.keys(plans)?.map(
     (plan: Exclude<LinodeTypeClass, 'nanode' | 'standard'>) => {
       const plansMap: PlanSelectionType[] = plans[plan]!;
       const {
@@ -253,6 +258,19 @@ export const PlansPanel = (props: PlansPanelProps) => {
         sx={{ width: '100%' }}
       />
     );
+  }
+
+  // If there are no premium plans available, plans table will hide the premium tab.
+  // To override this behavior, we add the tab again and then disable it.
+  if (
+    shouldDisablePremiumPlansTab &&
+    !tabs.some((tab) => tab.title === planTabInfoContent.premium?.title)
+  ) {
+    tabs.push({
+      disabled: true,
+      render: () => <div />,
+      title: planTabInfoContent.premium?.title,
+    });
   }
 
   return (

--- a/packages/manager/src/features/components/PlansPanel/utils.ts
+++ b/packages/manager/src/features/components/PlansPanel/utils.ts
@@ -23,6 +23,7 @@ import type {
 import type {
   BaseType,
   Capabilities,
+  LinodeType,
   LinodeTypeClass,
   Region,
   RegionAvailability,
@@ -494,4 +495,19 @@ export const getDisabledPlanReasonCopy = ({
   }
 
   return PLAN_IS_CURRENTLY_UNAVAILABLE_COPY;
+};
+
+export const useShouldDisablePremiumPlansTab = ({
+  types,
+}: {
+  types: LinodeType[] | PlanSelectionType[] | undefined;
+}): boolean => {
+  const flags = useFlags();
+  // Check if any public premium plans are available.
+  // We can omit "Premium HT" and "Premium nested" plans as customers don't deploy them using cloud manager.
+  const arePublicPremiumPlansAvailable = types?.some(
+    (plan) => plan.class === 'premium' && /^Premium \d+GB$/i.test(plan.label)
+  );
+
+  return Boolean(flags.generationalPlans) && !arePublicPremiumPlansAvailable;
 };

--- a/packages/manager/src/features/components/PlansPanel/utils.ts
+++ b/packages/manager/src/features/components/PlansPanel/utils.ts
@@ -2,6 +2,7 @@ import { useAccount } from '@linode/queries';
 import { arrayToList, isFeatureEnabledV2 } from '@linode/utilities';
 
 import { useFlags } from 'src/hooks/useFlags';
+import { useIsGenerationalPlansEnabled } from 'src/utilities/linodes';
 
 import {
   DEDICATED_512_GB_PLAN,
@@ -502,12 +503,13 @@ export const useShouldDisablePremiumPlansTab = ({
 }: {
   types: LinodeType[] | PlanSelectionType[] | undefined;
 }): boolean => {
-  const flags = useFlags();
+  const { isGenerationalPlansEnabled, allowedPlans } =
+    useIsGenerationalPlansEnabled();
   // Check if any public premium plans are available.
   // We can omit "Premium HT" and "Premium nested" plans as customers don't deploy them using cloud manager.
   const arePublicPremiumPlansAvailable = types?.some(
-    (plan) => plan.class === 'premium' && /^Premium \d+GB$/i.test(plan.label)
+    (plan) => plan.class === 'premium' && allowedPlans.includes(plan.id)
   );
 
-  return Boolean(flags.generationalPlans) && !arePublicPremiumPlansAvailable;
+  return Boolean(isGenerationalPlansEnabled) && !arePublicPremiumPlansAvailable;
 };

--- a/packages/manager/src/mocks/presets/crud/handlers/linodes/linodes.ts
+++ b/packages/manager/src/mocks/presets/crud/handlers/linodes/linodes.ts
@@ -17,7 +17,8 @@ import {
   linodeStatsFactory,
   linodeTransferFactory,
   linodeTypeFactory,
-  premiumTypeFactory,
+  premiumHTTypeFactory,
+  premiumNestedTypeFactory,
 } from '@linode/utilities';
 import { DateTime } from 'luxon';
 import { http } from 'msw';
@@ -105,7 +106,10 @@ export const getLinodePlans = () => [
       const gpuTypesAda = gpuTypeAdaFactory.buildList(20);
       const gpuTypesRtx = gpuTypeRtxFactory.buildList(20);
       const gpuTypesRtxPro = gpuTypeRtxProFactory.buildList(20);
-      const premiumTypes = premiumTypeFactory.buildList(6);
+      const premiumTypes = [
+        premiumNestedTypeFactory.build(),
+        premiumHTTypeFactory.build(),
+      ];
       const acceleratedType = acceleratedTypeFactory.buildList(7);
       const mockPlans = [
         nanodeType,

--- a/packages/manager/src/utilities/linodes.test.ts
+++ b/packages/manager/src/utilities/linodes.test.ts
@@ -82,7 +82,9 @@ describe('useIsLinodeCloneFirewallEnabled', () => {
 
 describe('useIsGenerationalPlansEnabled', () => {
   it('returns isGenerationalPlansEnabled: true if the feature is enabled', () => {
-    const options = { flags: { generationalPlans: true } };
+    const options = {
+      flags: { generationalPlansv2: { enabled: true, allowedPlans: [] } },
+    };
 
     const { result } = renderHook(() => useIsGenerationalPlansEnabled(), {
       wrapper: (ui) => wrapWithTheme(ui, options),
@@ -92,7 +94,9 @@ describe('useIsGenerationalPlansEnabled', () => {
   });
 
   it('returns isGenerationalPlansEnabled: false if the feature is NOT enabled', () => {
-    const options = { flags: { generationalPlans: false } };
+    const options = {
+      flags: { generationalPlansv2: { enabled: false, allowedPlans: [] } },
+    };
 
     const { result } = renderHook(() => useIsGenerationalPlansEnabled(), {
       wrapper: (ui) => wrapWithTheme(ui, options),

--- a/packages/manager/src/utilities/linodes.ts
+++ b/packages/manager/src/utilities/linodes.ts
@@ -97,6 +97,7 @@ export const useIsGenerationalPlansEnabled = () => {
   const flags = useFlags();
 
   return {
-    isGenerationalPlansEnabled: Boolean(flags.generationalPlans),
+    isGenerationalPlansEnabled: Boolean(flags.generationalPlansv2?.enabled),
+    allowedPlans: flags.generationalPlansv2?.allowedPlans || [],
   };
 };

--- a/packages/utilities/src/factories/linodes.ts
+++ b/packages/utilities/src/factories/linodes.ts
@@ -444,6 +444,20 @@ export const gpuTypeRtxProFactory = linodeTypeFactory.extend({
 
 export const premiumTypeFactory = linodeTypeFactory.extend({
   class: 'premium',
+  id: Factory.each((i) => `g7-premium-${i}`),
+  label: Factory.each((i) => `Premium ${i}GB`),
+});
+
+export const premiumNestedTypeFactory = linodeTypeFactory.extend({
+  class: 'premium',
+  id: 'g7-premium-112',
+  label: 'Premium Nested 112GB',
+});
+
+export const premiumHTTypeFactory = linodeTypeFactory.extend({
+  class: 'premium',
+  id: 'g7-premium-ht-256',
+  label: 'Premium HT 256GB',
 });
 
 export const acceleratedTypeFactory = linodeTypeFactory.extend({


### PR DESCRIPTION
## Description 📝

This PR is to disable premium plans tab if corresponding GCP plans are available and show tooltip as well.

## Changes  🔄

- Disable premium plans tab if no public premium plans available and generationalPlans flag is enabled(migrated to corresponding g7 dedicated plans). Premium nested and HT plans can be ignored in this logic
- Show tooltip with corresponding message
- Changes applicable in linodes and kubernetes.

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [x] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

NA

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-11-12 at 1 37 01 PM](https://github.com/user-attachments/assets/b52c9d1b-e726-44a3-a545-11648eb70372) |  ![Screenshot 2025-11-12 at 1 37 39 PM](https://github.com/user-attachments/assets/4171067a-1ea0-426a-a341-1ebcfe94a12f) |

## How to test 🧪

### Prerequisites
- Enable `generationalPlans` feature flag
- Enable MSW (with CRUD)

### Verification steps

- In plan selection panel under create linode/kubernetes cluster, premium plans tab should be disabled with a tooltip
- Disable "generationalPlans" flag and ensure the tab is enabled.
- If MSW mode is disabled, premium plans tab should be enabled as GCP plans are not available yet for corresponding premium plans

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

-->