### PR TITLE
fix: [UIE-9523] - Show edit RDNS button for VPC NAT IPv4 address row in linode network tab

### DIFF
--- a/packages/manager/.changeset/pr-13170-fixed-1764918493011.md
+++ b/packages/manager/.changeset/pr-13170-fixed-1764918493011.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Show edit RDNS button for VPC NAT IPv4 address row in linode network tab ([#13170](https://github.com/linode/manager/pull/13170))

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddressRow.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeIPAddressRow.test.tsx
@@ -16,7 +16,9 @@ const ipDisplay = ipResponseToDisplayRows({
   ipResponse: ips,
   isLinodeInterface: false,
 })[0];
-const ipDisplayVPC = createVPCIPv4Display([vpcIPv4Factory.build()])[0];
+const [ipDisplayVPC, ipDisplayVPCNAT] = createVPCIPv4Display([
+  vpcIPv4Factory.build(),
+]);
 
 const handlers: IPAddressRowHandlers = {
   handleOpenEditRDNS: vi.fn(),
@@ -70,6 +72,26 @@ describe('LinodeIPAddressRow', () => {
     // No actions should be rendered
     expect(queryByText('Delete')).not.toBeInTheDocument();
     expect(queryByText('Edit RDNS')).not.toBeInTheDocument();
+  });
+
+  it('should render a VPC NAT IPv4 Address row', () => {
+    const { getAllByText } = renderWithTheme(
+      wrapWithTableBody(
+        <LinodeIPAddressRow
+          isLinodeInterface={false}
+          isUnreachablePublicIPv4={false}
+          linodeId={1}
+          readOnly={false}
+          {...handlers}
+          {...ipDisplayVPCNAT}
+        />
+      )
+    );
+
+    getAllByText(ipDisplayVPCNAT.address);
+    getAllByText(ipDisplayVPCNAT.type);
+    // Check if actions were rendered
+    getAllByText('Edit RDNS');
   });
 
   it('should disable the row if disabled is true and display a tooltip', async () => {

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingActionMenu.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingActionMenu.tsx
@@ -49,7 +49,9 @@ export const LinodeNetworkingActionMenu = (props: Props) => {
     'Reserved IPv4 (private)',
     'Reserved IPv4 (public)',
     'VPC – IPv4',
-    'VPC NAT – IPv4',
+    'VPC – IPv6',
+    'VPC – Range – IPv4',
+    'VPC – Range – IPv6',
   ].includes(ipType);
 
   const deletableIPTypes = ['Private – IPv4', 'Public – IPv4', 'Range – IPv6'];

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/utils.ts
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/utils.ts
@@ -138,6 +138,25 @@ export const ipToDisplay = (ip: IPAddress, key: IPKey): IPDisplay => {
   };
 };
 
+const ipAdressForVPC = (
+  ip: VPCIP,
+  ipAdress: string,
+  ipType: string
+): IPAddress => {
+  return {
+    address: ipAdress,
+    gateway: ip.gateway,
+    interface_id: ip.interface_id,
+    linode_id: ip.linode_id!,
+    prefix: ip.prefix!,
+    public: false,
+    rdns: null,
+    region: ip.region,
+    subnet_mask: ip.subnet_mask,
+    type: ipType,
+  };
+};
+
 export const createVPCIPv4Display = (ips: VPCIP[]): IPDisplay[] => {
   const emptyProps = {
     gateway: '',
@@ -163,6 +182,7 @@ export const createVPCIPv4Display = (ips: VPCIP[]): IPDisplay[] => {
     }
     if (ip.nat_1_1) {
       vpcIPDisplay.push({
+        _ip: ipAdressForVPC(ip, ip.nat_1_1, 'VPC NAT – IPv4'),
         address: ip.nat_1_1,
         type: 'VPC NAT – IPv4',
         ...emptyProps,

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/utils.ts
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/utils.ts
@@ -138,13 +138,13 @@ export const ipToDisplay = (ip: IPAddress, key: IPKey): IPDisplay => {
   };
 };
 
-const ipAdressForVPC = (
+const ipAddressForVPC = (
   ip: VPCIP,
-  ipAdress: string,
+  ipAddress: string,
   ipType: string
 ): IPAddress => {
   return {
-    address: ipAdress,
+    address: ipAddress,
     gateway: ip.gateway,
     interface_id: ip.interface_id,
     linode_id: ip.linode_id!,
@@ -182,7 +182,7 @@ export const createVPCIPv4Display = (ips: VPCIP[]): IPDisplay[] => {
     }
     if (ip.nat_1_1) {
       vpcIPDisplay.push({
-        _ip: ipAdressForVPC(ip, ip.nat_1_1, 'VPC NAT – IPv4'),
+        _ip: ipAddressForVPC(ip, ip.nat_1_1, 'VPC NAT – IPv4'),
         address: ip.nat_1_1,
         type: 'VPC NAT – IPv4',
         ...emptyProps,


### PR DESCRIPTION
## Description 📝

Under linode network tab, edit button is hidden currently for VPC NAT IPv4 address. As part of this PR, this issue is fixed by showing the button for such IP address row.

## Changes  🔄

- Updated logic to show/hide edit button in IP address row under linode network tab to show the button for VPC NAT IP address as well.

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [x] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

December 2025

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-12-05 at 12 21 41 PM](https://github.com/user-attachments/assets/c36a3627-a6c0-488a-a999-7140fb78782f) | ![Screenshot 2025-12-05 at 12 22 18 PM](https://github.com/user-attachments/assets/1e219820-430e-4164-8657-4209895168c8) |

## How to test 🧪

### Prerequisites

- Login to https://cloud.devcloud.linode.com/ or https://cloud.linode.com
- Navigate to linodes page

### Reproduction steps

- Create Linode
- Create VPC
- Assign linode to VPC. Ensure "Allow public IPv4 access (1:1 NAT)" is checked before assigning Linode to VPC
- Reboot Linode
- After reboot is completed, switch to network tab under linode details page and under IP addresses table, see that IP address row with type "VPC NAT – IPv4" doesn't have edit RDNS button.

### Verification steps

(How to verify changes)

- [ ] Follow above steps and ensure Edit RDNS button is shown for IP address row with type "VPC NAT – IPv4".
- [ ] Ensure no regressions

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

-->