### PR TITLE
change: [UIE-9860] - Change the default selection of network interface type to linode interface in Linode create flow

### DIFF
--- a/packages/manager/.changeset/pr-13221-changed-1766474458876.md
+++ b/packages/manager/.changeset/pr-13221-changed-1766474458876.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Change the default selection of network interface type to linode interface in Linode create flow ([#13221](https://github.com/linode/manager/pull/13221))

--- a/packages/manager/.changeset/pr-13221-changed-1766474458876.md
+++ b/packages/manager/.changeset/pr-13221-changed-1766474458876.md
@@ -2,4 +2,4 @@
 "@linode/manager": Changed
 ---
 
-Change the default selection of network interface type to linode interface in Linode create flow ([#13221](https://github.com/linode/manager/pull/13221))
+Default selection of network interface type to linode interface in Linode create flow ([#13221](https://github.com/linode/manager/pull/13221))

--- a/packages/manager/cypress/e2e/core/linodes/create-linode-with-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode-with-firewall.spec.ts
@@ -421,6 +421,9 @@ describe('Create Linode with Firewall (Linode Interfaces)', () => {
     // Confirm the Linode Interfaces section is shown.
     assertNewLinodeInterfacesIsAvailable();
 
+    // Switch to legacy Config Interfaces
+    linodeCreatePage.selectLegacyConfigInterfacesType();
+
     // Confirm that mocked Firewall is shown in the Autocomplete, and then select it.
     cy.findByLabelText('Firewall').should('be.visible');
     cy.get('[data-qa-autocomplete="Firewall"]').within(() => {
@@ -490,9 +493,6 @@ describe('Create Linode with Firewall (Linode Interfaces)', () => {
 
     // Confirm the Linode Interfaces section is shown.
     assertNewLinodeInterfacesIsAvailable();
-
-    // Switch to Linode Interfaces
-    linodeCreatePage.selectLinodeInterfacesType();
 
     // Confirm that mocked Firewall is shown in the Autocomplete, and then select it.
     cy.findByLabelText('Public Interface Firewall').should('be.visible');
@@ -565,6 +565,9 @@ describe('Create Linode with Firewall (Linode Interfaces)', () => {
 
     // Confirm the Linode Interfaces section is shown.
     assertNewLinodeInterfacesIsAvailable();
+
+    // Switch to legacy Config Interfaces
+    linodeCreatePage.selectLegacyConfigInterfacesType();
 
     cy.findByText('Create Firewall').should('be.visible').click();
 
@@ -660,9 +663,6 @@ describe('Create Linode with Firewall (Linode Interfaces)', () => {
 
     // Confirm the Linode Interfaces section is shown.
     assertNewLinodeInterfacesIsAvailable();
-
-    // Switch to Linode Interfaces
-    linodeCreatePage.selectLinodeInterfacesType();
 
     cy.findByText('Create Firewall').should('be.visible').click();
 
@@ -766,6 +766,9 @@ describe('Create Linode with Firewall (Linode Interfaces)', () => {
     // Confirm the Linode Interfaces section is shown.
     assertNewLinodeInterfacesIsAvailable();
 
+    // Switch to legacy Config Interfaces
+    linodeCreatePage.selectLegacyConfigInterfacesType();
+
     // Creating the linode without a firewall should display a warning.
     ui.button
       .findByTitle('Create Linode')
@@ -868,9 +871,6 @@ describe('Create Linode with Firewall (Linode Interfaces)', () => {
 
     // Confirm the Linode Interfaces section is shown.
     assertNewLinodeInterfacesIsAvailable();
-
-    // Switch to Linode Interfaces
-    linodeCreatePage.selectLinodeInterfacesType();
 
     // Creating the linode without a firewall should display a warning.
     ui.button

--- a/packages/manager/cypress/e2e/core/linodes/create-linode-with-vlan.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode-with-vlan.spec.ts
@@ -319,6 +319,9 @@ describe('Create Linode with VLANs (Linode Interfaces)', () => {
     // Confirm the Linode Interfaces section is shown.
     assertNewLinodeInterfacesIsAvailable();
 
+    // Switch to legacy Config Interfaces
+    linodeCreatePage.selectLegacyConfigInterfacesType();
+
     // select existing VLAN.
     linodeCreatePage.selectInterface('vlan');
     // Confirm that mocked VLAN is shown in the Autocomplete, and then select it.
@@ -399,9 +402,6 @@ describe('Create Linode with VLANs (Linode Interfaces)', () => {
 
     // Confirm the Linode Interfaces section is shown.
     assertNewLinodeInterfacesIsAvailable();
-
-    // Switch to Linode Interfaces
-    linodeCreatePage.selectLinodeInterfacesType();
 
     // Select VLAN card
     linodeCreatePage.selectInterface('vlan');
@@ -485,6 +485,9 @@ describe('Create Linode with VLANs (Linode Interfaces)', () => {
     // Confirm the Linode Interfaces section is shown.
     assertNewLinodeInterfacesIsAvailable();
 
+    // Switch to legacy Config Interfaces
+    linodeCreatePage.selectLegacyConfigInterfacesType();
+
     // Select VLAN card
     linodeCreatePage.selectInterface('vlan');
 
@@ -566,9 +569,6 @@ describe('Create Linode with VLANs (Linode Interfaces)', () => {
 
     // Confirm the Linode Interfaces section is shown.
     assertNewLinodeInterfacesIsAvailable();
-
-    // Switch to Linode Interfaces
-    linodeCreatePage.selectLinodeInterfacesType();
 
     // Select VLAN card
     linodeCreatePage.selectInterface('vlan');

--- a/packages/manager/cypress/e2e/core/linodes/create-linode-with-vpc.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode-with-vpc.spec.ts
@@ -476,6 +476,9 @@ describe('Create Linode with VPCs (Linode Interfaces)', () => {
     // Confirm the Linode Interfaces section is shown.
     assertNewLinodeInterfacesIsAvailable();
 
+    // Switch to legacy Config Interfaces
+    linodeCreatePage.selectLegacyConfigInterfacesType();
+
     // Select VPC
     linodeCreatePage.selectInterface('vpc');
 
@@ -612,9 +615,6 @@ describe('Create Linode with VPCs (Linode Interfaces)', () => {
     // Confirm the Linode Interfaces section is shown.
     assertNewLinodeInterfacesIsAvailable();
 
-    // Switch to Linode Interfaces
-    linodeCreatePage.selectLinodeInterfacesType();
-
     // Select VPC option
     linodeCreatePage.selectInterface('vpc');
 
@@ -749,6 +749,9 @@ describe('Create Linode with VPCs (Linode Interfaces)', () => {
 
     // Confirm the Linode Interfaces section is shown.
     assertNewLinodeInterfacesIsAvailable();
+
+    // Switch to legacy Config Interfaces
+    linodeCreatePage.selectLegacyConfigInterfacesType();
 
     // Select VPC card
     linodeCreatePage.selectInterface('vpc');
@@ -932,9 +935,6 @@ describe('Create Linode with VPCs (Linode Interfaces)', () => {
 
     // Confirm the Linode Interfaces section is shown.
     assertNewLinodeInterfacesIsAvailable();
-
-    // Switch to Linode Interfaces
-    linodeCreatePage.selectLinodeInterfacesType();
 
     // Select VPC card
     linodeCreatePage.selectInterface('vpc');

--- a/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceGeneration.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceGeneration.tsx
@@ -65,7 +65,7 @@ export const InterfaceGeneration = () => {
             aria-labelledby="interface-generation"
             onChange={field.onChange}
             sx={{ my: '0px !important' }}
-            value={field.value ?? 'legacy_config'}
+            value={field.value ?? 'linode'}
           >
             <FormControlLabel
               control={<Radio />}

--- a/packages/manager/src/features/Linodes/LinodeCreate/utilities.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/utilities.test.tsx
@@ -434,14 +434,6 @@ describe('getIsValidLinodeLabelCharacter', () => {
 });
 
 describe('getDefaultInterfaceGenerationFromAccountSetting', () => {
-  it('returns "legacy_config" for "legacy_config_default_but_linode_allowed"', () => {
-    expect(
-      getDefaultInterfaceGenerationFromAccountSetting(
-        'legacy_config_default_but_linode_allowed'
-      )
-    ).toBe('legacy_config');
-  });
-
   it('returns "legacy_config" for "legacy_config_only"', () => {
     expect(
       getDefaultInterfaceGenerationFromAccountSetting('legacy_config_only')
@@ -452,6 +444,14 @@ describe('getDefaultInterfaceGenerationFromAccountSetting', () => {
     expect(getDefaultInterfaceGenerationFromAccountSetting('linode_only')).toBe(
       'linode'
     );
+  });
+
+  it('returns "linode" for "legacy_config_default_but_linode_allowed"', () => {
+    expect(
+      getDefaultInterfaceGenerationFromAccountSetting(
+        'legacy_config_default_but_linode_allowed'
+      )
+    ).toBe('linode');
   });
 
   it('returns "linode" for "linode_default_but_legacy_config_allowed"', () => {

--- a/packages/manager/src/features/Linodes/LinodeCreate/utilities.ts
+++ b/packages/manager/src/features/Linodes/LinodeCreate/utilities.ts
@@ -616,14 +616,13 @@ export const getDefaultInterfaceGenerationFromAccountSetting = (
 ): InterfaceGenerationType | undefined => {
   if (
     accountSetting === 'linode_only' ||
-    accountSetting === 'linode_default_but_legacy_config_allowed'
-  ) {
-    return 'linode';
-  }
-  if (
-    accountSetting === 'legacy_config_only' ||
+    accountSetting === 'linode_default_but_legacy_config_allowed' ||
     accountSetting === 'legacy_config_default_but_linode_allowed'
   ) {
+    // Default selection is to the Linode interface to encourage new customer accounts to adopt it safely when using Cloud Manager.
+    return 'linode';
+  }
+  if (accountSetting === 'legacy_config_only') {
     return 'legacy_config';
   }
   return undefined;


### PR DESCRIPTION
## Description 📝

Change the default selection of network interface type from legacy 'configuration profile' to 'linode interface' in Linode create flow.

## Changes  🔄

- Changed default value of interface generation type to 'linode' in `getDefaultInterfaceGenerationFromAccountSetting` utility function

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [x] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

NA

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-12-23 at 12 13 09 PM](https://github.com/user-attachments/assets/f33438a0-4cd2-4cf4-87e6-bbcc0539fcf9) | ![Screenshot 2025-12-23 at 12 28 07 PM](https://github.com/user-attachments/assets/ff84c443-8c65-454b-b25b-b43fd5749da6) |

## How to test 🧪

### Prerequisites

- In account settings, ensure the network interface type for new linodes is "config profile but allow Linode interface"

### Verification steps

- Network interface type in Linode create flow should be "Linode interfaces" by default.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

-->