### PR TITLE
change: [UIE-9863] - UX/UI changes in Linode Create flow - Networking

### DIFF
--- a/packages/manager/.changeset/pr-13223-changed-1766491572015.md
+++ b/packages/manager/.changeset/pr-13223-changed-1766491572015.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+UX/UI changes in Linode Create flow - Networking ([#13223](https://github.com/linode/manager/pull/13223))

--- a/packages/manager/cypress/e2e/core/linodes/create-linode-with-vlan.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode-with-vlan.spec.ts
@@ -319,9 +319,14 @@ describe('Create Linode with VLANs (Linode Interfaces)', () => {
     // Confirm the Linode Interfaces section is shown.
     assertNewLinodeInterfacesIsAvailable();
 
-    // Open VLAN accordion and select existing VLAN.
-    cy.get('[data-qa-select-card-heading="VLAN"]').should('be.visible').click();
-    cy.findByLabelText('VLAN').should('be.enabled').type(mockVlan.label);
+    // select existing VLAN.
+    linodeCreatePage.selectInterface('vlan');
+    // Confirm that mocked VLAN is shown in the Autocomplete, and then select it.
+    cy.get('[data-qa-autocomplete="VLAN"]').within(() => {
+      cy.findByLabelText('VLAN').should('be.visible');
+      cy.get('[data-testid="textfield-input"]').click();
+      cy.focused().type(`${mockVlan.label}`);
+    });
     ui.autocompletePopper
       .findByTitle(mockVlan.label)
       .should('be.visible')
@@ -399,10 +404,14 @@ describe('Create Linode with VLANs (Linode Interfaces)', () => {
     linodeCreatePage.selectLinodeInterfacesType();
 
     // Select VLAN card
-    linodeCreatePage.selectInterfaceCard('VLAN');
+    linodeCreatePage.selectInterface('vlan');
 
-    // Open VLAN accordion and select existing VLAN.
-    cy.findByLabelText('VLAN').should('be.enabled').type(mockVlan.label);
+    // select existing VLAN.
+    cy.get('[data-qa-autocomplete="VLAN"]').within(() => {
+      cy.findByLabelText('VLAN').should('be.visible');
+      cy.get('[data-testid="textfield-input"]').click();
+      cy.focused().type(`${mockVlan.label}`);
+    });
     ui.autocompletePopper
       .findByTitle(mockVlan.label)
       .should('be.visible')
@@ -477,10 +486,14 @@ describe('Create Linode with VLANs (Linode Interfaces)', () => {
     assertNewLinodeInterfacesIsAvailable();
 
     // Select VLAN card
-    linodeCreatePage.selectInterfaceCard('VLAN');
+    linodeCreatePage.selectInterface('vlan');
 
-    // Open VLAN accordion and specify new VLAN.
-    cy.findByLabelText('VLAN').should('be.enabled').type(mockVlan.label);
+    // select new VLAN.
+    cy.get('[data-qa-autocomplete="VLAN"]').within(() => {
+      cy.findByLabelText('VLAN').should('be.visible');
+      cy.get('[data-testid="textfield-input"]').click();
+      cy.focused().type(`${mockVlan.label}`);
+    });
     ui.autocompletePopper
       .findByTitle(`Create "${mockVlan.label}"`)
       .should('be.visible')
@@ -558,10 +571,14 @@ describe('Create Linode with VLANs (Linode Interfaces)', () => {
     linodeCreatePage.selectLinodeInterfacesType();
 
     // Select VLAN card
-    linodeCreatePage.selectInterfaceCard('VLAN');
+    linodeCreatePage.selectInterface('vlan');
 
-    // Open VLAN accordion and specify new VLAN.
-    cy.findByLabelText('VLAN').should('be.enabled').type(mockVlan.label);
+    // select new VLAN.
+    cy.get('[data-qa-autocomplete="VLAN"]').within(() => {
+      cy.findByLabelText('VLAN').should('be.visible');
+      cy.get('[data-testid="textfield-input"]').click();
+      cy.focused().type(`${mockVlan.label}`);
+    });
     ui.autocompletePopper
       .findByTitle(`Create "${mockVlan.label}"`)
       .should('be.visible')
@@ -620,9 +637,9 @@ describe('Create Linode with VLANs (Linode Interfaces)', () => {
     assertNewLinodeInterfacesIsAvailable();
 
     // Select VLAN card
-    linodeCreatePage.selectInterfaceCard('VLAN');
+    linodeCreatePage.selectInterface('vlan');
 
-    // Expand VLAN accordion, confirm VLAN availability notice is displayed and
+    // confirm VLAN availability notice is displayed and
     // that VLAN fields are disabled while no region is selected.
     cy.findByText('VLAN is not available in the selected region.', {
       exact: false,

--- a/packages/manager/cypress/e2e/core/linodes/create-linode-with-vpc.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/create-linode-with-vpc.spec.ts
@@ -476,8 +476,8 @@ describe('Create Linode with VPCs (Linode Interfaces)', () => {
     // Confirm the Linode Interfaces section is shown.
     assertNewLinodeInterfacesIsAvailable();
 
-    // Select VPC card
-    linodeCreatePage.selectInterfaceCard('VPC');
+    // Select VPC
+    linodeCreatePage.selectInterface('vpc');
 
     // Confirm that mocked VPC is shown in the Autocomplete, and then select it.
     cy.get('[data-qa-autocomplete="VPC"]').within(() => {
@@ -615,8 +615,8 @@ describe('Create Linode with VPCs (Linode Interfaces)', () => {
     // Switch to Linode Interfaces
     linodeCreatePage.selectLinodeInterfacesType();
 
-    // Select VPC card
-    linodeCreatePage.selectInterfaceCard('VPC');
+    // Select VPC option
+    linodeCreatePage.selectInterface('vpc');
 
     // Confirm that mocked VPC is shown in the Autocomplete, and then select it.
     cy.get('[data-qa-autocomplete="VPC"]').within(() => {
@@ -751,7 +751,7 @@ describe('Create Linode with VPCs (Linode Interfaces)', () => {
     assertNewLinodeInterfacesIsAvailable();
 
     // Select VPC card
-    linodeCreatePage.selectInterfaceCard('VPC');
+    linodeCreatePage.selectInterface('vpc');
 
     cy.findByText('Create VPC').should('be.visible').click();
 
@@ -937,7 +937,7 @@ describe('Create Linode with VPCs (Linode Interfaces)', () => {
     linodeCreatePage.selectLinodeInterfacesType();
 
     // Select VPC card
-    linodeCreatePage.selectInterfaceCard('VPC');
+    linodeCreatePage.selectInterface('vpc');
 
     cy.findByText('Create VPC').should('be.visible').click();
 
@@ -1068,7 +1068,7 @@ describe('Create Linode with VPCs (Linode Interfaces)', () => {
     assertNewLinodeInterfacesIsAvailable();
 
     // Select VPC card.
-    linodeCreatePage.selectInterfaceCard('VPC');
+    linodeCreatePage.selectInterface('vpc');
 
     // Confirm that VPC selection is disabled.
     cy.get('[data-qa-autocomplete="VPC"]').within(() => {

--- a/packages/manager/cypress/support/constants/linode-interfaces.ts
+++ b/packages/manager/cypress/support/constants/linode-interfaces.ts
@@ -44,7 +44,7 @@ export const linodeInterfacesLabelText = 'Linode Interfaces';
 export const betaLabelText = 'beta';
 
 export const linodeInterfacesDescriptionText1 =
-  'Linode Interfaces are the preferred option for VPCs and are managed directly through a Linode’s Network settings.';
+  "Managed directly through a Linode's Network settings. This is the recommended option.";
 
 export const linodeInterfacesDescriptionText2 =
   'Cloud Firewalls are assigned to individual VPC and public interfaces.';
@@ -53,7 +53,7 @@ export const legacyInterfacesLabelText =
   'Configuration Profile Interfaces (Legacy)';
 
 export const legacyInterfacesDescriptionText1 =
-  'Interfaces in the Configuration Profile are part of a Linode’s configuration.';
+  'Interfaces are part of the Linode’s Configuration Profile.';
 
 export const legacyInterfacesDescriptionText2 =
   'Cloud Firewalls are applied at the Linode level and automatically cover all non-VLAN interfaces in the Configuration Profile.';

--- a/packages/manager/cypress/support/ui/pages/linode-create-page.ts
+++ b/packages/manager/cypress/support/ui/pages/linode-create-page.ts
@@ -130,7 +130,7 @@ export const linodeCreatePage = {
    * Select the Linode Interfaces Type.
    */
   selectLinodeInterfacesType: () => {
-    cy.findByText('Linode Interfaces').click();
+    cy.get('[data-qa-interfaces-option="linode"]').click();
   },
 
   /**
@@ -141,13 +141,11 @@ export const linodeCreatePage = {
   },
 
   /**
-   * Select the interfaces' card.
+   * Select the interfaces' type.
    *
-   * @param title - Interfaces' card title to select.
+   * @param type - Interfaces' type title to select.
    */
-  selectInterfaceCard: (title: string) => {
-    cy.get(`[data-qa-select-card-heading="${title}"]`)
-      .should('be.visible')
-      .click();
+  selectInterface: (type: 'public' | 'vlan' | 'vpc') => {
+    cy.get(`[data-qa-interface-type-option="${type}"]`).click();
   },
 };

--- a/packages/manager/cypress/support/util/linodes.ts
+++ b/packages/manager/cypress/support/util/linodes.ts
@@ -5,13 +5,7 @@ import { findOrCreateDependencyVlan } from 'support/api/vlans';
 import { pageSize } from 'support/constants/api';
 import {
   dryRunButtonText,
-  legacyInterfacesDescriptionText1,
-  legacyInterfacesDescriptionText2,
   legacyInterfacesLabelText,
-  linodeInterfacesDescriptionText1,
-  linodeInterfacesDescriptionText2,
-  linodeInterfacesLabelText,
-  networkConnectionDescriptionText,
   networkConnectionSectionText,
   networkInterfaceTypeSectionText,
   promptDialogDescription1,
@@ -330,14 +324,9 @@ export const assertNewLinodeInterfacesIsAvailable = (
 ): void => {
   const expectedBehavior = linodeInterfacesEnabled ? 'be.visible' : 'not.exist';
   cy.findByText(networkInterfaceTypeSectionText).should(expectedBehavior);
-  cy.findByText(linodeInterfacesLabelText).should(expectedBehavior);
-  cy.findByText(linodeInterfacesDescriptionText1).should(expectedBehavior);
-  cy.findByText(linodeInterfacesDescriptionText2).should(expectedBehavior);
+  cy.get('[data-qa-interfaces-option="linode"]').should(expectedBehavior);
   cy.findByText(legacyInterfacesLabelText).should(expectedBehavior);
-  cy.findByText(legacyInterfacesDescriptionText1).should(expectedBehavior);
-  cy.findByText(legacyInterfacesDescriptionText2).should(expectedBehavior);
   cy.findByText(networkConnectionSectionText).should(expectedBehavior);
-  cy.findByText(networkConnectionDescriptionText).should(expectedBehavior);
 };
 
 /**

--- a/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceGeneration.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceGeneration.test.tsx
@@ -33,7 +33,7 @@ describe('InterfaceGeneration', () => {
     await userEvent.hover(getByText('Network Interface Type'));
 
     await findByText(
-      'You account administrator has enforced that all new Linodes are created with Linode interfaces.'
+      'Your account administrator has enforced that all new Linodes are created with Linode interfaces.'
     );
 
     for (const radio of getAllByRole('radio')) {
@@ -66,7 +66,7 @@ describe('InterfaceGeneration', () => {
     await userEvent.hover(getByText('Network Interface Type'));
 
     await findByText(
-      'You account administrator has enforced that all new Linodes are created with legacy configuration interfaces.'
+      'Your account administrator has enforced that all new Linodes are created with legacy configuration interfaces.'
     );
 
     const radios = getAllByRole('radio');

--- a/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceGeneration.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceGeneration.tsx
@@ -57,7 +57,10 @@ export const InterfaceGeneration = () => {
         defaultExpanded={!disabled}
         name="Network Interface Type"
       >
-        <FormControl disabled={disabled} sx={{ my: '0px !important', mx: 0.5 }}>
+        <FormControl
+          disabled={disabled}
+          sx={{ mt: '0px !important', mb: 2, mx: 0.5 }}
+        >
           <RadioGroup
             aria-labelledby="interface-generation"
             onChange={field.onChange}

--- a/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceGeneration.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceGeneration.tsx
@@ -66,6 +66,7 @@ export const InterfaceGeneration = () => {
           >
             <FormControlLabel
               control={<Radio />}
+              data-qa-interfaces-option="linode"
               label={
                 <Stack mt={1.25} spacing={0.5}>
                   <Stack direction="row">
@@ -95,6 +96,7 @@ export const InterfaceGeneration = () => {
             />
             <FormControlLabel
               control={<Radio />}
+              data-qa-interfaces-option="legacy_config"
               label={
                 <Stack direction="row" mt={1.25} spacing={0.5}>
                   <Typography sx={(theme) => ({ font: theme.font.bold })}>

--- a/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceGeneration.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceGeneration.tsx
@@ -6,6 +6,7 @@ import {
   Radio,
   RadioGroup,
   Stack,
+  TooltipIcon,
   Typography,
 } from '@linode/ui';
 import React from 'react';
@@ -22,9 +23,9 @@ const disabledReasonMap: Partial<
   Record<LinodeInterfaceAccountSetting, string>
 > = {
   legacy_config_only:
-    'You account administrator has enforced that all new Linodes are created with legacy configuration interfaces.',
+    'Your account administrator has enforced that all new Linodes are created with legacy configuration interfaces.',
   linode_only:
-    'You account administrator has enforced that all new Linodes are created with Linode interfaces.',
+    'Your account administrator has enforced that all new Linodes are created with Linode interfaces.',
 };
 
 export const InterfaceGeneration = () => {
@@ -72,15 +73,21 @@ export const InterfaceGeneration = () => {
                       Linode Interfaces
                     </Typography>
                     <LinodeInterfaceFeatureStatusChip />
+                    <TooltipIcon
+                      status="info"
+                      sxTooltipIcon={{ p: 0, ml: 0.5 }}
+                      text={
+                        <>
+                          Managed directly through a Linode&apos;s Network
+                          settings. This is the recommended option.
+                          <br />
+                          <br />
+                          Cloud Firewalls are assigned to individual VPC and
+                          public interfaces.
+                        </>
+                      }
+                    />
                   </Stack>
-                  <Typography>
-                    Linode Interfaces are the preferred option for VPCs and are
-                    managed directly through a Linode’s Network settings.
-                  </Typography>
-                  <Typography>
-                    Cloud Firewalls are assigned to individual VPC and public
-                    interfaces.
-                  </Typography>
                 </Stack>
               }
               sx={{ alignItems: 'flex-start' }}
@@ -89,19 +96,25 @@ export const InterfaceGeneration = () => {
             <FormControlLabel
               control={<Radio />}
               label={
-                <Stack mt={1.25} spacing={0.5}>
+                <Stack direction="row" mt={1.25} spacing={0.5}>
                   <Typography sx={(theme) => ({ font: theme.font.bold })}>
                     Configuration Profile Interfaces (Legacy)
                   </Typography>
-                  <Typography>
-                    Interfaces in the Configuration Profile are part of a
-                    Linode’s configuration.
-                  </Typography>
-                  <Typography>
-                    Cloud Firewalls are applied at the Linode level and
-                    automatically cover all non-VLAN interfaces in the
-                    Configuration Profile.
-                  </Typography>
+                  <TooltipIcon
+                    status="info"
+                    sxTooltipIcon={{ p: 0, ml: 0.5 }}
+                    text={
+                      <>
+                        Interfaces are part of the Linode&apos;s Configuration
+                        Profile.
+                        <br />
+                        <br />
+                        Cloud Firewalls are applied at the Linode level and
+                        automatically cover all non-VLAN interfaces in the
+                        Configuration Profile.
+                      </>
+                    }
+                  />
                 </Stack>
               }
               sx={{ alignItems: 'flex-start' }}

--- a/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceType.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceType.tsx
@@ -7,13 +7,12 @@ import {
   TooltipIcon,
   Typography,
 } from '@linode/ui';
-import { Grid } from '@mui/material';
+import { FormControlLabel, Stack } from '@mui/material';
 import { useSnackbar } from 'notistack';
 import React from 'react';
 import { useController, useFormContext, useWatch } from 'react-hook-form';
 
 import { FormLabel } from 'src/components/FormLabel';
-import { SelectionCard } from 'src/components/SelectionCard/SelectionCard';
 
 import { useGetLinodeCreateType } from '../Tabs/utils/useGetLinodeCreateType';
 import { getDefaultFirewallForInterfacePurpose } from './utilities';
@@ -36,7 +35,7 @@ const interfaceTypes = [
     label: 'VPC',
     purpose: 'vpc',
     description:
-      'Connects your Linode to a private, Layer 3–isolated network, enabling secure communication with other Linodes in the same VPC.',
+      'Connects your Linode to a private, Layer 3 isolated network, allowing secure communication with other Linodes in the same VPC.',
   },
   {
     label: 'VLAN',
@@ -122,48 +121,33 @@ export const InterfaceType = ({ index }: Props) => {
           />
         )}
       </Box>
-      <Typography id="network-connection-helper-text">
-        The default interface used by this Linode to route network traffic.
-        Additional interfaces can be added after the Linode is created.
-      </Typography>
       <RadioGroup
         aria-describedby="network-connection-helper-text"
         aria-labelledby="network-connection-label"
-        sx={{ display: 'block', marginBottom: '0px !important' }}
+        onChange={(e) => onChange(e.target.value as InterfacePurpose)}
+        value={field.value}
       >
-        <Grid container spacing={2}>
-          {interfaceTypes.map((interfaceType) => (
-            <SelectionCard
-              checked={disabled ? false : field.value === interfaceType.purpose}
-              disabled={disabled}
-              gridSize={{
-                md: 3,
-                sm: 12,
-                xs: 12,
-              }}
-              heading={interfaceType.label}
-              key={interfaceType.purpose}
-              onClick={() => onChange(interfaceType.purpose)}
-              renderIcon={() => (
-                <Radio
-                  checked={
-                    disabled ? false : field.value === interfaceType.purpose
-                  }
-                  disabled={disabled}
-                />
-              )}
-              renderVariant={() => (
+        {interfaceTypes.map((interfaceType) => (
+          <FormControlLabel
+            control={<Radio />}
+            disabled={disabled}
+            key={interfaceType.purpose}
+            label={
+              <Stack direction="row" mt={1.25} spacing={0.5}>
+                <Typography sx={(theme) => ({ font: theme.font.bold })}>
+                  {interfaceType.label}
+                </Typography>
                 <TooltipIcon
                   status="info"
-                  sxTooltipIcon={{ p: 0.5 }}
+                  sxTooltipIcon={{ p: 0, ml: 0.5 }}
                   text={interfaceType.description}
                 />
-              )}
-              subheadings={[]}
-              sxCardBaseIcon={{ svg: { fontSize: '20px' } }}
-            />
-          ))}
-        </Grid>
+              </Stack>
+            }
+            sx={{ alignItems: 'flex-start' }}
+            value={disabled ? false : interfaceType.purpose}
+          />
+        ))}
       </RadioGroup>
     </FormControl>
   );

--- a/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceType.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceType.tsx
@@ -9,6 +9,7 @@ import {
 } from '@linode/ui';
 import { FormControlLabel, Stack } from '@mui/material';
 import { useSnackbar } from 'notistack';
+import type { ChangeEvent } from 'react';
 import React from 'react';
 import { useController, useFormContext, useWatch } from 'react-hook-form';
 
@@ -124,7 +125,7 @@ export const InterfaceType = ({ index }: Props) => {
       <RadioGroup
         aria-describedby="network-connection-helper-text"
         aria-labelledby="network-connection-label"
-        onChange={(e) => onChange(e.target.value as InterfacePurpose)}
+        onChange={(_: ChangeEvent, value: InterfacePurpose) => onChange(value)}
         value={field.value}
       >
         {interfaceTypes.map((interfaceType) => (

--- a/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceType.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceType.tsx
@@ -130,6 +130,7 @@ export const InterfaceType = ({ index }: Props) => {
         {interfaceTypes.map((interfaceType) => (
           <FormControlLabel
             control={<Radio />}
+            data-qa-interface-type-option={interfaceType.purpose}
             disabled={disabled}
             key={interfaceType.purpose}
             label={

--- a/packages/manager/src/features/Linodes/LinodeCreate/Networking/VLAN.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Networking/VLAN.tsx
@@ -27,7 +27,7 @@ export const VLAN = ({ index }: Props) => {
     selectedRegion?.capabilities.includes('Vlans') ?? false;
 
   return (
-    <Stack spacing={1.5}>
+    <Stack spacing={1.5} sx={{ mb: '16px !important' }}>
       {selectedRegion && !regionSupportsVLANs && <VLANAvailabilityNotice />}
       <Stack alignItems="flex-start" direction="row" flexWrap="wrap" gap={2}>
         <Controller

--- a/packages/manager/src/features/Linodes/LinodeCreate/Networking/VPC.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Networking/VPC.tsx
@@ -67,7 +67,7 @@ export const VPC = ({ index }: Props) => {
     Boolean(selectedSubnet?.ipv6?.length && selectedSubnet?.ipv6?.length > 0);
 
   return (
-    <Box>
+    <Box sx={{ mb: '16px !important' }}>
       <Stack spacing={1.5}>
         {selectedRegion && !regionSupportsVPCs && <VPCAvailabilityNotice />}
         <Controller
@@ -221,7 +221,6 @@ export const VPC = ({ index }: Props) => {
           </Box>
         </Stack>
         <VPCRanges disabled={!regionSupportsVPCs} interfaceIndex={index} />
-        <Divider sx={(theme) => ({ marginTop: theme.spacingFunction(16) })} />
         {showIPv6Fields && (
           <VPCIPv6Ranges
             disabled={!regionSupportsVPCs}

--- a/packages/manager/src/features/Linodes/LinodeCreate/Networking/VPC.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Networking/VPC.tsx
@@ -221,6 +221,7 @@ export const VPC = ({ index }: Props) => {
           </Box>
         </Stack>
         <VPCRanges disabled={!regionSupportsVPCs} interfaceIndex={index} />
+        <Divider sx={(theme) => ({ marginTop: theme.spacingFunction(16) })} />
         {showIPv6Fields && (
           <VPCIPv6Ranges
             disabled={!regionSupportsVPCs}

--- a/packages/manager/src/features/Linodes/LinodeCreate/Networking/VPC.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Networking/VPC.tsx
@@ -164,23 +164,25 @@ export const VPC = ({ index }: Props) => {
             )}
           />
           {showIPv6Fields && (
-            <Controller
-              control={control}
-              name={`linodeInterfaces.${index}.vpc.ipv6.slaac.0.range`}
-              render={({ field, fieldState }) => (
-                <VPCIPv6Address
-                  disabled={!regionSupportsVPCs}
-                  errorMessage={
-                    fieldState.error?.message ??
-                    errors.linodeInterfaces?.[index]?.vpc?.ipv6?.slaac?.[0]
-                      ?.range?.message
-                  }
-                  fieldValue={field.value}
-                  onBlur={field.onBlur}
-                  onChange={field.onChange}
-                />
-              )}
-            />
+            <Box sx={{ mb: 2 }}>
+              <Controller
+                control={control}
+                name={`linodeInterfaces.${index}.vpc.ipv6.slaac.0.range`}
+                render={({ field, fieldState }) => (
+                  <VPCIPv6Address
+                    disabled={!regionSupportsVPCs}
+                    errorMessage={
+                      fieldState.error?.message ??
+                      errors.linodeInterfaces?.[index]?.vpc?.ipv6?.slaac?.[0]
+                        ?.range?.message
+                    }
+                    fieldValue={field.value}
+                    onBlur={field.onBlur}
+                    onChange={field.onChange}
+                  />
+                )}
+              />
+            </Box>
           )}
           <Box>
             <Divider


### PR DESCRIPTION
## Description 📝

Apply suggested UX changes in networking section to ease the Linode create flow.

## Changes  🔄

- Change selection card to radio selection for network connection under networking section in create linode flow
- Remove description for each of the network interface type and show it in info icon.

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [x] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

NA

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2025-12-23 at 5 27 35 PM](https://github.com/user-attachments/assets/81eee531-213e-4db3-af80-ad80e22a2a3f) | ![Screenshot 2025-12-23 at 5 28 02 PM](https://github.com/user-attachments/assets/ea794268-e3ac-4e2f-bf30-5c3858702636) |
| ![Screenshot 2025-12-23 at 5 28 22 PM](https://github.com/user-attachments/assets/e208c7d7-0d25-4d08-94da-733282fbb1b5) | ![Screenshot 2025-12-23 at 5 28 34 PM](https://github.com/user-attachments/assets/cf656fe3-5d4d-4855-b8f2-c76ebe38e285) |


## How to test 🧪

### Prerequisites

- Navigate to create Linode flow and scroll to networking section

### Verification steps

- [x] Ensure new design changes are reflecting to show radio selection for network connection type instead of selection cards
- [x] Ensure descriptions are not shown and instead an info icon with tooltip message is shown for each network interface type.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

-->