### PR TITLE
fix: [UIE-9891] - Fix logic to remove linode interface from firewall's device page

### DIFF
--- a/packages/manager/.changeset/pr-13238-fixed-1767338454581.md
+++ b/packages/manager/.changeset/pr-13238-fixed-1767338454581.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Fix logic to remove linode interface from firewall's device page ([#13238](https://github.com/linode/manager/pull/13238))

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallDeviceTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallDeviceTable.tsx
@@ -181,9 +181,12 @@ export const FirewallDeviceTable = React.memo(
                   disabled={disabled}
                   handleRemoveDevice={handleRemoveDevice}
                   isLinodeRelatedDevice={isLinodeRelatedDevice}
-                  isLinodeUpdatable={updatableLinodes?.some(
-                    (linode) => linode.id === thisDevice.entity.id
-                  )}
+                  isLinodeUpdatable={updatableLinodes?.some((linode) => {
+                    if (thisDevice.entity.type === 'linode_interface') {
+                      return linode.id === thisDevice.entity.parent_entity?.id;
+                    }
+                    return linode.id === thisDevice.entity.id;
+                  })}
                   isNodebalancerUpdatable={updatableNodebalancers?.some(
                     (nodebalancer) => nodebalancer.id === thisDevice.entity.id
                   )}


### PR DESCRIPTION
## Description 📝

As part of this PR, logic to remove devices from a firewall is updated to allow removal of linode interface from it.

## Changes  🔄

- In `FirewallDeviceTable.tsx` file, logic to derive `isLinodeUpdatable` is fixed for removal linode interfaces as well.

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [x] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

NA

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2026-01-02 at 12 40 47 PM](https://github.com/user-attachments/assets/af010517-bb9e-444f-8477-e0b724ab5c12) | ![Screenshot 2026-01-02 at 12 40 11 PM](https://github.com/user-attachments/assets/f57bdc0a-a8e5-48d7-b7ff-83cf60c7c25a) |

## How to test 🧪

### Prerequisites

- Ensure linode interfaces feature is enabled
- Go to `firewalls/{firewall_id}/linodes` page

### Reproduction steps

- Currently in prod and test environments, under linodes tab in devices table of firewall details page, Remove button is disabled for linode interfaces.

### Verification steps

- Ensure remove button is enabled for linode interfaces as well

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

-->