### PR TITLE
fix: [UIE-9841] - Hide dual stack option if no IPv6 prefixes available in create VPC flow

### DIFF
--- a/packages/api-v4/.changeset/pr-13245-tech-stories-1767723985438.md
+++ b/packages/api-v4/.changeset/pr-13245-tech-stories-1767723985438.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Tech Stories
+---
+
+Clean up unused VPC IPv6 Large Prefixes tag ([#13245](https://github.com/linode/manager/pull/13245))

--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -93,7 +93,6 @@ export const accountCapabilities = [
   'Vlans',
   'VPCs',
   'VPC Dual Stack',
-  'VPC IPv6 Large Prefixes',
 ] as const;
 
 export type AccountCapability = (typeof accountCapabilities)[number];

--- a/packages/manager/.changeset/pr-13245-fixed-1767723908908.md
+++ b/packages/manager/.changeset/pr-13245-fixed-1767723908908.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Hide dual stack option if no IPv6 prefixes available in create VPC flow ([#13245](https://github.com/linode/manager/pull/13245))

--- a/packages/manager/src/factories/account.ts
+++ b/packages/manager/src/factories/account.ts
@@ -56,6 +56,7 @@ export const accountFactory = Factory.Sync.makeFactory<Account>({
     'Placement Group',
     'Vlans',
     'Kubernetes Enterprise',
+    'VPC Dual Stack',
   ],
   city: 'Philadelphia',
   company: Factory.each((i) => `company-${i}`),

--- a/packages/manager/src/factories/userAccountPermissions.ts
+++ b/packages/manager/src/factories/userAccountPermissions.ts
@@ -3,4 +3,5 @@ import type { PermissionType } from '@linode/api-v4';
 export const userAccountPermissionsFactory: PermissionType[] = [
   'create_linode',
   'create_firewall',
+  'create_vpc',
 ];

--- a/packages/manager/src/features/VPCs/VPCCreate/FormComponents/VPCTopSectionContent.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCCreate/FormComponents/VPCTopSectionContent.test.tsx
@@ -147,7 +147,7 @@ describe('VPC Top Section form content', () => {
     expect(IPv6CIDRRadios[3]).toBeChecked(); // /52
   });
 
-  it('does not show dual stack option and does not render VPC IPv6 Prefix Length options if there are none available or only /52 available', async () => {
+  it('does not show dual stack option and does not render VPC IPv6 Prefix Length options if there are none available', async () => {
     const account = accountFactory.build({
       capabilities: ['VPC Dual Stack'],
     });
@@ -159,7 +159,7 @@ describe('VPC Top Section form content', () => {
           makeResourcePage([
             regionVPCAvailabilityFactory.build({
               region: 'us-east',
-              available_ipv6_prefix_lengths: [52],
+              available_ipv6_prefix_lengths: [],
             }),
           ])
         )

--- a/packages/manager/src/features/VPCs/VPCCreate/FormComponents/VPCTopSectionContent.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCCreate/FormComponents/VPCTopSectionContent.test.tsx
@@ -73,12 +73,11 @@ describe('VPC Top Section form content', () => {
 
     const NetworkingIPStackRadios = screen.getAllByRole('radio');
     expect(NetworkingIPStackRadios[0]).toBeChecked(); // IPv4
-    expect(NetworkingIPStackRadios[1]).not.toBeChecked(); // Dual Stack
   });
 
   it('renders VPC IPv6 Prefix Length options with /52 selected if the selected region has multiple prefix lengths available', async () => {
     const account = accountFactory.build({
-      capabilities: ['VPC Dual Stack', 'VPC IPv6 Large Prefixes'],
+      capabilities: ['VPC Dual Stack'],
     });
 
     server.use(http.get('*/account', () => HttpResponse.json(account)));
@@ -148,7 +147,7 @@ describe('VPC Top Section form content', () => {
     expect(IPv6CIDRRadios[3]).toBeChecked(); // /52
   });
 
-  it('does not render VPC IPv6 Prefix Length options if there are none available or only /52 available', async () => {
+  it('does not show dual stack option and does not render VPC IPv6 Prefix Length options if there are none available or only /52 available', async () => {
     const account = accountFactory.build({
       capabilities: ['VPC Dual Stack'],
     });
@@ -189,10 +188,10 @@ describe('VPC Top Section form content', () => {
       expect(screen.getByText('IP Stack')).toBeVisible();
     });
 
-    const NetworkingIPStackRadios = screen.getAllByRole('radio');
-    await userEvent.click(NetworkingIPStackRadios[1]);
-    expect(NetworkingIPStackRadios[0]).not.toBeChecked(); // IPv4
-    expect(NetworkingIPStackRadios[1]).toBeChecked(); // Dual Stack
+    expect(screen.getByText('IPv4')).toBeVisible(); // IPv4
+    expect(
+      screen.queryByText('IPv4 + IPv6 (Dual Stack)')
+    ).not.toBeInTheDocument(); // Dual Stack
 
     expect(
       screen.queryByText('VPC IPv6 Prefix Length')

--- a/packages/manager/src/features/VPCs/VPCCreate/FormComponents/VPCTopSectionContent.tsx
+++ b/packages/manager/src/features/VPCs/VPCCreate/FormComponents/VPCTopSectionContent.tsx
@@ -206,7 +206,7 @@ export const VPCTopSectionContent = (props: Props) => {
                     sxCardBaseIcon={{ svg: { fontSize: '20px' } }}
                   />
                   {availableRegionIPv6PrefixLengths &&
-                    availableRegionIPv6PrefixLengths.length > 1 && (
+                    availableRegionIPv6PrefixLengths.length > 0 && (
                       <SelectionCard
                         checked={isDualStackSelected}
                         disabled={!permissions?.create_vpc}

--- a/packages/manager/src/features/VPCs/VPCCreate/FormComponents/VPCTopSectionContent.tsx
+++ b/packages/manager/src/features/VPCs/VPCCreate/FormComponents/VPCTopSectionContent.tsx
@@ -205,61 +205,64 @@ export const VPCTopSectionContent = (props: Props) => {
                     sxCardBase={{ gap: 0 }}
                     sxCardBaseIcon={{ svg: { fontSize: '20px' } }}
                   />
-                  <SelectionCard
-                    checked={isDualStackSelected}
-                    disabled={!permissions?.create_vpc}
-                    gridSize={{
-                      md: isDrawer ? 12 : 3,
-                      sm: 12,
-                      xs: 12,
-                    }}
-                    heading="IPv4 + IPv6 (Dual Stack)"
-                    onClick={() => {
-                      field.onChange([
-                        {
-                          range: '/52',
-                        },
-                      ]);
-                      subnets?.forEach((subnet, idx) =>
-                        update(idx, {
-                          ...subnet,
-                          ipv6: subnet.ipv6 ?? [{ range: '/56' }],
-                        })
-                      );
-                    }}
-                    renderIcon={() => (
-                      <Radio
+                  {availableRegionIPv6PrefixLengths &&
+                    availableRegionIPv6PrefixLengths.length > 1 && (
+                      <SelectionCard
                         checked={isDualStackSelected}
                         disabled={!permissions?.create_vpc}
-                      />
-                    )}
-                    renderVariant={() => (
-                      <TooltipIcon
-                        status="info"
-                        sxTooltipIcon={{
-                          padding: '8px',
+                        gridSize={{
+                          md: isDrawer ? 12 : 3,
+                          sm: 12,
+                          xs: 12,
                         }}
-                        text={
-                          <Stack spacing={2}>
-                            <Typography>
-                              The VPC supports both IPv4 and IPv6 addresses.
-                            </Typography>
-                            <Typography>
-                              For IPv4, {RFC1918HelperText}
-                            </Typography>
-                            <Typography>
-                              For IPv6, the VPC is assigned an IPv6 prefix
-                              length of <Code>/52</Code> by default.
-                            </Typography>
-                          </Stack>
-                        }
-                        width={250}
+                        heading="IPv4 + IPv6 (Dual Stack)"
+                        onClick={() => {
+                          field.onChange([
+                            {
+                              range: '/52',
+                            },
+                          ]);
+                          subnets?.forEach((subnet, idx) =>
+                            update(idx, {
+                              ...subnet,
+                              ipv6: subnet.ipv6 ?? [{ range: '/56' }],
+                            })
+                          );
+                        }}
+                        renderIcon={() => (
+                          <Radio
+                            checked={isDualStackSelected}
+                            disabled={!permissions?.create_vpc}
+                          />
+                        )}
+                        renderVariant={() => (
+                          <TooltipIcon
+                            status="info"
+                            sxTooltipIcon={{
+                              padding: '8px',
+                            }}
+                            text={
+                              <Stack spacing={2}>
+                                <Typography>
+                                  The VPC supports both IPv4 and IPv6 addresses.
+                                </Typography>
+                                <Typography>
+                                  For IPv4, {RFC1918HelperText}
+                                </Typography>
+                                <Typography>
+                                  For IPv6, the VPC is assigned an IPv6 prefix
+                                  length of <Code>/52</Code> by default.
+                                </Typography>
+                              </Stack>
+                            }
+                            width={250}
+                          />
+                        )}
+                        subheadings={[]}
+                        sxCardBase={{ gap: 0 }}
+                        sxCardBaseIcon={{ svg: { fontSize: '20px' } }}
                       />
                     )}
-                    subheadings={[]}
-                    sxCardBase={{ gap: 0 }}
-                    sxCardBaseIcon={{ svg: { fontSize: '20px' } }}
-                  />
                 </Grid>
               </RadioGroup>
             )}

--- a/packages/manager/src/hooks/useVPCDualStack.ts
+++ b/packages/manager/src/hooks/useVPCDualStack.ts
@@ -17,12 +17,6 @@ export const useVPCDualStack = (ipv6?: VPCIPv6[]) => {
     account?.capabilities ?? []
   );
 
-  const isEnterpriseCustomer = isFeatureEnabledV2(
-    'VPC IPv6 Large Prefixes',
-    Boolean(flags.vpcIpv6),
-    account?.capabilities ?? []
-  );
-
   const shouldDisplayIPv6 = isDualStackEnabled && isDualStackSelected;
   const recommendedIPv6 = shouldDisplayIPv6
     ? [
@@ -35,7 +29,6 @@ export const useVPCDualStack = (ipv6?: VPCIPv6[]) => {
   return {
     isDualStackEnabled,
     isDualStackSelected,
-    isEnterpriseCustomer,
     shouldDisplayIPv6,
     recommendedIPv6,
   };

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -521,6 +521,30 @@ const vpc = [
     const subnet = subnetFactory.build({ ...(body as any) });
     return HttpResponse.json(subnet);
   }),
+  http.get('*/v4beta/regions/vpc-availability', () => {
+    return HttpResponse.json({
+      data: [
+        {
+          region: 'ap-west',
+          available: false,
+          available_ipv6_prefix_lengths: [],
+        },
+        {
+          region: 'in-maa',
+          available: true,
+          available_ipv6_prefix_lengths: [52],
+        },
+        {
+          region: 'us-southeast',
+          available: true,
+          available_ipv6_prefix_lengths: [48, 52],
+        },
+      ],
+      page: 1,
+      pages: 1,
+      results: 3,
+    });
+  }),
 ];
 
 const iam = [

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -526,7 +526,7 @@ const vpc = [
       data: [
         {
           region: 'ap-west',
-          available: false,
+          available: true,
           available_ipv6_prefix_lengths: [],
         },
         {


### PR DESCRIPTION
## Description 📝

As part of this PR,  if the available VPC IPv6 prefix length for a DC is 0, then dual-stack option should not be shown under IP stack in create VPC flow.

## Changes  🔄

- If `availableRegionIPv6PrefixLengths > 0`, only then show `IPv4 + IPv6 (Dual Stack)` option in create VPC screen.
- Make necessary changes to enable Create VPC flow in MSW setup with legacy MSW handlers enabled.
- Clean up unused `VPC IPv6 Large Prefixes` tag.

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [x] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

NA

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2026-01-06 at 11 28 17 PM](https://github.com/user-attachments/assets/cc8456a0-010c-4944-ad64-97f9cc9d7b6c) | ![Screenshot 2026-01-06 at 11 28 07 PM](https://github.com/user-attachments/assets/2de3f06f-b3e6-4e95-bb4d-fcea174ae19f) |

## How to test 🧪

### Prerequisites

- Add `new-dc-testing-alpha` tag in prod account.
- In local, switch to prod environment.

### Reproduction steps

- Go to https://cloud.linode.com/vpcs/create and select "us-iad-2" region.
- See that "Dual stack" option is visible under IP stack and submission of create form with dual stack option selected fails with related error.

### Verification steps

- In local with prod environment setup, go to /vpcs/create and select "us-iad-2" region
- See that "Dual stack" option is not visible under IP stack as the DC doesn't supports multiple IPv6 prefixes.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

-->