### PR TITLE
change: [UIE-9859] - Improvements in Add Network interface drawer

### DIFF
--- a/packages/manager/.changeset/pr-13264-changed-1768219863915.md
+++ b/packages/manager/.changeset/pr-13264-changed-1768219863915.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Improvements in Add Network interface drawer ([#13264](https://github.com/linode/manager/pull/13264))

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/AddInterfaceDrawer/AddInterfaceForm.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/AddInterfaceDrawer/AddInterfaceForm.test.tsx
@@ -1,3 +1,4 @@
+import { linodeInterfaceFactoryPublic } from '@linode/utilities';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
@@ -11,8 +12,23 @@ import { AddInterfaceForm } from './AddInterfaceForm';
 const props = { linodeId: 0, onClose: vi.fn(), regionId: '' };
 
 describe('AddInterfaceForm', () => {
-  it('renders radios for the interface types (Public, VPC, VLAN)', () => {
-    const { getByRole } = renderWithTheme(<AddInterfaceForm {...props} />);
+  beforeEach(() => {
+    server.use(
+      http.get('*/linode/instances/:linodeId/interfaces', () => {
+        return HttpResponse.json({
+          interfaces: [],
+        });
+      })
+    );
+  });
+
+  it('renders radios for the interface types (Public, VPC, VLAN)', async () => {
+    const { getByRole, findByRole } = renderWithTheme(
+      <AddInterfaceForm {...props} />
+    );
+
+    // Wait for the loading to complete and form to render
+    await findByRole('radio', { name: 'VPC' });
 
     expect(getByRole('radio', { name: 'VPC' })).toBeInTheDocument();
     expect(getByRole('radio', { name: 'Public' })).toBeInTheDocument();
@@ -20,30 +36,36 @@ describe('AddInterfaceForm', () => {
   });
 
   it('renders a Firewall select if "VPC" is selected', async () => {
-    const { getByRole, getByLabelText } = renderWithTheme(
+    const { getByRole, getByLabelText, findByRole } = renderWithTheme(
       <AddInterfaceForm {...props} />
     );
 
+    // Wait for the loading to complete and form to render
+    await findByRole('radio', { name: 'VPC' });
     await userEvent.click(getByRole('radio', { name: 'VPC' }));
 
     expect(getByLabelText('Firewall')).toBeVisible();
   });
 
   it('renders a Firewall select if "Public" is selected', async () => {
-    const { getByRole, getByLabelText } = renderWithTheme(
+    const { getByRole, getByLabelText, findByRole } = renderWithTheme(
       <AddInterfaceForm {...props} />
     );
 
+    // Wait for the loading to complete and form to render
+    await findByRole('radio', { name: 'Public' });
     await userEvent.click(getByRole('radio', { name: 'Public' }));
 
     expect(getByLabelText('Firewall')).toBeVisible();
   });
 
   it('renders does not render a Firewall select if "VLAN" is selected', async () => {
-    const { getByRole, queryByLabelText } = renderWithTheme(
+    const { getByRole, queryByLabelText, findByRole } = renderWithTheme(
       <AddInterfaceForm {...props} />
     );
 
+    // Wait for the loading to complete and form to render
+    await findByRole('radio', { name: 'VLAN' });
     await userEvent.click(getByRole('radio', { name: 'VLAN' }));
 
     expect(queryByLabelText('Firewall')).toBeNull();
@@ -67,12 +89,58 @@ describe('AddInterfaceForm', () => {
       })
     );
 
-    const { getByRole, findByDisplayValue } = renderWithTheme(
+    const { getByRole, findByDisplayValue, findByRole } = renderWithTheme(
       <AddInterfaceForm {...props} />
     );
 
+    // Wait for the loading to complete and form to render
+    await findByRole('radio', { name: 'VPC' });
     await userEvent.click(getByRole('radio', { name: 'VPC' }));
 
     await findByDisplayValue(firewall.label);
+  });
+
+  it('should show a warning notice on selection of VPC option if a Public interface already exists', async () => {
+    const mockPublicInterface = linodeInterfaceFactoryPublic.build();
+
+    server.use(
+      http.get('*/linode/instances/:linodeId/interfaces', () => {
+        return HttpResponse.json({
+          interfaces: [mockPublicInterface],
+        });
+      })
+    );
+
+    const { getByRole, findByRole, getByText } = renderWithTheme(
+      <AddInterfaceForm {...props} />
+    );
+
+    // Wait for the loading to complete and form to render
+    await findByRole('radio', { name: 'VPC' });
+    await userEvent.click(getByRole('radio', { name: 'VPC' }));
+    expect(
+      getByText(/This Linode already has a public interface/)
+    ).toBeVisible();
+  });
+
+  it('should disable Public interface radio button if a Public interface already exists', async () => {
+    const mockPublicInterface = linodeInterfaceFactoryPublic.build();
+
+    server.use(
+      http.get('*/linode/instances/:linodeId/interfaces', () => {
+        return HttpResponse.json({
+          interfaces: [mockPublicInterface],
+        });
+      })
+    );
+
+    const { getByRole, findByRole } = renderWithTheme(
+      <AddInterfaceForm {...props} />
+    );
+
+    // Wait for the loading to complete and form to render
+    await findByRole('radio', { name: 'Public' });
+
+    expect(getByRole('radio', { name: 'Public' })).toBeDisabled();
   });
 });

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/AddInterfaceDrawer/AddInterfaceForm.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/AddInterfaceDrawer/AddInterfaceForm.tsx
@@ -13,6 +13,7 @@ import {
   getLinodeInterfacePayload,
 } from 'src/features/Linodes/LinodeCreate/Networking/utilities';
 
+import { getLinodeInterfaceType } from '../utilities';
 import { Actions } from './Actions';
 import { InterfaceFirewall } from './InterfaceFirewall';
 import { InterfaceType } from './InterfaceType';
@@ -39,16 +40,10 @@ export const AddInterfaceForm = (props: Props) => {
     useLinodeInterfacesQuery(linodeId);
 
   const existingInterfaces =
-    interfacesData?.interfaces.map((networkInterface) => {
-      if (networkInterface.public) {
-        return 'public';
-      } else if (networkInterface.vlan) {
-        return 'vlan';
-      } else {
-        return 'vpc';
-      }
-    }) ?? [];
-  const isPublicInterfacePresent = existingInterfaces.includes('public');
+    interfacesData?.interfaces.map((networkInterface) =>
+      getLinodeInterfaceType(networkInterface)
+    ) ?? [];
+  const isPublicInterfacePresent = existingInterfaces.includes('Public');
   const form = useForm<CreateInterfaceFormValues>({
     defaultValues: {
       firewall_id: null,

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/AddInterfaceDrawer/AddInterfaceForm.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/AddInterfaceDrawer/AddInterfaceForm.tsx
@@ -1,6 +1,9 @@
 import { yupResolver } from '@hookform/resolvers/yup';
-import { useCreateLinodeInterfaceMutation } from '@linode/queries';
-import { Notice, Stack } from '@linode/ui';
+import {
+  useCreateLinodeInterfaceMutation,
+  useLinodeInterfacesQuery,
+} from '@linode/queries';
+import { Box, CircleProgress, Notice, Stack, Typography } from '@linode/ui';
 import { useSnackbar } from 'notistack';
 import React from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
@@ -32,6 +35,20 @@ export const AddInterfaceForm = (props: Props) => {
 
   const { mutateAsync } = useCreateLinodeInterfaceMutation(linodeId);
 
+  const { data: interfacesData, isPending: isLoadingInterfaces } =
+    useLinodeInterfacesQuery(linodeId);
+
+  const existingInterfaces =
+    interfacesData?.interfaces.map((networkInterface) => {
+      if (networkInterface.public) {
+        return 'public';
+      } else if (networkInterface.vlan) {
+        return 'vlan';
+      } else {
+        return 'vpc';
+      }
+    }) ?? [];
+  const isPublicInterfacePresent = existingInterfaces.includes('public');
   const form = useForm<CreateInterfaceFormValues>({
     defaultValues: {
       firewall_id: null,
@@ -78,6 +95,21 @@ export const AddInterfaceForm = (props: Props) => {
 
   const selectedInterfacePurpose = form.watch('purpose');
 
+  if (isLoadingInterfaces) {
+    return (
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          height: 'calc(100% - 100px)',
+        }}
+      >
+        <CircleProgress size="md" />
+      </Box>
+    );
+  }
+
   return (
     <FormProvider {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)}>
@@ -94,13 +126,30 @@ export const AddInterfaceForm = (props: Props) => {
               variant="error"
             />
           )}
-          <InterfaceType />
+          <InterfaceType existingInterfaces={existingInterfaces} />
           {selectedInterfacePurpose === 'public' && <PublicInterface />}
           {selectedInterfacePurpose === 'vlan' && (
             <VLANInterface regionId={regionId} />
           )}
           {selectedInterfacePurpose === 'vpc' && (
-            <VPCInterface regionId={regionId} />
+            <Box>
+              {isPublicInterfacePresent && (
+                <Notice variant="warning">
+                  <Typography>
+                    This Linode already has a public interface. Having a both a
+                    VPC interface and a public interface is not recommnded. If
+                    you need public internet access, consider using the VPC’s
+                    <strong> Public access</strong> option instead.
+                  </Typography>
+                  <Typography paddingTop={2}>
+                    Each Linode includes one public IP address. To request
+                    additional public IPs, please note that they incur a monthly
+                    charge.
+                  </Typography>
+                </Notice>
+              )}
+              <VPCInterface regionId={regionId} />
+            </Box>
           )}
           {selectedInterfacePurpose !== 'vlan' && <InterfaceFirewall />}
           <Actions onClose={onClose} />

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/AddInterfaceDrawer/AddInterfaceForm.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/AddInterfaceDrawer/AddInterfaceForm.tsx
@@ -137,7 +137,7 @@ export const AddInterfaceForm = (props: Props) => {
                 <Notice variant="warning">
                   <Typography>
                     This Linode already has a public interface. Having a both a
-                    VPC interface and a public interface is not recommnded. If
+                    VPC interface and a public interface is not recommended. If
                     you need public internet access, consider using the VPC’s
                     <strong> Public access</strong> option instead.
                   </Typography>

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/AddInterfaceDrawer/AddInterfaceForm.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/AddInterfaceDrawer/AddInterfaceForm.tsx
@@ -131,7 +131,7 @@ export const AddInterfaceForm = (props: Props) => {
               {isPublicInterfacePresent && (
                 <Notice variant="warning">
                   <Typography>
-                    This Linode already has a public interface. Having a both a
+                    This Linode already has a public interface. Having both a
                     VPC interface and a public interface is not recommended. If
                     you need public internet access, consider using the VPC’s
                     <strong> Public access</strong> option instead.

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/AddInterfaceDrawer/InterfaceType.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/AddInterfaceDrawer/InterfaceType.tsx
@@ -5,6 +5,8 @@ import {
   FormHelperText,
   Radio,
   RadioGroup,
+  Stack,
+  TooltipIcon,
 } from '@linode/ui';
 import { useQueryClient } from '@tanstack/react-query';
 import { useSnackbar } from 'notistack';
@@ -16,7 +18,11 @@ import { getDefaultFirewallForInterfacePurpose } from 'src/features/Linodes/Lino
 import type { CreateInterfaceFormValues } from './utilities';
 import type { InterfacePurpose } from '@linode/api-v4';
 
-export const InterfaceType = () => {
+interface Props {
+  existingInterfaces?: InterfacePurpose[] | null;
+}
+export const InterfaceType = (props: Props) => {
+  const { existingInterfaces } = props;
   const queryClient = useQueryClient();
   const { enqueueSnackbar } = useSnackbar();
 
@@ -72,7 +78,23 @@ export const InterfaceType = () => {
         sx={{ my: `0 !important` }}
         value={field.value ?? null}
       >
-        <FormControlLabel control={<Radio />} label="Public" value="public" />
+        <FormControlLabel
+          control={<Radio />}
+          disabled={existingInterfaces?.includes('public')}
+          label={
+            <Stack alignItems="center" direction="row" spacing={0.5}>
+              Public
+              {existingInterfaces?.includes('public') && (
+                <TooltipIcon
+                  status="info"
+                  sxTooltipIcon={{ p: 0, ml: '8px !important' }}
+                  text="Each Linode can only have one public interface"
+                />
+              )}
+            </Stack>
+          }
+          value="public"
+        />
         <FormControlLabel control={<Radio />} label="VPC" value="vpc" />
         <FormControlLabel control={<Radio />} label="VLAN" value="vlan" />
       </RadioGroup>

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/AddInterfaceDrawer/InterfaceType.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/AddInterfaceDrawer/InterfaceType.tsx
@@ -15,11 +15,12 @@ import { useController, useFormContext } from 'react-hook-form';
 
 import { getDefaultFirewallForInterfacePurpose } from 'src/features/Linodes/LinodeCreate/Networking/utilities';
 
+import type { LinodeInterfaceType } from '../utilities';
 import type { CreateInterfaceFormValues } from './utilities';
 import type { InterfacePurpose } from '@linode/api-v4';
 
 interface Props {
-  existingInterfaces?: InterfacePurpose[] | null;
+  existingInterfaces?: LinodeInterfaceType[] | null;
 }
 export const InterfaceType = (props: Props) => {
   const { existingInterfaces } = props;
@@ -80,11 +81,11 @@ export const InterfaceType = (props: Props) => {
       >
         <FormControlLabel
           control={<Radio />}
-          disabled={existingInterfaces?.includes('public')}
+          disabled={existingInterfaces?.includes('Public')}
           label={
             <Stack alignItems="center" direction="row" spacing={0.5}>
               Public
-              {existingInterfaces?.includes('public') && (
+              {existingInterfaces?.includes('Public') && (
                 <TooltipIcon
                   status="info"
                   sxTooltipIcon={{ p: 0, ml: '8px !important' }}


### PR DESCRIPTION
## Description 📝

As part of this PR, changes has been introduced to improvise UX of Add network interface drawer.

## Changes  🔄

- Show warning when VPC is selected for a linode that already includes public interface.
- Disable public interface option when linode already has public interface.

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [x] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

Jan 28

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2026-01-12 at 5 27 48 PM](https://github.com/user-attachments/assets/ee836e28-eb0e-4bed-8c26-2353825a1f1e) | ![Screenshot 2026-01-12 at 5 11 23 PM](https://github.com/user-attachments/assets/837ef6fe-3092-429d-b4a7-bcd18f4d4307) |
| ![Screenshot 2026-01-12 at 5 28 07 PM](https://github.com/user-attachments/assets/e307bab0-5307-4edc-ab00-ac732713ce50) | ![Screenshot 2026-01-12 at 5 28 57 PM](https://github.com/user-attachments/assets/5b132b7d-6fa4-430d-841e-664256651cd9) |


## How to test 🧪

### Prerequisites

- Create a linode with linode interfaces as configuration type and public internet as network connection.
- Go to Linode details page and switch to Network tab. Click on Add Network interface button.

### Verification steps

- [x] Ensure Public option is disabled as the linode already has a public interface
- [x] Click on VPC option and see that a warning is shown
- [x] Go back to details page and delete public interface from network interface table. Ensure previous behavior is retained in this case.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

-->