### PR TITLE
change: [UIE-9945] - Implement UX and user feedback for linode interfaces feature in Account settings page

### DIFF
--- a/packages/manager/.changeset/pr-13280-changed-1768458211341.md
+++ b/packages/manager/.changeset/pr-13280-changed-1768458211341.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Apply UX and user feedback for linode interfaces feature in Account settings page ([#13280](https://github.com/linode/manager/pull/13280))

--- a/packages/manager/cypress/e2e/core/account/network-settings.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/network-settings.spec.ts
@@ -28,9 +28,9 @@ import type { LinodeInterfaceAccountSetting } from '@linode/api-v4';
 
 const interfaceTypeMap = {
   legacy_config_default_but_linode_allowed:
-    'Configuration Profile Interfaces but allow Linode Interfaces',
+    'Configuration Profile Interfaces (default) but allow Linode Interfaces',
   linode_default_but_legacy_config_allowed:
-    'Linode Interfaces but allow Configuration Profile Interfaces',
+    'Linode Interfaces (default) but allow Configuration Profile Interfaces',
   legacy_config_only: 'Configuration Profile Interfaces Only',
   linode_only: 'Linode Interfaces Only',
 };
@@ -54,7 +54,7 @@ describe('Account network settings', () => {
   describe('Network interface types', () => {
     /*
      * - Confirms that customers can update their account-level Linode interface type.
-     * - Confirms that "Interfaces for new Linodes" drop-down displays user's set value on page load.
+     * - Confirms that "Allowed interfaces for new Linodes" drop-down displays user's set value on page load.
      * - Confirms that save button is initially disabled, but becomes enabled upon changing the selection.
      * - Confirms that outgoing API request contains expected payload data for chosen interface type.
      * - Confirms that toast appears upon successful settings update operation.
@@ -81,7 +81,7 @@ describe('Account network settings', () => {
 
           // Confirm that selected interface type matches API response, and that
           // "Save" button is disabled by default.
-          cy.findByLabelText('Interfaces for new Linodes').should(
+          cy.findByLabelText('Allowed interfaces for new Linodes').should(
             'have.value',
             interfaceTypeMap[defaultInterface]
           );
@@ -89,7 +89,7 @@ describe('Account network settings', () => {
 
           // Confirm that changing selection causes "Save" button to become enabled,
           // then changing back causes it to become disabled again.
-          cy.findByLabelText('Interfaces for new Linodes').click();
+          cy.findByLabelText('Allowed interfaces for new Linodes').click();
           ui.autocompletePopper.find().within(() => {
             cy.findByText(interfaceTypeMap[otherInterfaces[0]])
               .should('be.visible')
@@ -97,7 +97,7 @@ describe('Account network settings', () => {
           });
           ui.button.findByTitle('Save').should('be.enabled');
 
-          cy.findByLabelText('Interfaces for new Linodes').click();
+          cy.findByLabelText('Allowed interfaces for new Linodes').click();
           ui.autocompletePopper.find().within(() => {
             cy.findByText(interfaceTypeMap[defaultInterface])
               .should('be.visible')
@@ -108,7 +108,7 @@ describe('Account network settings', () => {
           // Confirm that we can update our setting using every other choice,
           // and that the outgoing API request payload contains the expected value.
           otherInterfaces.forEach((otherInterface, index) => {
-            cy.findByLabelText('Interfaces for new Linodes').click();
+            cy.findByLabelText('Allowed interfaces for new Linodes').click();
             ui.autocompletePopper.find().within(() => {
               cy.findByText(interfaceTypeMap[otherInterface])
                 .should('be.visible')
@@ -161,7 +161,7 @@ describe('Account network settings', () => {
         .should('be.visible')
         .within(() => {
           cy.findByText('Network Interface Type').should('be.visible');
-          cy.findByLabelText('Interfaces for new Linodes')
+          cy.findByLabelText('Allowed interfaces for new Linodes')
             .should('be.visible')
             .click();
           ui.autocompletePopper.find().within(() => {

--- a/packages/manager/src/features/Account/NetworkInterfaceType.test.tsx
+++ b/packages/manager/src/features/Account/NetworkInterfaceType.test.tsx
@@ -21,7 +21,7 @@ describe('NetworkInterfaces', () => {
     const { getByText } = renderWithTheme(<NetworkInterfaceType />);
 
     expect(getByText('Network Interface Type')).toBeVisible();
-    expect(getByText('Interfaces for new Linodes')).toBeVisible();
+    expect(getByText('Allowed interfaces for new Linodes')).toBeVisible();
     expect(getByText('Save')).toBeVisible();
   });
 
@@ -49,9 +49,9 @@ describe('NetworkInterfaces', () => {
       <NetworkInterfaceType />
     );
 
-    expect(getByLabelText('Interfaces for new Linodes')).toHaveAttribute(
-      'disabled'
-    );
+    expect(
+      getByLabelText('Allowed interfaces for new Linodes')
+    ).toHaveAttribute('disabled');
     expect(getByText('Save')).toHaveAttribute('aria-disabled', 'true');
   });
 });

--- a/packages/manager/src/features/Account/NetworkInterfaceType.tsx
+++ b/packages/manager/src/features/Account/NetworkInterfaceType.tsx
@@ -177,7 +177,7 @@ export const NetworkInterfaceType = () => {
 const optionsTooltipText = (
   <Stack spacing={3}>
     {accountSettingInterfaceOptions.map((option) => (
-      <Stack key={option.label}>
+      <Stack key={option.value}>
         <Typography>
           <strong>{option.label}</strong>
         </Typography>

--- a/packages/manager/src/features/Account/NetworkInterfaceType.tsx
+++ b/packages/manager/src/features/Account/NetworkInterfaceType.tsx
@@ -1,11 +1,20 @@
 import { useAccountSettings, useMutateAccountSettings } from '@linode/queries';
-import { Box, Button, Paper, Select, Stack, Typography } from '@linode/ui';
+import {
+  Box,
+  Button,
+  Paper,
+  Select,
+  Stack,
+  Typography,
+  useTheme,
+} from '@linode/ui';
 import { useSnackbar } from 'notistack';
 import React from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
+import { Link } from 'src/components/Link';
+
 import { usePermissions } from '../IAM/hooks/usePermissions';
-import { LinodeInterfaceFeatureStatusChip } from '../Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/LinodeInterfaceFeatureChip';
 
 import type {
   AccountSettings,
@@ -18,29 +27,44 @@ type InterfaceSettingValues = Pick<
   'interfaces_for_new_linodes'
 >;
 
-const accountSettingInterfaceOptions: SelectOption<LinodeInterfaceAccountSetting>[] =
-  [
-    {
-      label: 'Linode Interfaces but allow Configuration Profile Interfaces',
-      value: 'linode_default_but_legacy_config_allowed',
-    },
-    {
-      label: 'Linode Interfaces Only',
-      value: 'linode_only',
-    },
-    {
-      label: 'Configuration Profile Interfaces but allow Linode Interfaces',
-      value: 'legacy_config_default_but_linode_allowed',
-    },
-    {
-      label: 'Configuration Profile Interfaces Only',
-      value: 'legacy_config_only',
-    },
-  ];
+interface AccountSettingInterfaceOptionType
+  extends SelectOption<LinodeInterfaceAccountSetting> {
+  tooltipText: string;
+}
+
+const accountSettingInterfaceOptions: AccountSettingInterfaceOptionType[] = [
+  {
+    label:
+      'Linode Interfaces (default) but allow Configuration Profile Interfaces',
+    value: 'linode_default_but_legacy_config_allowed',
+    tooltipText:
+      'Linode Interfaces are used by default unless you select Configuration Profile Interfaces. Linodes with Configuration Profile Interfaces can be upgraded to Linode Interfaces.',
+  },
+  {
+    label: 'Linode Interfaces Only',
+    value: 'linode_only',
+    tooltipText:
+      'Existing Linodes with Configuration Profile Interfaces will continue to work. You can upgrade these Linodes to use Linode Interfaces.',
+  },
+  {
+    label:
+      'Configuration Profile Interfaces (default) but allow Linode Interfaces',
+    value: 'legacy_config_default_but_linode_allowed',
+    tooltipText:
+      'Configuration Profile Interfaces are used by default unless you select Linode Interfaces. You can upgrade to Linode Interfaces at any time.',
+  },
+  {
+    label: 'Configuration Profile Interfaces Only',
+    value: 'legacy_config_only',
+    tooltipText:
+      'Existing Linodes with Linode Interfaces will continue to work. Upgrades to Linode Interfaces are not available.',
+  },
+];
 
 export const NetworkInterfaceType = () => {
   const { enqueueSnackbar } = useSnackbar();
   const { data: accountSettings } = useAccountSettings();
+  const theme = useTheme();
 
   const { mutateAsync: updateAccountSettings } = useMutateAccountSettings();
   const { data: permissions } = usePermissions('account', [
@@ -80,11 +104,18 @@ export const NetworkInterfaceType = () => {
       </Typography>
       <form onSubmit={handleSubmit(onSubmit)}>
         <Stack mt={1}>
-          <Typography variant="body1">
-            Choose whether to use Configuration Profile Interfaces or Linode
-            Interfaces
-            <LinodeInterfaceFeatureStatusChip fallback=" " sx={{ mx: 0.5 }} />
-            when creating new Linodes or upgrading existing ones.
+          <Typography>
+            When creating new Linodes or upgrading existing ones, select between
+            Configuration Profile Interfaces and Linode Interfaces.{' '}
+            <Link to="https://techdocs.akamai.com/cloud-computing/docs/networking-interface">
+              Learn more
+            </Link>
+            .
+          </Typography>
+          <Typography mt={2}>
+            Linode Interfaces are recommended. However, use Configuration
+            Profile Interfaces with LKE or when a Linode needs a private IP
+            address.
           </Typography>
           <Controller
             control={control}
@@ -93,7 +124,7 @@ export const NetworkInterfaceType = () => {
               <Select
                 disabled={!permissions.update_account_settings}
                 errorText={fieldState.error?.message}
-                label="Interfaces for new Linodes"
+                label="Allowed interfaces for new Linodes"
                 onChange={(
                   _,
                   item: SelectOption<LinodeInterfaceAccountSetting>
@@ -101,11 +132,16 @@ export const NetworkInterfaceType = () => {
                   field.onChange(item?.value);
                 }}
                 options={accountSettingInterfaceOptions}
-                sx={(theme) => ({
-                  [theme.breakpoints.up('md')]: {
-                    minWidth: '480px',
+                sx={{
+                  [theme.breakpoints.up('sm')]: {
+                    '.MuiFormControl-root.MuiFormControl-fullWidth': {
+                      minWidth: '480px',
+                    },
                   },
-                })}
+                  '.MuiInputBase-root.MuiInput-root': {
+                    maxWidth: '480px',
+                  },
+                }}
                 textFieldProps={{
                   expand: true,
                   sx: {
@@ -114,7 +150,7 @@ export const NetworkInterfaceType = () => {
                   tooltipText: !permissions.update_account_settings
                     ? "You don't have permission to change this setting."
                     : optionsTooltipText,
-                  tooltipWidth: 410,
+                  tooltipWidth: 440,
                 }}
                 value={accountSettingInterfaceOptions.find(
                   (option) => option.value === field.value
@@ -139,49 +175,14 @@ export const NetworkInterfaceType = () => {
 };
 
 const optionsTooltipText = (
-  <Stack spacing={2}>
-    <Stack>
-      <Typography>
-        <strong>
-          Linode Interfaces but allow Configuration Profile Interfaces
-        </strong>
-      </Typography>
-      <Typography>
-        Use Linode Interfaces by default, unless Configuration Profile
-        Interfaces are explicitly selected. Linodes using Configuration Profile
-        Interfaces can be upgraded to use Linode Interfaces.
-      </Typography>
-    </Stack>
-    <Stack>
-      <Typography>
-        <strong>Linode Interfaces Only</strong>
-      </Typography>
-      <Typography>
-        Previously created Linodes using Configuration Profile Interfaces will
-        continue to function. Linodes using Configuration Profile Interfaces can
-        be upgraded to use Linode Interfaces.
-      </Typography>
-    </Stack>
-    <Stack>
-      <Typography>
-        <strong>
-          Configuration Profile Interfaces but allow Linode Interfaces
-        </strong>
-      </Typography>
-      <Typography>
-        Use Configuration Profile Interfaces by default, unless Linode
-        Interfaces are explicitly selected, and can be upgraded to use Linode
-        Interfaces.
-      </Typography>
-    </Stack>
-    <Stack>
-      <Typography>
-        <strong>Configuration Profile Interfaces Only</strong>
-      </Typography>
-      <Typography>
-        Previously created Linodes using Linode Interfaces will continue to
-        function. Linodes cannot be upgraded to use Linode Interfaces.
-      </Typography>
-    </Stack>
+  <Stack spacing={3}>
+    {accountSettingInterfaceOptions.map((option) => (
+      <Stack key={option.label}>
+        <Typography>
+          <strong>{option.label}</strong>
+        </Typography>
+        <Typography>{option.tooltipText}</Typography>
+      </Stack>
+    ))}
   </Stack>
 );


### PR DESCRIPTION
## Description 📝

As part of this PR, apply changes in Network Interface Type panel under account settings page as suggested by [UX](https://www.figma.com/proto/Ap7HySAV7KBS4sHagwrsdW/Linode-Interfaces?page-id=4984%3A75240&node-id=5021-41002&viewport=3824%2C-162%2C0.5&t=EPdjY73Z1Vdzllmx-1&scaling=min-zoom&content-scaling=fixed&starting-point-node-id=5021%3A41002) and [TW](https://docs.google.com/spreadsheets/d/1ayBYZVBkXKNMU5pur0BQI17fRoetIEDRJdMsr7QmnNw/edit?gid=0#gid=0)

## Changes  🔄

In account settings page(`/account-settings`), under Network Interface Type:

- Update description of the panel
- Update label for the network interface options
- Increase width of network interface type dropdown to fit in text of all options
- Update text for the options
- Update tooltip text as applicable

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [x] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

Jan 28

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2026-01-15 at 11 46 21 AM](https://github.com/user-attachments/assets/0ff8482d-6670-4ded-93ee-53795ae37176) | ![Screenshot 2026-01-15 at 11 47 05 AM](https://github.com/user-attachments/assets/d96266e1-f9d2-43e7-ad2d-5b0823fe3625) |
| ![Screenshot 2026-01-15 at 11 46 39 AM](https://github.com/user-attachments/assets/33e0a3ca-625f-4a4b-80d9-80a22aa21d08) | ![Screenshot 2026-01-15 at 11 47 12 AM](https://github.com/user-attachments/assets/9157d068-b0eb-4a7d-887e-075697f59a16) |
| ![Screenshot 2026-01-15 at 11 46 53 AM](https://github.com/user-attachments/assets/9f2b96a0-6bed-44ef-b62f-70d7486089b2) | ![Screenshot 2026-01-15 at 11 47 32 AM](https://github.com/user-attachments/assets/c0e6a8fa-df7b-4c5c-81a0-8278c99088bd) |


## How to test 🧪

### Prerequisites

- Ensure linode interfaces feature flag is enabled
- Navigate to `/account-settings` page

### Verification steps

(How to verify changes)

- [ ] Ensure above mentioned UX and text changes are reflecting
- [ ] Ensure no regression impact on existing functionality and test cases.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

-->