### PR TITLE
change: [UIE-10012] - Implement UX and user feedback for linode interfaces feature in Create linode page

### DIFF
--- a/packages/manager/.changeset/pr-13281-changed-1768479377489.md
+++ b/packages/manager/.changeset/pr-13281-changed-1768479377489.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Apply UX and user feedback for linode interfaces feature in Create linode page ([#13281](https://github.com/linode/manager/pull/13281))

--- a/packages/manager/src/features/Linodes/LinodeCreate/Addons/Addons.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Addons/Addons.tsx
@@ -1,7 +1,7 @@
 import { useRegionsQuery } from '@linode/queries';
 import { Divider, Notice, Paper, Stack, Typography } from '@linode/ui';
 import React, { useMemo } from 'react';
-import { useWatch } from 'react-hook-form';
+import { useFormContext, useWatch } from 'react-hook-form';
 
 import { Backups } from './Backups';
 import { PrivateIP } from './PrivateIP';
@@ -9,6 +9,7 @@ import { PrivateIP } from './PrivateIP';
 import type { CreateLinodeRequest } from '@linode/api-v4';
 
 export const Addons = () => {
+  const { setValue } = useFormContext<CreateLinodeRequest>();
   const [regionId, interfaceGeneration] = useWatch<
     CreateLinodeRequest,
     ['region', 'interface_generation']
@@ -25,6 +26,11 @@ export const Addons = () => {
     selectedRegion?.site_type === 'distributed';
 
   const shouldShowPrivateIP = interfaceGeneration !== 'linode';
+
+  // Clean up private IP value when the option is hidden
+  if (!shouldShowPrivateIP) {
+    setValue('private_ip', false);
+  }
 
   return (
     <Paper data-qa-add-ons>

--- a/packages/manager/src/features/Linodes/LinodeCreate/Addons/Backups.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Addons/Backups.tsx
@@ -108,7 +108,7 @@ export const Backups = () => {
               <React.Fragment>
                 Three backup slots are executed and rotated automatically: a
                 daily backup, a 2-7 day old backup, and an 8-14 day old backup.
-                Plans are priced according to the Linode plan selected above.
+                Pricing is based on the selected Linode plan.
               </React.Fragment>
             )}
           </Typography>

--- a/packages/manager/src/features/Linodes/LinodeCreate/Addons/PrivateIP.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Addons/PrivateIP.tsx
@@ -63,8 +63,9 @@ export const PrivateIP = () => {
             <Stack alignItems="center" direction="row" spacing={1}>
               <NewFeatureChip />
               <Typography>
-                You can use VPC for private networking instead. NodeBalancers
-                now connect to backend nodes without a private IPv4 address.
+                You can now establish network isolation and connections to
+                NodeBalancer backends through VPC. We recommend using VPC
+                instead of Private IPs.
               </Typography>
             </Stack>
           </Notice>

--- a/packages/manager/src/features/Linodes/LinodeCreate/Addons/PrivateIP.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Addons/PrivateIP.tsx
@@ -2,7 +2,6 @@ import { useRegionsQuery } from '@linode/queries';
 import {
   Checkbox,
   FormControlLabel,
-  NewFeatureChip,
   Notice,
   Stack,
   Typography,
@@ -59,15 +58,12 @@ export const PrivateIP = () => {
             Lets you connect with other Linodes in the same region over the data
             center&apos;s private network, without using a public IPv4 address.
           </Typography>
-          <Notice variant="tip">
-            <Stack alignItems="center" direction="row" spacing={1}>
-              <NewFeatureChip />
-              <Typography>
-                You can now establish network isolation and connections to
-                NodeBalancer backends through VPC. We recommend using VPC
-                instead of Private IPs.
-              </Typography>
-            </Stack>
+          <Notice marginTop="12px !important" variant="tip">
+            <Typography>
+              You can now establish network isolation and connections to
+              NodeBalancer backends through VPC. We recommend using VPC instead
+              of Private IPs.
+            </Typography>
           </Notice>
         </Stack>
       }

--- a/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceGeneration.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceGeneration.test.tsx
@@ -7,6 +7,8 @@ import { renderWithThemeAndHookFormContext } from 'src/utilities/testHelpers';
 
 import { InterfaceGeneration } from './InterfaceGeneration';
 
+const getAccountSettingsAPI = '*/v4*/account/settings';
+
 describe('InterfaceGeneration', () => {
   it('disables the radios if the account setting enforces linode_only interfaces', async () => {
     const accountSettings = accountSettingsFactory.build({
@@ -14,29 +16,25 @@ describe('InterfaceGeneration', () => {
     });
 
     server.use(
-      http.get('*/v4*/account/settings', () => {
+      http.get(getAccountSettingsAPI, () => {
         return HttpResponse.json(accountSettings);
       })
     );
 
-    const { findByText, getAllByRole, getByText } =
-      renderWithThemeAndHookFormContext({
-        component: <InterfaceGeneration />,
-      });
+    const { getAllByRole, findByRole } = renderWithThemeAndHookFormContext({
+      component: <InterfaceGeneration />,
+    });
 
-    const button = getByText('Network Interface Type');
+    // Wait for the tooltip icon to appear (indicating the disabled state)
+    await findByRole('button', {
+      name: 'Your account administrator has enforced that all new Linodes are created with Linode interfaces.',
+    });
 
-    // Expand the "Show More"
-    await userEvent.click(button);
+    // Verify both radio buttons are disabled
+    const radios = getAllByRole('radio');
+    expect(radios).toHaveLength(2);
 
-    // Hover to check for the tooltip
-    await userEvent.hover(getByText('Network Interface Type'));
-
-    await findByText(
-      'Your account administrator has enforced that all new Linodes are created with Linode interfaces.'
-    );
-
-    for (const radio of getAllByRole('radio')) {
+    for (const radio of radios) {
       expect(radio).toBeDisabled();
     }
   });
@@ -47,34 +45,143 @@ describe('InterfaceGeneration', () => {
     });
 
     server.use(
-      http.get('*/v4*/account/settings', () => {
+      http.get(getAccountSettingsAPI, () => {
         return HttpResponse.json(accountSettings);
       })
     );
 
-    const { findByText, getAllByRole, getByText } =
-      renderWithThemeAndHookFormContext({
-        component: <InterfaceGeneration />,
-      });
+    const { getAllByRole, findByRole } = renderWithThemeAndHookFormContext({
+      component: <InterfaceGeneration />,
+    });
 
-    const button = getByText('Network Interface Type');
+    // Wait for the tooltip icon to appear (indicating the disabled state)
+    await findByRole('button', {
+      name: 'Your account administrator has enforced that all new Linodes are created with legacy configuration interfaces.',
+    });
 
-    // Expand the "Show More"
-    await userEvent.click(button);
-
-    // Hover to check for the tooltip
-    await userEvent.hover(getByText('Network Interface Type'));
-
-    await findByText(
-      'Your account administrator has enforced that all new Linodes are created with legacy configuration interfaces.'
-    );
-
+    // Verify both radio buttons are disabled
     const radios = getAllByRole('radio');
-
     expect(radios).toHaveLength(2);
 
     for (const radio of radios) {
       expect(radio).toBeDisabled();
     }
+  });
+
+  it('enables the radios when account settings allow both interface types', async () => {
+    const accountSettings = accountSettingsFactory.build({
+      interfaces_for_new_linodes: 'linode_default_but_legacy_config_allowed',
+    });
+
+    server.use(
+      http.get(getAccountSettingsAPI, () => {
+        return HttpResponse.json(accountSettings);
+      })
+    );
+
+    const { getAllByRole, queryByRole } = renderWithThemeAndHookFormContext({
+      component: <InterfaceGeneration />,
+    });
+
+    // Wait for radios to render
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Verify no disabled tooltip appears
+    expect(
+      queryByRole('button', {
+        name: /Your account administrator has enforced/,
+      })
+    ).toBeNull();
+
+    // Verify both radio buttons are enabled
+    const radios = getAllByRole('radio');
+    expect(radios).toHaveLength(2);
+
+    for (const radio of radios) {
+      expect(radio).toBeEnabled();
+    }
+  });
+
+  it('defaults to linode interface when value is not set', async () => {
+    const accountSettings = accountSettingsFactory.build({
+      interfaces_for_new_linodes: 'linode_default_but_legacy_config_allowed',
+    });
+
+    server.use(
+      http.get(getAccountSettingsAPI, () => {
+        return HttpResponse.json(accountSettings);
+      })
+    );
+
+    const { getByDisplayValue } = renderWithThemeAndHookFormContext({
+      component: <InterfaceGeneration />,
+      useFormOptions: {
+        defaultValues: {
+          interface_generation: null,
+        },
+      },
+    });
+
+    // Wait for component to render
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Verify linode radio is selected by default
+    expect(getByDisplayValue('linode')).toBeChecked();
+  });
+
+  it('allows user to select legacy config interface when enabled', async () => {
+    const accountSettings = accountSettingsFactory.build({
+      interfaces_for_new_linodes: 'legacy_config_default_but_linode_allowed',
+    });
+
+    server.use(
+      http.get(getAccountSettingsAPI, () => {
+        return HttpResponse.json(accountSettings);
+      })
+    );
+
+    const { getByDisplayValue } = renderWithThemeAndHookFormContext({
+      component: <InterfaceGeneration />,
+      useFormOptions: {
+        defaultValues: {
+          interface_generation: 'linode',
+        },
+      },
+    });
+
+    // Wait for component to render
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const legacyConfigRadio = getByDisplayValue('legacy_config');
+
+    // Click on legacy config radio
+    await userEvent.click(legacyConfigRadio);
+
+    // Verify legacy config is now selected
+    expect(legacyConfigRadio).toBeChecked();
+    expect(getByDisplayValue('linode')).not.toBeChecked();
+  });
+
+  it('displays correct labels for both interface types', () => {
+    const accountSettings = accountSettingsFactory.build({
+      interfaces_for_new_linodes: 'linode_default_but_legacy_config_allowed',
+    });
+
+    server.use(
+      http.get(getAccountSettingsAPI, () => {
+        return HttpResponse.json(accountSettings);
+      })
+    );
+
+    const { getByText } = renderWithThemeAndHookFormContext({
+      component: <InterfaceGeneration />,
+    });
+
+    // Verify interface type labels
+    expect(getByText('Linode Interfaces (Recommended)')).toBeVisible();
+    expect(
+      getByText('Configuration Profile Interfaces (Legacy)')
+    ).toBeVisible();
+    expect(getByText('Network Interface Type')).toBeVisible();
   });
 });

--- a/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceGeneration.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceGeneration.test.tsx
@@ -1,3 +1,4 @@
+import { waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
@@ -84,14 +85,14 @@ describe('InterfaceGeneration', () => {
     });
 
     // Wait for radios to render
-    await new Promise((resolve) => setTimeout(resolve, 100));
-
-    // Verify no disabled tooltip appears
-    expect(
-      queryByRole('button', {
-        name: /Your account administrator has enforced/,
-      })
-    ).toBeNull();
+    await waitFor(() => {
+      // Verify no disabled tooltip appears
+      expect(
+        queryByRole('button', {
+          name: /Your account administrator has enforced/,
+        })
+      ).toBeNull();
+    });
 
     // Verify both radio buttons are enabled
     const radios = getAllByRole('radio');
@@ -123,10 +124,10 @@ describe('InterfaceGeneration', () => {
     });
 
     // Wait for component to render
-    await new Promise((resolve) => setTimeout(resolve, 100));
-
-    // Verify linode radio is selected by default
-    expect(getByDisplayValue('linode')).toBeChecked();
+    await waitFor(() => {
+      // Verify linode radio is selected by default
+      expect(getByDisplayValue('linode')).toBeChecked();
+    });
   });
 
   it('allows user to select legacy config interface when enabled', async () => {
@@ -148,9 +149,6 @@ describe('InterfaceGeneration', () => {
         },
       },
     });
-
-    // Wait for component to render
-    await new Promise((resolve) => setTimeout(resolve, 100));
 
     const legacyConfigRadio = getByDisplayValue('legacy_config');
 

--- a/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceGeneration.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceGeneration.tsx
@@ -9,12 +9,9 @@ import {
   TooltipIcon,
   Typography,
 } from '@linode/ui';
+import { FormLabel } from '@mui/material';
 import React from 'react';
 import { useController } from 'react-hook-form';
-
-import { ShowMoreExpansion } from 'src/components/ShowMoreExpansion';
-
-import { LinodeInterfaceFeatureStatusChip } from '../../LinodesDetail/LinodeNetworking/LinodeInterfaces/LinodeInterfaceFeatureChip';
 
 import type { LinodeCreateFormValues } from '../utilities';
 import type { LinodeInterfaceAccountSetting } from '@linode/api-v4';
@@ -45,89 +42,106 @@ export const InterfaceGeneration = () => {
   const disabled = disabledReason !== undefined;
 
   return (
-    <Box>
-      <ShowMoreExpansion
-        ButtonProps={{
-          TooltipProps: {
-            placement: 'right',
-          },
-          alwaysShowTooltip: disabled,
-          tooltipText: disabledReason,
-        }}
-        defaultExpanded={!disabled}
-        name="Network Interface Type"
+    <FormControl>
+      <Box alignItems="center" display="flex" flexDirection="row">
+        <FormLabel id="network-interface-label">
+          Network Interface Type
+        </FormLabel>
+        {disabled && (
+          <TooltipIcon
+            status="info"
+            sxTooltipIcon={{
+              padding: 0,
+              marginLeft: '8px',
+              marginBottom: '8px',
+            }}
+            text={disabledReason}
+          />
+        )}
+      </Box>
+      <RadioGroup
+        aria-labelledby="interface-generation"
+        onChange={field.onChange}
+        value={field.value ?? 'linode'}
       >
-        <FormControl
+        <FormControlLabel
+          control={<Radio />}
+          data-qa-interfaces-option="linode"
           disabled={disabled}
-          sx={{ mt: '0px !important', mb: 2, mx: 0.5 }}
-        >
-          <RadioGroup
-            aria-labelledby="interface-generation"
-            onChange={field.onChange}
-            sx={{ my: '0px !important' }}
-            value={field.value ?? 'linode'}
-          >
-            <FormControlLabel
-              control={<Radio />}
-              data-qa-interfaces-option="linode"
-              label={
-                <Stack mt={1.25} spacing={0.5}>
-                  <Stack direction="row">
-                    <Typography sx={(theme) => ({ font: theme.font.bold })}>
-                      Linode Interfaces
+          label={
+            <Stack mt={1.25} spacing={0.5}>
+              <Stack direction="row">
+                <Typography sx={(theme) => ({ font: theme.font.bold })}>
+                  Linode Interfaces (Recommended)
+                </Typography>
+                <TooltipIcon
+                  status="info"
+                  sxTooltipIcon={{
+                    p: 0,
+                    ml: 0.5,
+                  }}
+                  text={
+                    <Stack spacing={2}>
+                      <Typography>
+                        For VPC or public networking setups and when private IPs
+                        are not required.
+                      </Typography>
+                      <Typography>
+                        Linode Interfaces are directly associated with the
+                        compute instance for easier visibility and management.
+                      </Typography>
+                      <Typography>
+                        Different Cloud Firewalls can be assigned to each VPC
+                        and public interface.
+                      </Typography>
+                    </Stack>
+                  }
+                  tooltipPosition="right"
+                  width={280}
+                />
+              </Stack>
+            </Stack>
+          }
+          sx={{ alignItems: 'flex-start' }}
+          value="linode"
+        />
+        <FormControlLabel
+          control={<Radio />}
+          data-qa-interfaces-option="legacy_config"
+          disabled={disabled}
+          label={
+            <Stack direction="row" mt={1.25} spacing={0.5}>
+              <Typography sx={(theme) => ({ font: theme.font.bold })}>
+                Configuration Profile Interfaces (Legacy)
+              </Typography>
+              <TooltipIcon
+                status="info"
+                sxTooltipIcon={{
+                  p: 0,
+                  ml: 0.5,
+                }}
+                text={
+                  <Stack spacing={2}>
+                    <Typography>For Linodes requiring a private IP.</Typography>
+                    <Typography>
+                      Configuration Profile Interfaces are a part of the
+                      configuration profile.
                     </Typography>
-                    <LinodeInterfaceFeatureStatusChip />
-                    <TooltipIcon
-                      status="info"
-                      sxTooltipIcon={{ p: 0, ml: 0.5 }}
-                      text={
-                        <>
-                          Managed directly through a Linode&apos;s Network
-                          settings. This is the recommended option.
-                          <br />
-                          <br />
-                          Cloud Firewalls are assigned to individual VPC and
-                          public interfaces.
-                        </>
-                      }
-                    />
+                    <Typography>
+                      The same Cloud Firewall is assigned to all non-VLAN
+                      interfaces on the Linode.
+                    </Typography>
                   </Stack>
-                </Stack>
-              }
-              sx={{ alignItems: 'flex-start' }}
-              value="linode"
-            />
-            <FormControlLabel
-              control={<Radio />}
-              data-qa-interfaces-option="legacy_config"
-              label={
-                <Stack direction="row" mt={1.25} spacing={0.5}>
-                  <Typography sx={(theme) => ({ font: theme.font.bold })}>
-                    Configuration Profile Interfaces (Legacy)
-                  </Typography>
-                  <TooltipIcon
-                    status="info"
-                    sxTooltipIcon={{ p: 0, ml: 0.5 }}
-                    text={
-                      <>
-                        Interfaces are part of the Linode&apos;s Configuration
-                        Profile.
-                        <br />
-                        <br />
-                        Cloud Firewalls are applied at the Linode level and
-                        automatically cover all non-VLAN interfaces in the
-                        Configuration Profile.
-                      </>
-                    }
-                  />
-                </Stack>
-              }
-              sx={{ alignItems: 'flex-start' }}
-              value="legacy_config"
-            />
-          </RadioGroup>
-        </FormControl>
-      </ShowMoreExpansion>
-    </Box>
+                }
+                tooltipPosition="right"
+                width={280}
+              />
+            </Stack>
+          }
+          sx={{ alignItems: 'flex-start' }}
+          value="legacy_config"
+        />
+      </RadioGroup>
+    </FormControl>
   );
 };

--- a/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceGeneration.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceGeneration.tsx
@@ -13,6 +13,8 @@ import { FormLabel } from '@mui/material';
 import React from 'react';
 import { useController } from 'react-hook-form';
 
+import { LinodeInterfaceFeatureStatusChip } from '../../LinodesDetail/LinodeNetworking/LinodeInterfaces/LinodeInterfaceFeatureChip';
+
 import type { LinodeCreateFormValues } from '../utilities';
 import type { LinodeInterfaceAccountSetting } from '@linode/api-v4';
 
@@ -74,6 +76,7 @@ export const InterfaceGeneration = () => {
                 <Typography sx={(theme) => ({ font: theme.font.bold })}>
                   Linode Interfaces (Recommended)
                 </Typography>
+                <LinodeInterfaceFeatureStatusChip />
                 <TooltipIcon
                   status="info"
                   sxTooltipIcon={{

--- a/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceType.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceType.test.tsx
@@ -1,0 +1,99 @@
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import { renderWithThemeAndHookFormContext } from 'src/utilities/testHelpers';
+
+import { InterfaceType } from './InterfaceType';
+
+import type { LinodeCreateFormValues } from '../utilities';
+
+const defaultFormValues: Partial<LinodeCreateFormValues> = {
+  interface_generation: 'linode',
+  linodeInterfaces: [
+    {
+      purpose: 'public',
+      firewall_id: null,
+      vpc: null,
+      public: null,
+      vlan: null,
+      default_route: null,
+    },
+  ],
+};
+
+describe('InterfaceType', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders all interface type options', () => {
+    const { getByText, getByRole } = renderWithThemeAndHookFormContext({
+      component: <InterfaceType index={0} />,
+      useFormOptions: {
+        defaultValues: defaultFormValues,
+      },
+    });
+
+    // Check that the form label is rendered
+    expect(getByText('Network Connection')).toBeVisible();
+
+    // Check that all three interface options are rendered
+    expect(getByText('Public Internet')).toBeVisible();
+    expect(getByText('VPC')).toBeVisible();
+    expect(getByText('VLAN')).toBeVisible();
+
+    // Check that radiogroup is rendered
+    expect(getByRole('radiogroup')).toBeVisible();
+  });
+
+  it('renders tooltip icons for each interface type', () => {
+    const { getAllByRole } = renderWithThemeAndHookFormContext({
+      component: <InterfaceType index={0} />,
+      useFormOptions: {
+        defaultValues: defaultFormValues,
+      },
+    });
+
+    // Should have tooltip buttons for each interface option
+    const tooltipButtons = getAllByRole('button');
+    expect(tooltipButtons.length).toBe(3);
+  });
+
+  it('selects the correct radio based on form value', () => {
+    const { getByDisplayValue } = renderWithThemeAndHookFormContext({
+      component: <InterfaceType index={0} />,
+      useFormOptions: {
+        defaultValues: {
+          ...defaultFormValues,
+          linodeInterfaces: [
+            {
+              purpose: 'vpc',
+              firewall_id: null,
+            },
+          ],
+        },
+      },
+    });
+
+    expect(getByDisplayValue('vpc')).toBeChecked();
+  });
+
+  it('allows user to change interface type selection', async () => {
+    const { getByDisplayValue } = renderWithThemeAndHookFormContext({
+      component: <InterfaceType index={0} />,
+      useFormOptions: {
+        defaultValues: defaultFormValues,
+      },
+    });
+
+    // Initially public should be selected
+    expect(getByDisplayValue('public')).toBeChecked();
+
+    // Click on VPC radio
+    await userEvent.click(getByDisplayValue('vpc'));
+
+    // VPC should now be selected
+    expect(getByDisplayValue('vpc')).toBeChecked();
+    expect(getByDisplayValue('public')).not.toBeChecked();
+  });
+});

--- a/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceType.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceType.test.tsx
@@ -22,10 +22,6 @@ const defaultFormValues: Partial<LinodeCreateFormValues> = {
 };
 
 describe('InterfaceType', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   it('renders all interface type options', () => {
     const { getByText, getByRole } = renderWithThemeAndHookFormContext({
       component: <InterfaceType index={0} />,

--- a/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceType.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Networking/InterfaceType.tsx
@@ -30,7 +30,7 @@ const interfaceTypes = [
     label: 'Public Internet',
     purpose: 'public',
     description:
-      'Connects your Linode to the internet, enabling traffic over the public IP address.',
+      'Connects your Linode to the internet and allows traffic through its public IP address.',
   },
   {
     label: 'VPC',
@@ -42,7 +42,7 @@ const interfaceTypes = [
     label: 'VLAN',
     purpose: 'vlan',
     description:
-      'Connects your Linode to a private Layer 2 network for local communication with other Linodes.',
+      'Connects your Linode to a private Layer 2 network, enabling local communication with other Linodes.',
   },
 ] as const;
 
@@ -108,7 +108,7 @@ export const InterfaceType = ({ index }: Props) => {
 
   return (
     <FormControl>
-      <Box alignItems="center" display="flex" flexDirection="row">
+      <Box alignItems="center" display="flex" flexDirection="row" mt={1}>
         <FormLabel id="network-connection-label">Network Connection</FormLabel>
         {disabled && (
           <TooltipIcon
@@ -143,6 +143,7 @@ export const InterfaceType = ({ index }: Props) => {
                   status="info"
                   sxTooltipIcon={{ p: 0, ml: 0.5 }}
                   text={interfaceType.description}
+                  tooltipPosition="right"
                 />
               </Stack>
             }

--- a/packages/manager/src/features/Linodes/LinodeCreate/Networking/LinodeInterface.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Networking/LinodeInterface.test.tsx
@@ -22,9 +22,18 @@ describe('LinodeInterface (Linode Interfaces)', () => {
       component: <LinodeInterface index={0} />,
     });
 
-    expect(getByText('Public Internet')).toBeInTheDocument();
-    expect(getByText('VPC')).toBeInTheDocument();
-    expect(getByText('VLAN')).toBeInTheDocument();
+    expect(getByText('Public Internet')).toBeVisible();
+    expect(getByText('VPC')).toBeVisible();
+    expect(getByText('VLAN')).toBeVisible();
+  });
+
+  it('renders radios for the interfaces (Linode interface, Config profile)', () => {
+    const { getByText } = renderWithThemeAndHookFormContext({
+      component: <LinodeInterface index={0} />,
+    });
+
+    expect(getByText(/Linode Interfaces/)).toBeVisible();
+    expect(getByText(/Configuration Profile Interfaces/)).toBeVisible();
   });
 
   it('renders a Firewall select if "VPC" is selected', async () => {

--- a/packages/manager/src/features/Linodes/LinodeCreate/Networking/LinodeInterface.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Networking/LinodeInterface.tsx
@@ -45,9 +45,9 @@ export const LinodeInterface = ({ index }: Props) => {
         />
       )}
       <InterfaceType index={index} />
-      <InterfaceGeneration />
       {interfaceType === 'vlan' && <VLAN index={index} />}
       {interfaceType === 'vpc' && <VPC index={index} />}
+      <InterfaceGeneration />
       {interfaceGeneration === 'linode' && interfaceType !== 'vlan' && (
         <InterfaceFirewall index={index} />
       )}

--- a/packages/manager/src/features/Linodes/LinodeCreate/Networking/LinodeInterface.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Networking/LinodeInterface.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 
 import { InterfaceFirewall } from './InterfaceFirewall';
+import { InterfaceGeneration } from './InterfaceGeneration';
 import { InterfaceType } from './InterfaceType';
 import { VLAN } from './VLAN';
 import { VPC } from './VPC';
@@ -44,6 +45,7 @@ export const LinodeInterface = ({ index }: Props) => {
         />
       )}
       <InterfaceType index={index} />
+      <InterfaceGeneration />
       {interfaceType === 'vlan' && <VLAN index={index} />}
       {interfaceType === 'vpc' && <VPC index={index} />}
       {interfaceGeneration === 'linode' && interfaceType !== 'vlan' && (

--- a/packages/manager/src/features/Linodes/LinodeCreate/Networking/Networking.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Networking/Networking.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
 
 import { Firewall } from './Firewall';
-import { InterfaceGeneration } from './InterfaceGeneration';
 import { LinodeInterface } from './LinodeInterface';
 
 import type { LinodeCreateFormValues } from '../utilities';
@@ -31,7 +30,6 @@ export const Networking = () => {
     <Paper>
       <Stack spacing={2}>
         <Typography variant="h2">Networking</Typography>
-        <InterfaceGeneration />
         {errors.linodeInterfaces?.message && (
           <Notice text={errors.linodeInterfaces.message} variant="error" />
         )}

--- a/packages/manager/src/features/Linodes/LinodeCreate/Networking/VLAN.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Networking/VLAN.tsx
@@ -1,5 +1,5 @@
 import { useRegionQuery } from '@linode/queries';
-import { Stack, TextField } from '@linode/ui';
+import { Box, Divider, Stack, TextField } from '@linode/ui';
 import React from 'react';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 
@@ -27,51 +27,60 @@ export const VLAN = ({ index }: Props) => {
     selectedRegion?.capabilities.includes('Vlans') ?? false;
 
   return (
-    <Stack spacing={1.5} sx={{ mb: '16px !important' }}>
-      {selectedRegion && !regionSupportsVLANs && <VLANAvailabilityNotice />}
-      <Stack alignItems="flex-start" direction="row" flexWrap="wrap" gap={2}>
-        <Controller
-          control={control}
-          name={`linodeInterfaces.${index}.vlan.vlan_label`}
-          render={({ field, fieldState }) => (
-            <VLANSelect
-              disabled={!permissions.create_linode || !regionSupportsVLANs}
-              errorText={fieldState.error?.message}
-              filter={{ region: regionId }}
-              helperText={
-                !regionId
-                  ? 'Select a region to see available VLANs.'
-                  : undefined
-              }
-              onBlur={field.onBlur}
-              onChange={field.onChange}
-              sx={{ width: 300 }}
-              value={field.value ?? null}
-            />
-          )}
-        />
-        <Controller
-          control={control}
-          name={`linodeInterfaces.${index}.vlan.ipam_address`}
-          render={({ field, fieldState }) => (
-            <TextField
-              containerProps={{ maxWidth: 335 }}
-              disabled={!permissions.create_linode || !regionSupportsVLANs}
-              errorText={fieldState.error?.message}
-              label="IPAM Address"
-              noMarginTop
-              onBlur={field.onBlur}
-              onChange={field.onChange}
-              optional
-              placeholder="192.0.2.0/24"
-              tooltipText={
-                'IPAM address must use IP/netmask format, e.g. 192.0.2.0/24.'
-              }
-              value={field.value ?? ''}
-            />
-          )}
-        />
+    <Box>
+      <Stack spacing={1.5} sx={{ mb: '16px !important' }}>
+        {selectedRegion && !regionSupportsVLANs && <VLANAvailabilityNotice />}
+        <Stack spacing={3}>
+          <Controller
+            control={control}
+            name={`linodeInterfaces.${index}.vlan.vlan_label`}
+            render={({ field, fieldState }) => (
+              <VLANSelect
+                disabled={!permissions.create_linode || !regionSupportsVLANs}
+                errorText={fieldState.error?.message}
+                filter={{ region: regionId }}
+                helperText={
+                  !regionId
+                    ? 'Select a region to see available VLANs.'
+                    : undefined
+                }
+                onBlur={field.onBlur}
+                onChange={field.onChange}
+                sx={{ width: 300 }}
+                value={field.value ?? null}
+              />
+            )}
+          />
+          <Controller
+            control={control}
+            name={`linodeInterfaces.${index}.vlan.ipam_address`}
+            render={({ field, fieldState }) => (
+              <TextField
+                containerProps={{ maxWidth: 335 }}
+                disabled={!permissions.create_linode || !regionSupportsVLANs}
+                errorText={fieldState.error?.message}
+                label="IPAM Address"
+                noMarginTop
+                onBlur={field.onBlur}
+                onChange={field.onChange}
+                optional
+                placeholder="192.0.2.0/24"
+                tooltipText={
+                  'IPAM address must use IP/netmask format, e.g. 192.0.2.0/24.'
+                }
+                value={field.value ?? ''}
+              />
+            )}
+          />
+        </Stack>
       </Stack>
-    </Stack>
+      <Divider
+        spacingBottom={16}
+        spacingTop={32}
+        sx={{
+          maxWidth: '416px',
+        }}
+      />
+    </Box>
   );
 };

--- a/packages/manager/src/features/Linodes/LinodeCreate/Networking/VPC.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Networking/VPC.tsx
@@ -1,5 +1,12 @@
 import { useAllVPCsQuery, useRegionQuery } from '@linode/queries';
-import { Autocomplete, Box, Divider, Stack, Typography } from '@linode/ui';
+import {
+  Autocomplete,
+  Box,
+  Divider,
+  Stack,
+  TooltipIcon,
+  Typography,
+} from '@linode/ui';
 import { LinkButton } from '@linode/ui';
 import React, { useState } from 'react';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
@@ -8,6 +15,10 @@ import { PublicIPv4Access } from 'src/features/Linodes/LinodesDetail/LinodeNetwo
 import { PublicIPv6Access } from 'src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/PublicIPv6Access';
 import { VPCIPv4Address } from 'src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/VPCIPv4Address';
 import { VPCIPv6Address } from 'src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/VPCIPv6Address';
+import {
+  DualStackVPCRangesDescription,
+  VPCRangesDescription,
+} from 'src/features/VPCs/components/VPCRangesDescription';
 import { REGION_CAVEAT_HELPER_TEXT } from 'src/features/VPCs/constants';
 import { VPCCreateDrawer } from 'src/features/VPCs/VPCCreateDrawer/VPCCreateDrawer';
 import { useVPCDualStack } from 'src/hooks/useVPCDualStack';
@@ -164,7 +175,7 @@ export const VPC = ({ index }: Props) => {
             )}
           />
           {showIPv6Fields && (
-            <Box sx={{ mb: 2 }}>
+            <Box sx={{ mb: 1 }}>
               <Controller
                 control={control}
                 name={`linodeInterfaces.${index}.vpc.ipv6.slaac.0.range`}
@@ -186,9 +197,17 @@ export const VPC = ({ index }: Props) => {
           )}
           <Box>
             <Divider
-              sx={(theme) => ({ marginBottom: theme.spacingFunction(16) })}
+              sx={(theme) => ({
+                marginBottom: theme.spacingFunction(24),
+                maxWidth: '416px',
+              })}
             />
-            <Typography sx={(theme: Theme) => ({ font: theme.font.bold })}>
+            <Typography
+              sx={(theme: Theme) => ({
+                font: theme.font.bold,
+                marginBottom: 1,
+              })}
+            >
               Public access
             </Typography>
             <Controller
@@ -218,17 +237,54 @@ export const VPC = ({ index }: Props) => {
               />
             )}
             <Divider
-              sx={(theme) => ({ marginTop: theme.spacingFunction(16) })}
+              spacingBottom={8}
+              spacingTop={16}
+              sx={{ maxWidth: '416px' }}
             />
           </Box>
         </Stack>
-        <VPCRanges disabled={!regionSupportsVPCs} interfaceIndex={index} />
-        {showIPv6Fields && (
-          <VPCIPv6Ranges
-            disabled={!regionSupportsVPCs}
-            interfaceIndex={index}
-          />
-        )}
+        <Box>
+          <Stack spacing={1.5}>
+            <Stack direction="row" spacing={1}>
+              {!showIPv6Fields && (
+                <Stack alignItems="center" direction="row" spacing={1}>
+                  <Typography
+                    sx={(theme: Theme) => ({ font: theme.font.bold })}
+                  >
+                    Assign additional IPv4 ranges
+                  </Typography>
+                  <TooltipIcon
+                    status="info"
+                    sxTooltipIcon={{ p: 0 }}
+                    text={<VPCRangesDescription />}
+                  />
+                </Stack>
+              )}
+              {showIPv6Fields && (
+                <Stack alignItems="center" direction="row" spacing={1}>
+                  <Typography
+                    sx={(theme: Theme) => ({ font: theme.font.bold })}
+                  >
+                    Assign additional IP ranges
+                  </Typography>
+                  <TooltipIcon
+                    status="info"
+                    sxTooltipIcon={{ p: 0 }}
+                    text={<DualStackVPCRangesDescription />}
+                  />
+                </Stack>
+              )}
+            </Stack>
+            <VPCRanges disabled={!regionSupportsVPCs} interfaceIndex={index} />
+            {showIPv6Fields && (
+              <VPCIPv6Ranges
+                disabled={!regionSupportsVPCs}
+                interfaceIndex={index}
+              />
+            )}
+          </Stack>
+          <Divider spacingTop={24} sx={{ maxWidth: '416px' }} />
+        </Box>
       </Stack>
       <VPCCreateDrawer
         onClose={() => setIsCreateDrawerOpen(false)}

--- a/packages/manager/src/features/Linodes/LinodeCreate/Networking/VPC.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Networking/VPC.tsx
@@ -181,6 +181,7 @@ export const VPC = ({ index }: Props) => {
                 name={`linodeInterfaces.${index}.vpc.ipv6.slaac.0.range`}
                 render={({ field, fieldState }) => (
                   <VPCIPv6Address
+                    autoAssignValue="auto"
                     disabled={!regionSupportsVPCs}
                     errorMessage={
                       fieldState.error?.message ??

--- a/packages/manager/src/features/Linodes/LinodeCreate/Networking/VPCIPv6Ranges.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Networking/VPCIPv6Ranges.tsx
@@ -5,12 +5,9 @@ import {
   Notice,
   Stack,
   TextField,
-  TooltipIcon,
 } from '@linode/ui';
 import React from 'react';
 import { Controller, useFieldArray, useFormContext } from 'react-hook-form';
-
-import { VPCIPv6RangesDescription } from 'src/features/VPCs/components/VPCRangesDescription';
 
 import type { LinodeCreateFormValues } from '../utilities';
 
@@ -79,11 +76,6 @@ export const VPCIPv6Ranges = ({ disabled, interfaceIndex }: Props) => {
         <LinkButton disabled={disabled} onClick={() => append({ range: '' })}>
           Add IPv6 Range
         </LinkButton>
-        <TooltipIcon
-          status="info"
-          sxTooltipIcon={{ p: 0.5 }}
-          text={<VPCIPv6RangesDescription />}
-        />
       </Stack>
     </Stack>
   );

--- a/packages/manager/src/features/Linodes/LinodeCreate/Networking/VPCRanges.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/Networking/VPCRanges.tsx
@@ -1,16 +1,7 @@
-import {
-  CloseIcon,
-  IconButton,
-  Notice,
-  Stack,
-  TextField,
-  TooltipIcon,
-} from '@linode/ui';
+import { CloseIcon, IconButton, Notice, Stack, TextField } from '@linode/ui';
 import { LinkButton } from '@linode/ui';
 import React from 'react';
 import { Controller, useFieldArray, useFormContext } from 'react-hook-form';
-
-import { VPCRangesDescription } from 'src/features/VPCs/components/VPCRangesDescription';
 
 import type { LinodeCreateFormValues } from '../utilities';
 
@@ -79,11 +70,6 @@ export const VPCRanges = ({ disabled, interfaceIndex }: Props) => {
         <LinkButton disabled={disabled} onClick={() => append({ range: '' })}>
           Add IPv4 Range
         </LinkButton>
-        <TooltipIcon
-          status="info"
-          sxTooltipIcon={{ p: 0.5 }}
-          text={<VPCRangesDescription />}
-        />
       </Stack>
     </Stack>
   );

--- a/packages/manager/src/features/Linodes/LinodeCreate/VPC/VPC.tsx
+++ b/packages/manager/src/features/Linodes/LinodeCreate/VPC/VPC.tsx
@@ -250,6 +250,7 @@ export const VPC = () => {
                         name="interfaces.0.ipv6.slaac.0.range"
                         render={({ field, fieldState }) => (
                           <VPCIPv6Address
+                            autoAssignValue={null}
                             errorMessage={fieldState.error?.message}
                             fieldValue={field.value}
                             onBlur={field.onBlur}

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/AddInterfaceDrawer/VPC/AddVPCIPv6Address.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/AddInterfaceDrawer/VPC/AddVPCIPv6Address.tsx
@@ -27,6 +27,7 @@ export const AddVPCIPv6Address = () => {
         name="vpc.ipv6.slaac.0.range"
         render={({ field, fieldState }) => (
           <VPCIPv6Address
+            autoAssignValue="auto"
             errorMessage={fieldState.error?.message}
             fieldValue={field.value}
             onChange={field.onChange}

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/EditInterfaceDrawer/VPCInterface/EditVPCIPv6Address.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/EditInterfaceDrawer/VPCInterface/EditVPCIPv6Address.tsx
@@ -35,6 +35,7 @@ export const EditVPCIPv6Address = (props: Props) => {
         name="vpc.ipv6.slaac.0.range"
         render={({ field, fieldState }) => (
           <VPCIPv6Address
+            autoAssignValue="auto"
             errorMessage={fieldState.error?.message}
             fieldValue={field.value}
             ipv6Address={linodeInterface.vpc?.ipv6?.slaac[0].range}

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/VPCIPv6Address.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/VPCIPv6Address.tsx
@@ -13,34 +13,57 @@ import {
 } from 'src/features/VPCs/constants';
 
 interface Props {
+  /**
+   * Linode Interfaces use "auto" to auto-assign IP addresses
+   * Legacy Config Interfaces use `null` to auto-assign IP addresses
+   */
+  autoAssignValue: 'auto' | null;
   disabled?: boolean;
   errorMessage?: string;
   fieldValue?: null | string;
   ipv6Address?: string;
   onBlur?: () => void;
-  onChange: (ipv6Address: string) => void;
+  onChange: (ipv6Address: null | string) => void;
 }
 
 export const VPCIPv6Address = (props: Props) => {
-  const { errorMessage, fieldValue, onBlur, onChange, disabled, ipv6Address } =
-    props;
+  const {
+    errorMessage,
+    fieldValue,
+    onBlur,
+    onChange,
+    disabled,
+    ipv6Address,
+    autoAssignValue,
+  } = props;
+
+  // Auto-assign should be checked if any of the following are true
+  // - field value is 'auto
+  // - field value is undefined
+  const shouldAutoAssign =
+    fieldValue === autoAssignValue || fieldValue === undefined;
+
+  // Initialize the form value to autoAssignValue if it should auto-assign but is undefined
+  if (shouldAutoAssign && fieldValue === undefined) {
+    onChange(autoAssignValue);
+  }
 
   return (
     <Stack rowGap={1}>
       <Stack direction="row">
         <FormControlLabel
-          checked={fieldValue === 'auto'}
+          checked={shouldAutoAssign}
           control={<Checkbox />}
           disabled={disabled}
           label="Auto-assign VPC IPv6"
           onChange={(e, checked) => {
-            onChange(checked ? 'auto' : (ipv6Address ?? ''));
+            onChange(checked ? autoAssignValue : (ipv6Address ?? ''));
           }}
           sx={{ pl: 0.4, mr: 0 }}
         />
         <TooltipIcon status="info" text={VPC_AUTO_ASSIGN_IPV6_TOOLTIP} />
       </Stack>
-      {fieldValue !== 'auto' && (
+      {!shouldAutoAssign && (
         <TextField
           errorText={errorMessage}
           helperText={VPC_IPV6_INPUT_HELPER_TEXT}

--- a/packages/manager/src/features/components/PlansPanel/DedicatedPlanFilters.tsx
+++ b/packages/manager/src/features/components/PlansPanel/DedicatedPlanFilters.tsx
@@ -166,7 +166,7 @@ const DedicatedPlanFiltersComponent = React.memo(
             onChange={handleGenerationChange}
             options={GENERATION_OPTIONS}
             placeholder="Select a plan"
-            sx={{ width: 446 }}
+            sx={{ width: 360 }}
             value={selectedGenerationOption}
           />
 


### PR DESCRIPTION
## Description 📝

As part of this PR, apply changes in Networking section under create linode page as suggested by [UX](https://www.figma.com/proto/Ap7HySAV7KBS4sHagwrsdW/Linode-Interfaces?page-id=4984%3A75240&node-id=5021-41002&viewport=3824%2C-162%2C0.5&t=EPdjY73Z1Vdzllmx-1&scaling=min-zoom&content-scaling=fixed&starting-point-node-id=5021%3A41002) and [TW](https://docs.google.com/spreadsheets/d/1ayBYZVBkXKNMU5pur0BQI17fRoetIEDRJdMsr7QmnNw/edit?gid=0#gid=0)

## Changes  🔄

- Swap placement of network interface type and network connection fields under networking
- Update tooltip copy for all radio options under networking section as mentioned in [UX copy ](https://docs.google.com/spreadsheets/d/1ayBYZVBkXKNMU5pur0BQI17fRoetIEDRJdMsr7QmnNw/edit?gid=0#gid=0) sheet
- Add recommendation to Linode interfaces under network interface type options
- Remove accordion for Network interface type
- Update backups description
- Add relevant unit test cases
- Fix issue with private IP value in POST payload introduced due to previous [PR](https://github.com/linode/manager/pull/13253)
- Add dividers between panel in VPC panel under networking
- Check Auto assign VPC IPv6 checkbox by default(similar to IPv4 option)

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [x] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

Jan 28

## Preview 📷

| Before  | After   |
| ------- | ------- |
| When network setting is linode only |
| ![Screenshot 2026-01-15 at 5 17 40 PM](https://github.com/user-attachments/assets/29ab17c0-af88-4e09-88e8-abea9ae86f3a) | ![Screenshot 2026-01-15 at 5 17 53 PM](https://github.com/user-attachments/assets/a4f625ee-6a55-4a62-b285-9ee0e28f9523) |
| When both interfaces are supported |
| ![Screenshot 2026-01-15 at 5 18 36 PM](https://github.com/user-attachments/assets/d0c18a35-8008-4403-a851-c3954c84d78f) | ![Screenshot 2026-01-15 at 5 18 43 PM](https://github.com/user-attachments/assets/50183534-185c-41f2-bf68-f776627566d0) |
![Screenshot 2026-01-15 at 5 18 56 PM](https://github.com/user-attachments/assets/fd5e3736-aa7d-457f-8ade-df08ad3e14ca) | ![Screenshot 2026-01-15 at 5 19 04 PM](https://github.com/user-attachments/assets/9222aa56-8b31-4928-8269-48800fdbe137) |
| ![Screenshot 2026-01-21 at 5 09 45 PM](https://github.com/user-attachments/assets/8f91d3b6-9eaa-4ff9-9379-f1f148529ba5) | ![Screenshot 2026-01-21 at 5 10 36 PM](https://github.com/user-attachments/assets/4a10678d-54bc-4771-ab5b-171990f9c362) |
| Auto-assign VPC IPv6 by default |
| ![Screenshot 2026-01-21 at 11 20 07 PM](https://github.com/user-attachments/assets/13708870-8d64-41f8-baf3-94ba316d1ce6) | ![Screenshot 2026-01-21 at 11 20 27 PM](https://github.com/user-attachments/assets/47d1e16c-010a-4094-8dd4-d6e3434f54dc) |


## How to test 🧪

- Ensure linode interfaces feature flag is enabled
- Navigate to `/linodes/create/os` page

### Verification steps

- [x] Ensure above mentioned UX and text changes are reflecting
- [x] Ensure no regression impact on existing functionality and test cases

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

-->