### PR TITLE
fix: [UIE-10016] - Show notice in add interface drawer when adding Public Internet interface to Linode with VPC

### DIFF
--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/AddInterfaceDrawer/AddInterfaceForm.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/AddInterfaceDrawer/AddInterfaceForm.test.tsx
@@ -1,4 +1,7 @@
-import { linodeInterfaceFactoryPublic } from '@linode/utilities';
+import {
+  linodeInterfaceFactoryPublic,
+  linodeInterfaceFactoryVPC,
+} from '@linode/utilities';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
@@ -121,6 +124,27 @@ describe('AddInterfaceForm', () => {
     expect(
       getByText(/This Linode already has a public interface/)
     ).toBeVisible();
+  });
+
+  it('should show a warning notice on selection of Public option if a VPC interface already exists', async () => {
+    const mockVPCInterface = linodeInterfaceFactoryVPC.build();
+
+    server.use(
+      http.get('*/linode/instances/:linodeId/interfaces', () => {
+        return HttpResponse.json({
+          interfaces: [mockVPCInterface],
+        });
+      })
+    );
+
+    const { getByRole, findByRole, getByText } = renderWithTheme(
+      <AddInterfaceForm {...props} />
+    );
+
+    // Wait for the loading to complete and form to render
+    await findByRole('radio', { name: 'Public' });
+    await userEvent.click(getByRole('radio', { name: 'Public' }));
+    expect(getByText(/This Linode already has a VPC interface/)).toBeVisible();
   });
 
   it('should disable Public interface radio button if a Public interface already exists', async () => {

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/AddInterfaceDrawer/AddInterfaceForm.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/LinodeInterfaces/AddInterfaceDrawer/AddInterfaceForm.tsx
@@ -43,7 +43,6 @@ export const AddInterfaceForm = (props: Props) => {
     interfacesData?.interfaces.map((networkInterface) =>
       getLinodeInterfaceType(networkInterface)
     ) ?? [];
-  const isPublicInterfacePresent = existingInterfaces.includes('Public');
   const form = useForm<CreateInterfaceFormValues>({
     defaultValues: {
       firewall_id: null,
@@ -105,6 +104,46 @@ export const AddInterfaceForm = (props: Props) => {
     );
   }
 
+  const additionalWarningMessage =
+    'Each Linode comes with one public IP address. Additional public IP addresses are available upon request and will incur a monthly charge.';
+
+  const getWarningNotice = () => {
+    if (
+      selectedInterfacePurpose === 'public' &&
+      existingInterfaces.includes('VPC')
+    ) {
+      return (
+        <Notice variant="warning">
+          <Typography>
+            This Linode already has a VPC interface. Having both a VPC interface
+            and a public interface is not recommended. If you need internet
+            access, consider using the VPC’s
+            <strong> Public access</strong> option instead.
+          </Typography>
+          <Typography paddingTop={2}>{additionalWarningMessage}</Typography>
+        </Notice>
+      );
+    }
+
+    if (
+      selectedInterfacePurpose === 'vpc' &&
+      existingInterfaces.includes('Public')
+    ) {
+      return (
+        <Notice variant="warning">
+          <Typography>
+            This Linode already has a public interface. Having both a VPC
+            interface and a public interface is not recommended. If you need
+            public internet access, consider using the VPC’s{' '}
+            <strong> Public access</strong> option instead.
+          </Typography>
+          <Typography paddingTop={2}>{additionalWarningMessage}</Typography>
+        </Notice>
+      );
+    }
+    return null;
+  };
+
   return (
     <FormProvider {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)}>
@@ -122,30 +161,15 @@ export const AddInterfaceForm = (props: Props) => {
             />
           )}
           <InterfaceType existingInterfaces={existingInterfaces} />
+          {getWarningNotice()}
           {selectedInterfacePurpose === 'public' && <PublicInterface />}
           {selectedInterfacePurpose === 'vlan' && (
             <VLANInterface regionId={regionId} />
           )}
           {selectedInterfacePurpose === 'vpc' && (
-            <Box>
-              {isPublicInterfacePresent && (
-                <Notice variant="warning">
-                  <Typography>
-                    This Linode already has a public interface. Having both a
-                    VPC interface and a public interface is not recommended. If
-                    you need public internet access, consider using the VPC’s
-                    <strong> Public access</strong> option instead.
-                  </Typography>
-                  <Typography paddingTop={2}>
-                    Each Linode includes one public IP address. To request
-                    additional public IPs, please note that they incur a monthly
-                    charge.
-                  </Typography>
-                </Notice>
-              )}
-              <VPCInterface regionId={regionId} />
-            </Box>
+            <VPCInterface regionId={regionId} />
           )}
+
           {selectedInterfacePurpose !== 'vlan' && <InterfaceFirewall />}
           <Actions onClose={onClose} />
         </Stack>


### PR DESCRIPTION
## Description 📝

As part of this PR, changes has been made to show notice in Add interface drawer when linode already has a VPC interface and user tries to add public interface to the linode

> Note: Changeset is not required as this bug got introduced due to recent [changes](https://github.com/linode/manager/pull/13264)>

## Changes  🔄

- Add notice in `AddInterfaceForm.tsx` to show warning message while adding public interface to a linode with VPC from linode details page.

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [x] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

Jan 28

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2026-01-21 at 6 20 59 PM](https://github.com/user-attachments/assets/e024f9a6-0333-4aa0-bcc7-d987150d32fb) | ![Screenshot 2026-01-21 at 7 08 58 PM](https://github.com/user-attachments/assets/b6c6d219-8fe5-440f-8166-5ff71a5c8f2e) |

## How to test 🧪

### Prerequisites

- Enable linode interfaces feature flag
- Create a Linode using Linode interfaces with a VPC interface
- On the Linode's details page, navigate to the "Network" tab and click "Add Network Interface"

### Reproduction steps

- [ ] In the drawer, select the "Public" interface. Observe that no notice is shown regarding having a VPC and Public IP interface at the same time, even though the same considerations apply

### Verification steps

- [ ] Ensure a warning notice is shown while adding public interface to linode with VPC

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

-->