### PR TITLE
Enable feature flag to show/hide blackwell GPU plans in LKE plans panel

### DIFF
--- a/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/lke-create.spec.ts
@@ -1914,6 +1914,9 @@ describe('smoketest for Nvidia Blackwell GPUs in kubernetes/create page', () => 
   });
 
   it('both tiers should include blackwell GPUs', () => {
+    mockAppendFeatureFlags({
+      kubernetesBlackwellPlans: true,
+    }).as('getFeatureFlags');
     cy.visitWithLogin('/kubernetes/create');
     cy.wait(['@getRegions', '@getLinodeTypes']);
 

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -36,6 +36,7 @@ const options: { flag: keyof Flags; label: string }[] = [
   },
   { flag: 'gecko2', label: 'Gecko' },
   { flag: 'generationalPlansv2', label: 'Generational compute plans' },
+  { flag: 'kubernetesBlackwellPlans', label: 'Kubernetes Blackwell Plans' },
   { flag: 'limitsEvolution', label: 'Limits Evolution' },
   { flag: 'linodeDiskEncryption', label: 'Linode Disk Encryption (LDE)' },
   { flag: 'linodeInterfaces', label: 'Linode Interfaces' },

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -246,6 +246,7 @@ export interface Flags {
   iamDelegation: BaseFeatureFlag;
   iamLimitedAvailabilityBadges: boolean;
   ipv6Sharing: boolean;
+  kubernetesBlackwellPlans: boolean;
   limitsEvolution: LimitsEvolution;
   linodeCloneFirewall: boolean;
   linodeCreateBanner: LinodeCreateBanner;

--- a/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlansPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesPlansPanel/KubernetesPlansPanel.tsx
@@ -99,7 +99,10 @@ export const KubernetesPlansPanel = (props: Props) => {
     }
 
     return (
-      !type.id.includes('dedicated-edge') && !type.id.includes('nanode-edge')
+      !type.id.includes('dedicated-edge') &&
+      !type.id.includes('nanode-edge') &&
+      // Filter out Blackwell plans for kubernetes (for now)
+      !(type.id.includes('blackwell') && !flags.kubernetesBlackwellPlans)
     );
   });
 


### PR DESCRIPTION
## Description 📝

Enable feature flag for GPU blackwell plans in LKE plans panel. This check was recent removed as part of [PR](https://github.com/linode/manager/pull/13347) to enable GPU plans in LKE flow for GA but this program is on hold for now. So we are adding back the feature flag check.


## Changes  🔄

- In `kubernetesPlansPanel.tsx`, add a check to show/hide blackwell GPU plans based on feature flag.

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [x] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

Feb 2026

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2026-02-20 at 12 27 41 PM](https://github.com/user-attachments/assets/34e6cb2b-b495-4f7c-9b57-cf207b36b9ae) | ![Screenshot 2026-02-20 at 12 30 14 PM](https://github.com/user-attachments/assets/1cfd3ee4-ff73-4e49-9ca2-d71c5b0f1dd2) |

## How to test 🧪

### Prerequisites

- Navigate to create LKE flow
- Enable "Kubernetes Blackwell Plans" feature flag.

### Verification steps

- [ ] Ensure blackwell GPU plans are visible under GPU tab in create flow
- [ ] Uncheck the flag and ensure that the plans are not shown.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

-->