### PR TITLE
fix: [UIE-9888] - update node balancer type for enterprise and remove duplicate nodebalancer rows in VPC subnet table

### DIFF
--- a/packages/api-v4/.changeset/pr-13472-changed-1773131929522.md
+++ b/packages/api-v4/.changeset/pr-13472-changed-1773131929522.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Changed
+---
+
+Update  node balancer type for enterprise from premium_40GB to premium_40gb ([#13472](https://github.com/linode/manager/pull/13472))

--- a/packages/api-v4/src/nodebalancers/types.ts
+++ b/packages/api-v4/src/nodebalancers/types.ts
@@ -10,7 +10,7 @@ type UDPStickiness = 'none' | 'session' | 'source_ip';
 
 export type Stickiness = TCPStickiness | UDPStickiness;
 
-type NodeBalancerType = 'common' | 'premium' | 'premium_40GB';
+type NodeBalancerType = 'common' | 'premium' | 'premium_40gb';
 
 export interface LKEClusterInfo {
   id: number;

--- a/packages/manager/.changeset/pr-13472-fixed-1773071273109.md
+++ b/packages/manager/.changeset/pr-13472-fixed-1773071273109.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Update node balancer type for enterprise and remove duplicate nodebalancer rows in VPC subnet table ([#13472](https://github.com/linode/manager/pull/13472))

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.test.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.test.tsx
@@ -162,9 +162,9 @@ describe('SummaryPanel', () => {
     expect(typeElement).toBeVisible();
   });
 
-  it('displays type: Enterprise if the nodebalancer is premium_40GB', () => {
+  it('displays type: Enterprise if the nodebalancer is premium_40gb', () => {
     queryMocks.useNodeBalancerQuery.mockReturnValue({
-      data: nodeBalancerFactory.build({ type: 'premium_40GB' }),
+      data: nodeBalancerFactory.build({ type: 'premium_40gb' }),
     });
 
     const { getByText } = renderWithTheme(<SummaryPanel />);

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
@@ -112,7 +112,7 @@ export const SummaryPanel = () => {
               <strong>Type: </strong>
               {nodebalancer.type === 'common' && 'Basic'}
               {nodebalancer.type === 'premium' && 'Premium'}
-              {nodebalancer.type === 'premium_40GB' && 'Enterprise'}
+              {nodebalancer.type === 'premium_40gb' && 'Enterprise'}
             </Typography>
           </StyledSection>
           <StyledSection>

--- a/packages/manager/src/features/VPCs/VPCDetail/VPCSubnetsTable.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/VPCSubnetsTable.tsx
@@ -315,6 +315,13 @@ export const VPCSubnetsTable = (props: Props) => {
 
   const getTableItems = (): TableItem[] => {
     return subnets.data.map((subnet) => {
+      // NodeBalancers can have same VPC subnet as its frontend and backend configuration.
+      // and this can create duplicate entries in the resources count and also in the list of nodebalancers assigned to a subnet.
+      // To avoid this, we are creating a unique list of nodebalancers based on their id.
+      const uniqueNodebalancers = Array.from(
+        new Map(subnet.nodebalancers.map((nb) => [nb.id, nb])).values()
+      );
+
       const OuterTableCells = (
         <>
           <Hidden smDown>
@@ -326,7 +333,7 @@ export const VPCSubnetsTable = (props: Props) => {
           )}
           <Hidden smDown>
             <TableCell>
-              {`${isNodebalancerVPCEnabled ? subnet.linodes.length + subnet.nodebalancers.length : subnet.linodes.length}`}
+              {`${isNodebalancerVPCEnabled ? subnet.linodes.length + uniqueNodebalancers.length : subnet.linodes.length}`}
             </TableCell>
           </Hidden>
           <TableCell actionCell>
@@ -336,7 +343,7 @@ export const VPCSubnetsTable = (props: Props) => {
               handleEdit={handleSubnetEdit}
               handleUnassignLinodes={handleSubnetUnassignLinodes}
               numLinodes={subnet.linodes.length}
-              numNodebalancers={subnet.nodebalancers.length}
+              numNodebalancers={uniqueNodebalancers.length}
               subnet={subnet}
               vpcId={vpcId}
             />
@@ -376,7 +383,7 @@ export const VPCSubnetsTable = (props: Props) => {
               )}
             </TableBody>
           </Table>
-          {isNodebalancerVPCEnabled && subnet.nodebalancers?.length > 0 && (
+          {isNodebalancerVPCEnabled && uniqueNodebalancers.length > 0 && (
             <Table aria-label="NodeBalancers" size="small" striped={false}>
               <TableHead
                 style={{
@@ -386,7 +393,7 @@ export const VPCSubnetsTable = (props: Props) => {
                 {SubnetNodebalancerTableRowHead}
               </TableHead>
               <TableBody>
-                {subnet.nodebalancers.map((nb) => (
+                {uniqueNodebalancers.map((nb) => (
                   <SubnetNodeBalancerRow
                     key={nb.id}
                     nodeBalancerId={nb.id}

--- a/packages/utilities/src/factories/nodebalancer.ts
+++ b/packages/utilities/src/factories/nodebalancer.ts
@@ -47,7 +47,7 @@ export const nodeBalancerFactory = Factory.Sync.makeFactory<NodeBalancer>({
   }),
   type: Factory.each((i) => {
     if (i === 1) {
-      return 'premium_40GB';
+      return 'premium_40gb';
     }
     if (i % 2 === 0) {
       return 'premium';


### PR DESCRIPTION
## Description 📝

This is to update type of nodebalancer "premium_40GB" to "premium_40gb" across API typings and fix empty text shown for type field in node balancer summary page for this type. Also when node balancer is created with same VPC as frontend and backend configuration, duplicate row in subnet nodebalancers table under VPC details page has to be removed.

## Changes  🔄

- Update node balancer type for enterprise to 'premium_40gb' instead of 'premium_40GB'
- Remove duplicate nodebalancer rows in VPC subnet table.

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [x] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

Mar 18

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2026-03-09 at 9 03 29 PM](https://github.com/user-attachments/assets/95074bae-697f-4b9a-85b3-2140f65114d0) | ![Screenshot 2026-03-09 at 8 56 29 PM](https://github.com/user-attachments/assets/543a64a1-7deb-43cb-ba63-499466cfe78f) |
| ![Screenshot 2026-03-09 at 9 04 02 PM](https://github.com/user-attachments/assets/76ceac14-2881-4401-ba60-f48c73ca83d5) | ![Screenshot 2026-03-09 at 9 04 23 PM](https://github.com/user-attachments/assets/9b45d24f-948b-45a0-891a-34c4b022f791) |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Create a nodebalancer with type "premium_40gb" in devcloud using postman or curl.
- Make use of same VPC subnet for both frontend and backend configurations while creating nodebalancer.

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] In https://cloud.devcloud.linode.com/, see that under summary, type for nodebalancer created is shown empty
- [ ] In "/vpcs/{vpc_id}" page, duplicate row for nodebalancer is shown under subnet nodebalancer table

### Verification steps

- [ ] Ensure correct type is shown for the nodebalancer after checking out to this branch
- [ ] Ensure duplicate row is removed for nodebalancer under VPC subnet table.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

-->