### PR TITLE
feat: [DPS-36767] - Embedded metrics dashboard as contextual view in stream

### DIFF
--- a/packages/manager/.changeset/pr-13492-added-1773404986416.md
+++ b/packages/manager/.changeset/pr-13492-added-1773404986416.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Stream Metrics tab with embedded metrics dashboard ([#13492](https://github.com/linode/manager/pull/13492))

--- a/packages/manager/cypress/e2e/core/delivery/destinations-non-empty-landing-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/delivery/destinations-non-empty-landing-page.spec.ts
@@ -92,7 +92,7 @@ function editDestinationViaActionMenu(
       mockGetDestination(destination);
       // Edit destination redirect
       ui.actionMenuItem.findByTitle('Edit').click();
-      cy.url().should('endWith', `/destinations/${destination.id}/edit`);
+      cy.url().should('endWith', `/destinations/${destination.id}/summary`);
     });
 }
 
@@ -255,7 +255,7 @@ describe('destinations landing checks for non-empty state', () => {
       mockGetDestination(destination).as('getDestination');
 
       cy.findByText(destination.label).click();
-      cy.url().should('endWith', `/destinations/${destination.id}/edit`);
+      cy.url().should('endWith', `/destinations/${destination.id}/summary`);
       cy.wait('@getDestination');
     });
 

--- a/packages/manager/cypress/e2e/core/delivery/destinations-non-empty-landing-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/delivery/destinations-non-empty-landing-page.spec.ts
@@ -181,7 +181,7 @@ describe('destinations landing checks for non-empty state', () => {
       });
     });
 
-    it('navigates to edit page when clicking destination label', () => {
+    it('navigates to summary page when clicking destination label', () => {
       cy.visitWithLogin('/logs/delivery/destinations');
       cy.wait('@getDestinations');
 
@@ -189,7 +189,7 @@ describe('destinations landing checks for non-empty state', () => {
       mockGetDestination(destination).as('getDestination');
 
       cy.findByText(destination.label).click();
-      cy.url().should('endWith', `/destinations/${destination.id}/edit`);
+      cy.url().should('endWith', `/destinations/${destination.id}/summary`);
       cy.wait('@getDestination');
     });
 

--- a/packages/manager/cypress/e2e/core/delivery/edit-destination.spec.ts
+++ b/packages/manager/cypress/e2e/core/delivery/edit-destination.spec.ts
@@ -43,7 +43,7 @@ describe('Edit Destination', () => {
   describe('given Akamai Object Storage type destination', () => {
     beforeEach(() => {
       cy.visitWithLogin(
-        `/logs/delivery/destinations/${mockAkamaiObjectStorageDestination.id}/edit`
+        `/logs/delivery/destinations/${mockAkamaiObjectStorageDestination.id}/summary`
       );
       mockGetDestination(mockAkamaiObjectStorageDestination);
     });
@@ -201,7 +201,7 @@ describe('Edit Destination', () => {
   describe('given Custom HTTPS type destination', () => {
     beforeEach(() => {
       cy.visitWithLogin(
-        `/logs/delivery/destinations/${mockCustomHttpsDestination.id}/edit`
+        `/logs/delivery/destinations/${mockCustomHttpsDestination.id}/summary`
       );
       mockGetDestination(mockCustomHttpsDestination);
     });

--- a/packages/manager/cypress/e2e/core/delivery/edit-stream.spec.ts
+++ b/packages/manager/cypress/e2e/core/delivery/edit-stream.spec.ts
@@ -46,9 +46,7 @@ describe('Edit Stream', () => {
       mockGetStream(mockAuditLogsStream);
 
       // Visit the Edit Stream page
-      cy.visitWithLogin(
-        `/logs/delivery/streams/${mockAuditLogsStream.id}/edit/`
-      );
+      cy.visitWithLogin(`/logs/delivery/streams/${mockAuditLogsStream.id}`);
 
       const updatedLabel = randomLabel();
 
@@ -207,9 +205,7 @@ describe('Edit Stream', () => {
       mockGetClusters([cluster1, cluster2, cluster3, cluster4]);
 
       // Visit the Edit Stream page
-      cy.visitWithLogin(
-        `/logs/delivery/streams/${mockLKEAuditLogsStream.id}/edit/`
-      );
+      cy.visitWithLogin(`/logs/delivery/streams/${mockLKEAuditLogsStream.id}`);
 
       const updatedLabel = randomLabel();
 

--- a/packages/manager/cypress/e2e/core/delivery/streams-non-empty-landing-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/delivery/streams-non-empty-landing-page.spec.ts
@@ -88,7 +88,7 @@ function editStreamViaActionMenu(tableAlias: string, stream: Stream) {
       mockGetStream(stream);
       // Edit stream redirect
       ui.actionMenuItem.findByTitle('Edit').click();
-      cy.url().should('endWith', `/streams/${stream.id}/edit`);
+      cy.url().should('endWith', `/streams/${stream.id}/summary`);
     });
 }
 
@@ -180,7 +180,7 @@ describe('Streams non-empty landing page', () => {
 
     // Redirect to stream edit page via name
     cy.findByText(exampleStream.label).click();
-    cy.url().should('endWith', `/streams/${exampleStream.id}/edit`);
+    cy.url().should('endWith', `/streams/${exampleStream.id}/summary`);
     cy.wait(['@getStream', '@getDestinations']);
 
     // Redirect to stream edit page via menu item

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -135,6 +135,10 @@ interface AclpLogsFlag extends BetaFeatureFlag {
    */
   customHttpsEnabled?: boolean;
   /**
+   * This property indicates whether to show the "Metrics" tab on Logs Stream details page or not
+   */
+  metricsEnabled?: boolean;
+  /**
    * This property indicates whether the feature is new or not
    */
   new?: boolean;

--- a/packages/manager/src/features/Delivery/Destinations/DestinationForm/DestinationEdit.test.tsx
+++ b/packages/manager/src/features/Delivery/Destinations/DestinationForm/DestinationEdit.test.tsx
@@ -216,14 +216,14 @@ describe('DestinationEdit', () => {
     });
   });
 
-  describe('given Test Connection and Edit Destination buttons', () => {
+  describe('given Test Connection and Save Changes buttons', () => {
     const testConnectionButtonText = 'Test Connection';
     const saveDestinationButtonText = 'Save Changes';
     const editDestinationSpy = vi.fn();
     const verifyDestinationSpy = vi.fn();
 
     describe('when Test Connection button clicked and connection verified positively', () => {
-      it("should enable Edit Destination button and perform proper call when it's clicked", async () => {
+      it("should enable Save Changes button and perform proper call when it's clicked", async () => {
         server.use(
           http.get(`*/monitor/streams/destinations/${destinationId}`, () => {
             return HttpResponse.json(mockDestination);
@@ -269,7 +269,7 @@ describe('DestinationEdit', () => {
     });
 
     describe('when Test Connection button clicked and connection verified negatively', () => {
-      it('should not enable Edit Destination button', async () => {
+      it('should not enable Save Changes button', async () => {
         server.use(
           http.get(`*/monitor/streams/destinations/${destinationId}`, () => {
             return HttpResponse.json(mockDestination);

--- a/packages/manager/src/features/Delivery/Destinations/DestinationForm/DestinationEdit.tsx
+++ b/packages/manager/src/features/Delivery/Destinations/DestinationForm/DestinationEdit.tsx
@@ -25,7 +25,7 @@ import type { DestinationFormType } from 'src/features/Delivery/Shared/types';
 export const DestinationEdit = () => {
   const navigate = useNavigate();
   const { destinationId } = useParams({
-    from: '/logs/delivery/destinations/$destinationId/edit',
+    from: '/logs/delivery/destinations/$destinationId/summary',
   });
   const { mutateAsync: updateDestination, isPending: isUpdatingDestination } =
     useUpdateDestinationMutation();
@@ -37,7 +37,7 @@ export const DestinationEdit = () => {
 
   const landingHeaderProps: LandingHeaderProps = {
     breadcrumbProps: {
-      pathname: '/logs/delivery/destinations/edit',
+      pathname: '/logs/delivery/destinations/summary',
       crumbOverrides: [
         {
           label: 'Delivery',
@@ -48,7 +48,7 @@ export const DestinationEdit = () => {
     },
     docsLink: 'https://techdocs.akamai.com/cloud-computing/docs/log-delivery',
     removeCrumbX: [1, 2],
-    title: `Edit Destination ${destinationId}`,
+    title: `Destination ${destinationId}`,
   };
 
   const form = useForm<DestinationFormType>({
@@ -136,7 +136,7 @@ export const DestinationEdit = () => {
 
   return (
     <>
-      <DocumentTitleSegment segment="Edit Destination" />
+      <DocumentTitleSegment segment="Destination" />
       <LandingHeader {...landingHeaderProps} />
       <FormProvider {...form}>
         <DestinationForm

--- a/packages/manager/src/features/Delivery/Destinations/DestinationForm/destinationEditLazyRoute.ts
+++ b/packages/manager/src/features/Delivery/Destinations/DestinationForm/destinationEditLazyRoute.ts
@@ -3,7 +3,7 @@ import { createLazyRoute } from '@tanstack/react-router';
 import { DestinationEdit } from 'src/features/Delivery/Destinations/DestinationForm/DestinationEdit';
 
 export const destinationEditLazyRoute = createLazyRoute(
-  '/logs/delivery/destinations/$destinationId/edit'
+  '/logs/delivery/destinations/$destinationId/summary'
 )({
   component: DestinationEdit,
 });

--- a/packages/manager/src/features/Delivery/Destinations/DestinationTableRow.tsx
+++ b/packages/manager/src/features/Delivery/Destinations/DestinationTableRow.tsx
@@ -25,7 +25,7 @@ export const DestinationTableRow = React.memo(
         <TableCell>
           <LinkWithTooltipAndEllipsis
             pendoId="Logs Delivery Destinations-Name"
-            to={`/logs/delivery/destinations/${id}/edit`}
+            to={`/logs/delivery/destinations/${id}/summary`}
           >
             {destination.label}
           </LinkWithTooltipAndEllipsis>

--- a/packages/manager/src/features/Delivery/Destinations/DestinationsLanding.test.tsx
+++ b/packages/manager/src/features/Delivery/Destinations/DestinationsLanding.test.tsx
@@ -166,7 +166,7 @@ describe('Destinations Landing Table', () => {
         await clickOnActionMenuItem('Edit');
 
         expect(mockNavigate).toHaveBeenCalledWith({
-          to: '/logs/delivery/destinations/1/edit',
+          to: '/logs/delivery/destinations/1/summary',
         });
       });
     });

--- a/packages/manager/src/features/Delivery/Destinations/DestinationsLanding.tsx
+++ b/packages/manager/src/features/Delivery/Destinations/DestinationsLanding.tsx
@@ -105,7 +105,7 @@ export const DestinationsLanding = () => {
   }
 
   const handleEdit = ({ id }: Destination) => {
-    navigate({ to: `/logs/delivery/destinations/${id}/edit` });
+    navigate({ to: `/logs/delivery/destinations/${id}/summary` });
   };
 
   const openDeleteDialog = (destination: Destination) => {

--- a/packages/manager/src/features/Delivery/Streams/Stream/StreamLanding.test.tsx
+++ b/packages/manager/src/features/Delivery/Streams/Stream/StreamLanding.test.tsx
@@ -7,10 +7,21 @@ import {
   streamFactory,
 } from 'src/factories';
 import { StreamLanding } from 'src/features/Delivery/Streams/Stream/StreamLanding';
-import { http, HttpResponse, server } from 'src/mocks/testServer';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import type { Flags } from 'src/featureFlags';
+
+const queryMocks = vi.hoisted(() => ({
+  useStreamQuery: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('@linode/queries', async () => {
+  const actual = await vi.importActual('@linode/queries');
+  return {
+    ...actual,
+    useStreamQuery: queryMocks.useStreamQuery,
+  };
+});
 
 const streamId = 123;
 const mockDestinations = [
@@ -30,45 +41,83 @@ describe('StreamLanding', () => {
     });
   };
 
-  beforeEach(async () => {
-    server.use(
-      http.get(`*/monitor/streams/${streamId}`, () => {
-        return HttpResponse.json(mockStream);
-      })
-    );
-  });
+  describe('and stream has loaded successfully', () => {
+    beforeEach(async () => {
+      queryMocks.useStreamQuery.mockReturnValue({
+        data: mockStream,
+        isLoading: false,
+      });
+    });
 
-  describe('and metrics are not enabled', () => {
-    const flags = {
-      aclpLogs: {
-        enabled: true,
-        beta: false,
-        metricsEnabled: false,
-      },
-    };
+    describe('and metrics are not enabled', () => {
+      const flags = {
+        aclpLogs: {
+          enabled: true,
+          beta: false,
+          metricsEnabled: false,
+        },
+      };
 
-    it('should render the summary and not the metrics tab', async () => {
-      renderComponent(flags);
+      it('should render the summary and not the metrics tab', async () => {
+        renderComponent(flags);
 
-      screen.getByText('Summary');
-      expect(screen.queryByText('Metrics')).not.toBeInTheDocument();
+        screen.getByText('Summary');
+        expect(screen.queryByText('Metrics')).not.toBeInTheDocument();
+      });
+    });
+
+    describe('and metrics are enabled', () => {
+      const flags = {
+        aclpLogs: {
+          enabled: true,
+          beta: false,
+          metricsEnabled: true,
+        },
+      };
+
+      it('should render the summary tab and metrics tab', async () => {
+        renderComponent(flags);
+
+        screen.getByText('Summary');
+        expect(screen.queryByText('Metrics')).toBeInTheDocument();
+      });
     });
   });
 
-  describe('and metrics are enabled', () => {
-    const flags = {
-      aclpLogs: {
-        enabled: true,
-        beta: false,
-        metricsEnabled: true,
-      },
-    };
+  describe('and stream is loading', () => {
+    beforeEach(async () => {
+      queryMocks.useStreamQuery.mockReturnValue({
+        isLoading: true,
+      });
+    });
 
-    it('should render the summary tab and metrics tab', async () => {
-      renderComponent(flags);
+    it('should render loading spinner', async () => {
+      renderComponent({});
 
-      screen.getByText('Summary');
-      expect(screen.queryByText('Metrics')).toBeInTheDocument();
+      expect(screen.queryByText('Summary')).not.toBeInTheDocument();
+      expect(screen.queryByText('Metrics')).not.toBeInTheDocument();
+
+      const loadingElement = screen.queryByTestId('circle-progress');
+      expect(loadingElement).toBeInTheDocument();
+    });
+  });
+
+  describe('and stream request threw error', () => {
+    const streamErrorMessage = 'Stream not found';
+    beforeEach(async () => {
+      queryMocks.useStreamQuery.mockReturnValue({
+        isLoading: false,
+        error: [{ reason: streamErrorMessage }],
+      });
+    });
+
+    it('should render error state with message', async () => {
+      renderComponent({});
+
+      expect(screen.queryByText('Summary')).not.toBeInTheDocument();
+      expect(screen.queryByText('Metrics')).not.toBeInTheDocument();
+
+      expect(screen.queryByText(streamErrorMessage)).toBeInTheDocument();
     });
   });
 });

--- a/packages/manager/src/features/Delivery/Streams/Stream/StreamLanding.test.tsx
+++ b/packages/manager/src/features/Delivery/Streams/Stream/StreamLanding.test.tsx
@@ -1,0 +1,74 @@
+import { screen } from '@testing-library/react';
+import * as React from 'react';
+import { beforeEach, describe, it } from 'vitest';
+
+import {
+  akamaiObjectStorageDestinationFactory,
+  streamFactory,
+} from 'src/factories';
+import { StreamLanding } from 'src/features/Delivery/Streams/Stream/StreamLanding';
+import { http, HttpResponse, server } from 'src/mocks/testServer';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import type { Flags } from 'src/featureFlags';
+
+const streamId = 123;
+const mockDestinations = [
+  akamaiObjectStorageDestinationFactory.build({ id: 1 }),
+];
+const mockStream = streamFactory.build({
+  id: streamId,
+  label: `Stream ${streamId}`,
+  destinations: mockDestinations,
+});
+
+describe('StreamLanding', () => {
+  const renderComponent = (flags: Partial<Flags>) => {
+    renderWithTheme(<StreamLanding />, {
+      flags,
+      initialRoute: '/logs/delivery/streams/$streamId/summary',
+    });
+  };
+
+  beforeEach(async () => {
+    server.use(
+      http.get(`*/monitor/streams/${streamId}`, () => {
+        return HttpResponse.json(mockStream);
+      })
+    );
+  });
+
+  describe('and metrics are not enabled', () => {
+    const flags = {
+      aclpLogs: {
+        enabled: true,
+        beta: false,
+        metricsEnabled: false,
+      },
+    };
+
+    it('should render the summary and not the metrics tab', async () => {
+      renderComponent(flags);
+
+      screen.getByText('Summary');
+      expect(screen.queryByText('Metrics')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('and metrics are enabled', () => {
+    const flags = {
+      aclpLogs: {
+        enabled: true,
+        beta: false,
+        metricsEnabled: true,
+      },
+    };
+
+    it('should render the summary tab and metrics tab', async () => {
+      renderComponent(flags);
+
+      screen.getByText('Summary');
+      expect(screen.queryByText('Metrics')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/manager/src/features/Delivery/Streams/Stream/StreamLanding.tsx
+++ b/packages/manager/src/features/Delivery/Streams/Stream/StreamLanding.tsx
@@ -1,0 +1,69 @@
+import { useParams } from '@tanstack/react-router';
+import * as React from 'react';
+
+import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import {
+  LandingHeader,
+  type LandingHeaderProps,
+} from 'src/components/LandingHeader';
+import { SuspenseLoader } from 'src/components/SuspenseLoader';
+import { SafeTabPanel } from 'src/components/Tabs/SafeTabPanel';
+import { TabPanels } from 'src/components/Tabs/TabPanels';
+import { Tabs } from 'src/components/Tabs/Tabs';
+import { TanStackTabLinkList } from 'src/components/Tabs/TanStackTabLinkList';
+import { StreamMetrics } from 'src/features/Delivery/Streams/Stream/StreamMetrics';
+import { StreamEdit } from 'src/features/Delivery/Streams/StreamForm/StreamEdit';
+import { useTabs } from 'src/hooks/useTabs';
+
+export const StreamLanding = () => {
+  const { streamId } = useParams({
+    strict: false,
+  });
+
+  const { handleTabChange, tabIndex, tabs } = useTabs([
+    {
+      title: 'Summary',
+      to: `/logs/delivery/streams/$streamId/summary`,
+    },
+    {
+      title: 'Metrics',
+      to: `/logs/delivery/streams/$streamId/metrics`,
+    },
+  ]);
+
+  const landingHeaderProps: LandingHeaderProps = {
+    breadcrumbProps: {
+      pathname: '/logs/delivery/streams/summary',
+      crumbOverrides: [
+        {
+          label: 'Delivery',
+          linkTo: '/logs/delivery/streams',
+          position: 1,
+        },
+      ],
+    },
+    docsLink: 'https://techdocs.akamai.com/cloud-computing/docs/log-delivery',
+    removeCrumbX: [1, 2],
+    title: `Stream ${streamId}`,
+  };
+
+  return (
+    <>
+      <DocumentTitleSegment segment="Stream" />
+      <LandingHeader {...landingHeaderProps} />
+      <Tabs index={tabIndex} onChange={handleTabChange}>
+        <TanStackTabLinkList tabs={tabs} />
+        <React.Suspense fallback={<SuspenseLoader />}>
+          <TabPanels>
+            <SafeTabPanel index={0}>
+              <StreamEdit />
+            </SafeTabPanel>
+            <SafeTabPanel index={1}>
+              <StreamMetrics />
+            </SafeTabPanel>
+          </TabPanels>
+        </React.Suspense>
+      </Tabs>
+    </>
+  );
+};

--- a/packages/manager/src/features/Delivery/Streams/Stream/StreamLanding.tsx
+++ b/packages/manager/src/features/Delivery/Streams/Stream/StreamLanding.tsx
@@ -56,7 +56,7 @@ export const StreamLanding = () => {
 
   const landingHeaderProps: LandingHeaderProps = {
     breadcrumbProps: {
-      pathname: '/logs/delivery/streams/summary',
+      pathname: `/logs/delivery/streams/${streamId}`,
       crumbOverrides: [
         {
           label: 'Delivery',

--- a/packages/manager/src/features/Delivery/Streams/Stream/StreamLanding.tsx
+++ b/packages/manager/src/features/Delivery/Streams/Stream/StreamLanding.tsx
@@ -1,5 +1,6 @@
 import { useParams } from '@tanstack/react-router';
 import * as React from 'react';
+import { useMemo } from 'react';
 
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import {
@@ -11,25 +12,38 @@ import { SafeTabPanel } from 'src/components/Tabs/SafeTabPanel';
 import { TabPanels } from 'src/components/Tabs/TabPanels';
 import { Tabs } from 'src/components/Tabs/Tabs';
 import { TanStackTabLinkList } from 'src/components/Tabs/TanStackTabLinkList';
+import { useIsACLPLogsEnabled } from 'src/features/Delivery/deliveryUtils';
 import { StreamMetrics } from 'src/features/Delivery/Streams/Stream/StreamMetrics';
 import { StreamEdit } from 'src/features/Delivery/Streams/StreamForm/StreamEdit';
 import { useTabs } from 'src/hooks/useTabs';
+
+import type { Tab } from 'src/hooks/useTabs';
 
 export const StreamLanding = () => {
   const { streamId } = useParams({
     strict: false,
   });
+  const { isACLPLogsMetricsEnabled } = useIsACLPLogsEnabled();
 
-  const { handleTabChange, tabIndex, tabs } = useTabs([
-    {
-      title: 'Summary',
-      to: `/logs/delivery/streams/$streamId/summary`,
-    },
-    {
-      title: 'Metrics',
-      to: `/logs/delivery/streams/$streamId/metrics`,
-    },
-  ]);
+  const activeTabs = useMemo(() => {
+    const result: Tab[] = [
+      {
+        title: 'Summary',
+        to: `/logs/delivery/streams/$streamId/summary`,
+      },
+    ];
+
+    if (isACLPLogsMetricsEnabled) {
+      result.push({
+        title: 'Metrics',
+        to: `/logs/delivery/streams/$streamId/metrics`,
+      });
+    }
+
+    return result;
+  }, [isACLPLogsMetricsEnabled]);
+
+  const { handleTabChange, tabIndex, tabs } = useTabs(activeTabs);
 
   const landingHeaderProps: LandingHeaderProps = {
     breadcrumbProps: {

--- a/packages/manager/src/features/Delivery/Streams/Stream/StreamLanding.tsx
+++ b/packages/manager/src/features/Delivery/Streams/Stream/StreamLanding.tsx
@@ -1,3 +1,5 @@
+import { useStreamQuery } from '@linode/queries';
+import { Box, CircleProgress, ErrorState } from '@linode/ui';
 import { useParams } from '@tanstack/react-router';
 import * as React from 'react';
 import { useMemo } from 'react';
@@ -16,6 +18,7 @@ import { useIsACLPLogsEnabled } from 'src/features/Delivery/deliveryUtils';
 import { StreamMetrics } from 'src/features/Delivery/Streams/Stream/StreamMetrics';
 import { StreamEdit } from 'src/features/Delivery/Streams/StreamForm/StreamEdit';
 import { useTabs } from 'src/hooks/useTabs';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
 import type { Tab } from 'src/hooks/useTabs';
 
@@ -45,6 +48,12 @@ export const StreamLanding = () => {
 
   const { handleTabChange, tabIndex, tabs } = useTabs(activeTabs);
 
+  const { isLoading: isLoadingStream, error: errorStream } = useStreamQuery(
+    Number(streamId)
+  );
+  const streamErrorDefaultMessage =
+    'There was an error retrieving stream. Please reload and try again.';
+
   const landingHeaderProps: LandingHeaderProps = {
     breadcrumbProps: {
       pathname: '/logs/delivery/streams/summary',
@@ -60,6 +69,24 @@ export const StreamLanding = () => {
     removeCrumbX: [1, 2],
     title: `Stream ${streamId}`,
   };
+
+  if (isLoadingStream) {
+    return (
+      <Box display="flex" justifyContent="center">
+        <CircleProgress />
+      </Box>
+    );
+  }
+
+  if (errorStream) {
+    return (
+      <ErrorState
+        errorText={
+          getAPIErrorOrDefault(errorStream, streamErrorDefaultMessage)[0].reason
+        }
+      />
+    );
+  }
 
   return (
     <>

--- a/packages/manager/src/features/Delivery/Streams/Stream/StreamMetrics.tsx
+++ b/packages/manager/src/features/Delivery/Streams/Stream/StreamMetrics.tsx
@@ -1,0 +1,14 @@
+import { useParams } from '@tanstack/react-router';
+import * as React from 'react';
+
+import { CloudPulseDashboardWithFilters } from 'src/features/CloudPulse/Dashboard/CloudPulseDashboardWithFilters';
+
+export const StreamMetrics = () => {
+  const { streamId } = useParams({
+    from: '/logs/delivery/streams/$streamId/metrics',
+  });
+
+  return (
+    <CloudPulseDashboardWithFilters resource={streamId} serviceType="logs" />
+  );
+};

--- a/packages/manager/src/features/Delivery/Streams/Stream/streamLandingLazyRoute.ts
+++ b/packages/manager/src/features/Delivery/Streams/Stream/streamLandingLazyRoute.ts
@@ -1,0 +1,9 @@
+import { createLazyRoute } from '@tanstack/react-router';
+
+import { StreamLanding } from 'src/features/Delivery/Streams/Stream/StreamLanding';
+
+export const streamLandingLazyRoute = createLazyRoute(
+  '/logs/delivery/streams/$streamId'
+)({
+  component: StreamLanding,
+});

--- a/packages/manager/src/features/Delivery/Streams/StreamForm/StreamEdit.test.tsx
+++ b/packages/manager/src/features/Delivery/Streams/StreamForm/StreamEdit.test.tsx
@@ -87,7 +87,7 @@ describe('StreamEdit', () => {
   });
 
   describe(
-    'given Test Connection and Edit Stream buttons',
+    'given Test Connection and Save Changes buttons',
     { timeout: 10000 },
     () => {
       const testConnectionButtonText = 'Test Connection';
@@ -131,7 +131,7 @@ describe('StreamEdit', () => {
           const createDestinationSpy = vi.fn();
           const verifyDestinationSpy = vi.fn();
 
-          it("should enable Edit Stream button and perform proper calls when it's clicked", async () => {
+          it("should enable Save Changes button and perform proper calls when it's clicked", async () => {
             server.use(
               http.get('*/monitor/streams/destinations', () => {
                 return HttpResponse.json(makeResourcePage(mockDestinations));
@@ -191,7 +191,7 @@ describe('StreamEdit', () => {
           const editStreamSpy = vi.fn();
           const createDestinationSpy = vi.fn();
 
-          it("should enable Edit Stream button and perform proper calls when it's clicked", async () => {
+          it("should enable Save Changes button and perform proper calls when it's clicked", async () => {
             server.use(
               http.get('*/monitor/streams/destinations', () => {
                 return HttpResponse.json(makeResourcePage(mockDestinations));
@@ -226,7 +226,7 @@ describe('StreamEdit', () => {
               name: saveStreamButtonText,
             });
 
-            // Edit stream button should not be disabled with existing destination selected
+            // Save Changes button should not be disabled with existing destination selected
             expect(editStreamButton).toBeEnabled();
 
             // Test connection should be disabled when using existing destination
@@ -251,7 +251,7 @@ describe('StreamEdit', () => {
           describe.each(blockingStatuses)(
             'and stream has status: %status',
             (status) => {
-              it('should have disabled Edit Stream button and show info tooltip', async () => {
+              it('should have disabled Save Changes button and show info tooltip', async () => {
                 server.use(
                   http.get('*/monitor/streams/destinations', () => {
                     return HttpResponse.json(
@@ -276,7 +276,7 @@ describe('StreamEdit', () => {
                   name: saveStreamButtonText,
                 });
 
-                // Edit stream button should be disabled
+                // Save Changes button should be disabled
                 expect(editStreamButton).toBeDisabled();
 
                 // Edit stream
@@ -305,7 +305,7 @@ describe('StreamEdit', () => {
       describe('when form properly filled out and Test Connection button clicked and connection verified negatively', () => {
         const verifyDestinationSpy = vi.fn();
 
-        it('should not enable Edit Stream button', async () => {
+        it('should not enable Save Changes button', async () => {
           server.use(
             http.get('*/monitor/streams/destinations', () => {
               return HttpResponse.json(makeResourcePage(mockDestinations));

--- a/packages/manager/src/features/Delivery/Streams/StreamForm/StreamEdit.tsx
+++ b/packages/manager/src/features/Delivery/Streams/StreamForm/StreamEdit.tsx
@@ -8,18 +8,13 @@ import * as React from 'react';
 import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
-import { DocumentTitleSegment } from 'src/components/DocumentTitle';
-import {
-  LandingHeader,
-  type LandingHeaderProps,
-} from 'src/components/LandingHeader';
 import { StreamForm } from 'src/features/Delivery/Streams/StreamForm/StreamForm';
 
 import type { StreamAndDestinationFormType } from 'src/features/Delivery/Streams/StreamForm/types';
 
 export const StreamEdit = () => {
   const { streamId } = useParams({
-    from: '/logs/delivery/streams/$streamId/edit',
+    from: '/logs/delivery/streams/$streamId/summary',
   });
   const {
     data: destinations,
@@ -31,22 +26,6 @@ export const StreamEdit = () => {
     isLoading: isLoadingStream,
     error: errorStream,
   } = useStreamQuery(Number(streamId));
-
-  const landingHeaderProps: LandingHeaderProps = {
-    breadcrumbProps: {
-      pathname: '/logs/delivery/streams/edit',
-      crumbOverrides: [
-        {
-          label: 'Delivery',
-          linkTo: '/logs/delivery/streams',
-          position: 1,
-        },
-      ],
-    },
-    docsLink: 'https://techdocs.akamai.com/cloud-computing/docs/log-delivery',
-    removeCrumbX: [1, 2],
-    title: `Edit Stream ${streamId}`,
-  };
 
   const form = useForm<StreamAndDestinationFormType>({
     defaultValues: {
@@ -106,8 +85,6 @@ export const StreamEdit = () => {
 
   return (
     <>
-      <DocumentTitleSegment segment="Edit Stream" />
-      <LandingHeader {...landingHeaderProps} />
       {(isLoadingStream || isLoadingDestinations) && (
         <Box display="flex" justifyContent="center">
           <CircleProgress size="md" />

--- a/packages/manager/src/features/Delivery/Streams/StreamForm/StreamEdit.tsx
+++ b/packages/manager/src/features/Delivery/Streams/StreamForm/StreamEdit.tsx
@@ -21,11 +21,9 @@ export const StreamEdit = () => {
     isLoading: isLoadingDestinations,
     error: errorDestinations,
   } = useAllDestinationsQuery();
-  const {
-    data: stream,
-    isLoading: isLoadingStream,
-    error: errorStream,
-  } = useStreamQuery(Number(streamId));
+  const { data: stream, isLoading: isLoadingStream } = useStreamQuery(
+    Number(streamId)
+  );
 
   const form = useForm<StreamAndDestinationFormType>({
     defaultValues: {
@@ -90,26 +88,17 @@ export const StreamEdit = () => {
           <CircleProgress size="md" />
         </Box>
       )}
-      {errorStream && (
-        <ErrorState
-          compact
-          errorText="There was an error retrieving stream. Please reload and try again."
-        />
-      )}
       {errorDestinations && (
         <ErrorState
           compact
           errorText="There was an error retrieving destinations. Please reload and try again."
         />
       )}
-      {!isLoadingStream &&
-        !isLoadingDestinations &&
-        !errorStream &&
-        !errorDestinations && (
-          <FormProvider {...form}>
-            <StreamForm mode="edit" streamId={streamId} />
-          </FormProvider>
-        )}
+      {!isLoadingStream && !isLoadingDestinations && !errorDestinations && (
+        <FormProvider {...form}>
+          <StreamForm mode="edit" streamId={streamId} />
+        </FormProvider>
+      )}
     </>
   );
 };

--- a/packages/manager/src/features/Delivery/Streams/StreamForm/streamEditLazyRoute.ts
+++ b/packages/manager/src/features/Delivery/Streams/StreamForm/streamEditLazyRoute.ts
@@ -1,9 +1,0 @@
-import { createLazyRoute } from '@tanstack/react-router';
-
-import { StreamEdit } from 'src/features/Delivery/Streams/StreamForm/StreamEdit';
-
-export const streamEditLazyRoute = createLazyRoute(
-  '/logs/delivery/streams/$streamId/edit'
-)({
-  component: StreamEdit,
-});

--- a/packages/manager/src/features/Delivery/Streams/StreamTableRow.tsx
+++ b/packages/manager/src/features/Delivery/Streams/StreamTableRow.tsx
@@ -36,7 +36,7 @@ export const StreamTableRow = React.memo((props: StreamTableRowProps) => {
       <TableCell>
         <LinkWithTooltipAndEllipsis
           pendoId="Logs Delivery Streams-Name"
-          to={`/logs/delivery/streams/${id}/edit`}
+          to={`/logs/delivery/streams/${id}/summary`}
         >
           {stream.label}
         </LinkWithTooltipAndEllipsis>

--- a/packages/manager/src/features/Delivery/Streams/StreamsLanding.test.tsx
+++ b/packages/manager/src/features/Delivery/Streams/StreamsLanding.test.tsx
@@ -172,7 +172,7 @@ describe('Streams Landing Table', () => {
         await clickOnActionMenuItem('Edit');
 
         expect(mockNavigate).toHaveBeenCalledWith({
-          to: '/logs/delivery/streams/1/edit',
+          to: '/logs/delivery/streams/1/summary',
         });
       });
     });

--- a/packages/manager/src/features/Delivery/Streams/StreamsLanding.tsx
+++ b/packages/manager/src/features/Delivery/Streams/StreamsLanding.tsx
@@ -125,7 +125,7 @@ export const StreamsLanding = () => {
   }
 
   const handleEdit = ({ id }: Stream) => {
-    navigate({ to: `/logs/delivery/streams/${id}/edit` });
+    navigate({ to: `/logs/delivery/streams/${id}/summary` });
   };
 
   const openDeleteDialog = (stream: Stream) => {

--- a/packages/manager/src/features/Delivery/deliveryUtils.ts
+++ b/packages/manager/src/features/Delivery/deliveryUtils.ts
@@ -39,6 +39,7 @@ export const useIsACLPLogsEnabled = (): {
   isACLPLogsBeta: boolean;
   isACLPLogsCustomHttpsEnabled: boolean;
   isACLPLogsEnabled: boolean;
+  isACLPLogsMetricsEnabled: boolean;
   isACLPLogsNew: boolean;
 } => {
   const { data: account } = useAccount();
@@ -55,6 +56,7 @@ export const useIsACLPLogsEnabled = (): {
   return {
     isACLPLogsBeta: !!flags.aclpLogs?.beta,
     isACLPLogsCustomHttpsEnabled: !!flags.aclpLogs?.customHttpsEnabled,
+    isACLPLogsMetricsEnabled: !!flags.aclpLogs?.metricsEnabled,
     isACLPLogsNew: !!flags.aclpLogs?.new,
     isACLPLogsEnabled,
   };

--- a/packages/manager/src/routes/delivery/index.ts
+++ b/packages/manager/src/routes/delivery/index.ts
@@ -32,6 +32,12 @@ const streamsRoute = createRoute({
   getParentRoute: () => deliveryRoute,
   path: 'streams',
   validateSearch: (search: StreamSearchParams) => search,
+});
+
+const streamsLandingRoute = createRoute({
+  getParentRoute: () => streamsRoute,
+  path: '/',
+  validateSearch: (search: StreamSearchParams) => search,
 }).lazy(() =>
   import('src/features/Delivery/deliveryLandingLazyRoute').then(
     (m) => m.deliveryLandingLazyRoute
@@ -39,16 +45,16 @@ const streamsRoute = createRoute({
 );
 
 const streamsCreateRoute = createRoute({
-  getParentRoute: () => deliveryRoute,
-  path: 'streams/create',
+  getParentRoute: () => streamsRoute,
+  path: 'create',
 }).lazy(() =>
   import('src/features/Delivery/Streams/StreamForm/streamCreateLazyRoute').then(
     (m) => m.streamCreateLazyRoute
   )
 );
 
-const streamsEditRoute = createRoute({
-  getParentRoute: () => deliveryRoute,
+const streamRoute = createRoute({
+  getParentRoute: () => streamsRoute,
   params: {
     parse: ({ streamId }: { streamId: string }) => ({
       streamId: Number(streamId),
@@ -57,10 +63,40 @@ const streamsEditRoute = createRoute({
       streamId: String(streamId),
     }),
   },
-  path: 'streams/$streamId/edit',
+  path: '$streamId',
+});
+
+const streamLandingRoute = createRoute({
+  beforeLoad: ({ params }) => {
+    throw redirect({
+      to: '/logs/delivery/streams/$streamId/summary',
+      params: { streamId: params.streamId },
+      replace: true,
+    });
+  },
+  getParentRoute: () => streamRoute,
+  path: '/',
 }).lazy(() =>
-  import('src/features/Delivery/Streams/StreamForm/streamEditLazyRoute').then(
-    (m) => m.streamEditLazyRoute
+  import('src/features/Delivery/Streams/Stream/streamLandingLazyRoute').then(
+    (m) => m.streamLandingLazyRoute
+  )
+);
+
+const streamSummaryRoute = createRoute({
+  getParentRoute: () => streamRoute,
+  path: 'summary',
+}).lazy(() =>
+  import('src/features/Delivery/Streams/Stream/streamLandingLazyRoute').then(
+    (m) => m.streamLandingLazyRoute
+  )
+);
+
+const streamMetricsRoute = createRoute({
+  getParentRoute: () => streamRoute,
+  path: 'metrics',
+}).lazy(() =>
+  import('src/features/Delivery/Streams/Stream/streamLandingLazyRoute').then(
+    (m) => m.streamLandingLazyRoute
   )
 );
 
@@ -72,6 +108,12 @@ const destinationsRoute = createRoute({
   getParentRoute: () => deliveryRoute,
   path: 'destinations',
   validateSearch: (search: DestinationSearchParams) => search,
+});
+
+const destinationsLandingRoute = createRoute({
+  getParentRoute: () => destinationsRoute,
+  path: '/',
+  validateSearch: (search: DestinationSearchParams) => search,
 }).lazy(() =>
   import('src/features/Delivery/deliveryLandingLazyRoute').then(
     (m) => m.deliveryLandingLazyRoute
@@ -79,16 +121,16 @@ const destinationsRoute = createRoute({
 );
 
 const destinationsCreateRoute = createRoute({
-  getParentRoute: () => deliveryRoute,
-  path: 'destinations/create',
+  getParentRoute: () => destinationsRoute,
+  path: 'create',
 }).lazy(() =>
   import(
     'src/features/Delivery/Destinations/DestinationForm/destinationCreateLazyRoute'
   ).then((m) => m.destinationCreateLazyRoute)
 );
 
-const destinationsEditRoute = createRoute({
-  getParentRoute: () => deliveryRoute,
+const destinationRoute = createRoute({
+  getParentRoute: () => destinationsRoute,
   params: {
     parse: ({ destinationId }: { destinationId: string }) => ({
       destinationId: Number(destinationId),
@@ -97,7 +139,28 @@ const destinationsEditRoute = createRoute({
       destinationId: String(destinationId),
     }),
   },
-  path: 'destinations/$destinationId/edit',
+  path: '$destinationId',
+});
+
+const destinationLandingRoute = createRoute({
+  beforeLoad: ({ params }) => {
+    throw redirect({
+      to: '/logs/delivery/destinations/$destinationId/summary',
+      params: { destinationId: params.destinationId },
+      replace: true,
+    });
+  },
+  getParentRoute: () => destinationRoute,
+  path: '/',
+}).lazy(() =>
+  import(
+    'src/features/Delivery/Destinations/DestinationForm/destinationEditLazyRoute'
+  ).then((m) => m.destinationEditLazyRoute)
+);
+
+const destinationSummaryRoute = createRoute({
+  getParentRoute: () => destinationRoute,
+  path: 'summary',
 }).lazy(() =>
   import(
     'src/features/Delivery/Destinations/DestinationForm/destinationEditLazyRoute'
@@ -106,9 +169,21 @@ const destinationsEditRoute = createRoute({
 
 export const deliveryRouteTree = deliveryRoute.addChildren([
   deliveryLandingRoute,
-  streamsRoute.addChildren([streamsCreateRoute, streamsEditRoute]),
+  streamsRoute.addChildren([
+    streamsLandingRoute,
+    streamsCreateRoute,
+    streamRoute.addChildren([
+      streamLandingRoute,
+      streamSummaryRoute,
+      streamMetricsRoute,
+    ]),
+  ]),
   destinationsRoute.addChildren([
+    destinationsLandingRoute,
     destinationsCreateRoute,
-    destinationsEditRoute,
+    destinationRoute.addChildren([
+      destinationLandingRoute,
+      destinationSummaryRoute,
+    ]),
   ]),
 ]);

--- a/packages/manager/src/routes/delivery/index.ts
+++ b/packages/manager/src/routes/delivery/index.ts
@@ -92,6 +92,15 @@ const streamSummaryRoute = createRoute({
 );
 
 const streamMetricsRoute = createRoute({
+  beforeLoad: ({ params, context }) => {
+    if (!context?.flags?.aclpLogs?.metricsEnabled) {
+      throw redirect({
+        to: '/logs/delivery/streams/$streamId/summary',
+        params: { streamId: params.streamId },
+        replace: true,
+      });
+    }
+  },
   getParentRoute: () => streamRoute,
   path: 'metrics',
 }).lazy(() =>

--- a/packages/manager/src/routes/delivery/index.ts
+++ b/packages/manager/src/routes/delivery/index.ts
@@ -22,11 +22,7 @@ const deliveryLandingRoute = createRoute({
   },
   getParentRoute: () => deliveryRoute,
   path: '/',
-}).lazy(() =>
-  import('src/features/Delivery/deliveryLandingLazyRoute').then(
-    (m) => m.deliveryLandingLazyRoute
-  )
-);
+});
 
 const streamsRoute = createRoute({
   getParentRoute: () => deliveryRoute,
@@ -76,11 +72,7 @@ const streamLandingRoute = createRoute({
   },
   getParentRoute: () => streamRoute,
   path: '/',
-}).lazy(() =>
-  import('src/features/Delivery/Streams/Stream/streamLandingLazyRoute').then(
-    (m) => m.streamLandingLazyRoute
-  )
-);
+});
 
 const streamSummaryRoute = createRoute({
   getParentRoute: () => streamRoute,
@@ -161,11 +153,7 @@ const destinationLandingRoute = createRoute({
   },
   getParentRoute: () => destinationRoute,
   path: '/',
-}).lazy(() =>
-  import(
-    'src/features/Delivery/Destinations/DestinationForm/destinationEditLazyRoute'
-  ).then((m) => m.destinationEditLazyRoute)
-);
+});
 
 const destinationSummaryRoute = createRoute({
   getParentRoute: () => destinationRoute,

--- a/packages/manager/src/store/selectors/getSearchEntities.ts
+++ b/packages/manager/src/store/selectors/getSearchEntities.ts
@@ -213,7 +213,7 @@ export const stackscriptToSearchableItem = (
 export const streamToSearchableItem = (stream: Stream): SearchableItem => ({
   data: {
     description: getStreamDescription(stream),
-    path: `/logs/delivery/streams/${stream.id}/edit`,
+    path: `/logs/delivery/streams/${stream.id}/summary`,
     status: stream.status,
     created: stream.created,
   },
@@ -227,7 +227,7 @@ export const destinationToSearchableItem = (
 ): SearchableItem => ({
   data: {
     description: getDestinationDescription(destination),
-    path: `/logs/delivery/destinations/${destination.id}/edit`,
+    path: `/logs/delivery/destinations/${destination.id}/summary`,
     created: destination.created,
   },
   entityType: 'destination',


### PR DESCRIPTION
## Description 📝

New Metrics tab under Stream view.

## Changes  🔄

- Added new flag `aclpLogs.metricsEnabled`
- Stream view is now divided into 2 tabs: Summary (prev. Edit) and Metrics (hidden behind `aclpLogs.metricsEnabled` flag)
- Embedded Metrics component inside Stream Metrics tab
- Routing for `streams/$id/edit` changed to `streams/$id/summary`
- Routing for `destinations/$id/edit` changed to `destinations/$id/summary`
- Routing for `streams/$id` redirects  to `streams/$id/summary`
- Routing for `destinations/$id` redirects to `destinations/$id/summary`
- New routing `streams/$id/metrics` to stream metrics tab (hidden behind `aclpLogs.metricsEnabled` flag)

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [x] Some customers (e.g. in Beta or Limited Availability)

## Target release date 🗓️

April 2026

## Preview 📷

| Before  | After   |
| ------- | ------- |
|![Screenshot 2026-03-13 at 11 35 23](https://github.com/user-attachments/assets/d822fabf-083f-4523-94f7-270288fb7c36)|![Screenshot 2026-03-12 at 12 40 40](https://github.com/user-attachments/assets/3654905a-8db0-492b-9eac-0e2da63aba6f)|
||![Screenshot 2026-03-13 at 08 30 10](https://github.com/user-attachments/assets/8fee7e2a-5850-442b-bef0-ca0efe72ebc3)|

## How to test 🧪

### Prerequisites

Run manager with devcloud env.
Enable flag: `aclpLogs.metricsEnabled` (`true` value)

### Verification steps

Navigate to some stream. See new view with 2 tabs. Dashboard loading in Metrics tab.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🚩 Using a feature flag to protect the release
🧪 Providing/improving test coverage
📱 Providing mobile support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

-->