### PR TITLE
upcoming: [UIE-9487] VPC UI not displaying DBaaS resources

### DIFF
--- a/packages/api-v4/.changeset/pr-13504-added-1775602581034.md
+++ b/packages/api-v4/.changeset/pr-13504-added-1775602581034.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Added
+---
+
+SubnetAssignedDatabaseData interface and update to Subnet to include databases property ([#13504](https://github.com/linode/manager/pull/13504))

--- a/packages/api-v4/src/vpcs/types.ts
+++ b/packages/api-v4/src/vpcs/types.ts
@@ -42,6 +42,7 @@ export interface CreateSubnetPayload {
 
 export interface Subnet extends CreateSubnetPayload {
   created: string;
+  databases: SubnetAssignedDatabaseData[];
   id: number;
   linodes: SubnetAssignedLinodeData[];
   nodebalancers: SubnetAssignedNodeBalancerData[];
@@ -66,6 +67,12 @@ export interface SubnetAssignedLinodeData {
 export interface SubnetAssignedNodeBalancerData {
   id: number;
   ipv4_range: string;
+}
+
+export interface SubnetAssignedDatabaseData {
+  id: number;
+  ipv4_range: string;
+  ipv6_ranges: null | { range: string }[];
 }
 
 export interface VPCIP {

--- a/packages/manager/.changeset/pr-13504-fixed-1775602514569.md
+++ b/packages/manager/.changeset/pr-13504-fixed-1775602514569.md
@@ -1,0 +1,5 @@
+---
+'@linode/manager': Fixed
+---
+
+DBaaS resource counts and databases resource table in VPC UI ([#13504](https://github.com/linode/manager/pull/13504))

--- a/packages/manager/.changeset/pr-13504-upcoming-features-1775679549160.md
+++ b/packages/manager/.changeset/pr-13504-upcoming-features-1775679549160.md
@@ -1,5 +1,5 @@
 ---
-'@linode/manager': Fixed
+"@linode/manager": Upcoming Features
 ---
 
 DBaaS resource counts and databases resource table in VPC UI ([#13504](https://github.com/linode/manager/pull/13504))

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -94,6 +94,7 @@ const options: { flag: keyof Flags; label: string }[] = [
     label: 'Object Storage Contextual Metrics',
   },
   { flag: 'objSummaryPage', label: 'OBJ Summary Page' },
+  { flag: 'vpcDbaasResources', label: 'VPC DBaaS Resources' },
   { flag: 'vpcIpv6', label: 'VPC IPv6' },
   { flag: 'reserveIp', label: 'Reserve IP' },
   { flag: 'marketplaceV2GlobalBanner', label: 'Marketplace V2 Global Banner' },

--- a/packages/manager/src/factories/databases.ts
+++ b/packages/manager/src/factories/databases.ts
@@ -199,6 +199,8 @@ export const databaseInstanceFactory =
     label: Factory.each((i) => `example.com-database-${i}`),
     members: {
       '2.2.2.2': 'primary',
+      '2.2.2.3': 'failover',
+      '2.2.2.4': 'failover',
     },
     platform: 'rdbms-default',
     region: Factory.each((i) => possibleRegions[i % possibleRegions.length]),
@@ -268,6 +270,8 @@ export const databaseFactory = Factory.Sync.makeFactory<Database>({
   label: Factory.each((i) => `database-${i}`),
   members: {
     '2.2.2.2': 'primary',
+    '2.2.2.3': 'failover',
+    '2.2.2.4': 'failover',
   },
   oldest_restore_time: '2024-09-15T17:15:12',
   platform: 'rdbms-default',

--- a/packages/manager/src/factories/subnets.ts
+++ b/packages/manager/src/factories/subnets.ts
@@ -2,6 +2,7 @@ import { Factory } from '@linode/utilities';
 
 import type {
   Subnet,
+  SubnetAssignedDatabaseData,
   SubnetAssignedLinodeData,
   SubnetAssignedNodeBalancerData,
 } from '@linode/api-v4/lib/vpcs/types';
@@ -27,6 +28,23 @@ export const subnetAssignedNodebalancerDataFactory =
     ipv4_range: Factory.each((i) => `192.168.${i}.0/30`),
   });
 
+export const subnetAssignedDatabaseDataFactory =
+  Factory.Sync.makeFactory<SubnetAssignedDatabaseData>({
+    id: Factory.each((i) => i),
+    ipv4_range: Factory.each((i) => `192.168.${i}.0/30`),
+    ipv6_ranges: Factory.each((i) => [
+      {
+        range: `2600:3c11:e41c:${i}::/64`,
+      },
+      {
+        range: `2600:3c11:e41c:${i}::/64`,
+      },
+      {
+        range: `2600:3c11:e41c:${i}::/64`,
+      },
+    ]),
+  });
+
 export const subnetFactory = Factory.Sync.makeFactory<Subnet>({
   created: '2023-07-12T16:08:53',
   id: Factory.each((i) => i),
@@ -42,6 +60,13 @@ export const subnetFactory = Factory.Sync.makeFactory<Subnet>({
   nodebalancers: Factory.each((i) =>
     Array.from({ length: 3 }, (_, arrIdx) =>
       subnetAssignedNodebalancerDataFactory.build({
+        id: i * 10 + arrIdx,
+      })
+    )
+  ),
+  databases: Factory.each((i) =>
+    Array.from({ length: 3 }, (_, arrIdx) =>
+      subnetAssignedDatabaseDataFactory.build({
         id: i * 10 + arrIdx,
       })
     )

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -294,6 +294,7 @@ export interface Flags {
   udp: boolean;
   vmHostMaintenance: VMHostMaintenanceFlag;
   volumeSummaryPage: boolean;
+  vpcDbaasResources: boolean;
   vpcIpv6: boolean;
 }
 

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
@@ -68,7 +68,8 @@ export const DatabaseLanding = () => {
       page_size: newDatabasesPagination.pageSize,
     },
     databasesFilter,
-    isDefaultEnabled // TODO (UIE-8634): Determine if check if still necessary
+    isDefaultEnabled, // TODO (UIE-8634): Determine if check if still necessary
+    20000
   );
 
   if (databasesError) {

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
@@ -68,7 +68,7 @@ export const DatabaseLanding = () => {
       page_size: newDatabasesPagination.pageSize,
     },
     databasesFilter,
-    isDefaultEnabled, // TODO (UIE-8634): Determine if check if still necessary
+    isDefaultEnabled, // TODO (UIE-8634): Determine if check is still necessary
     20000
   );
 

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseRow.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseRow.tsx
@@ -12,7 +12,10 @@ import { Link } from 'src/components/Link';
 import { DatabaseStatusDisplay } from 'src/features/Databases/DatabaseDetail/DatabaseStatusDisplay';
 import { DatabaseEngineVersion } from 'src/features/Databases/DatabaseEngineVersion';
 import { DatabaseActionMenu } from 'src/features/Databases/DatabaseLanding/DatabaseActionMenu';
-import { useIsDatabasesEnabled } from 'src/features/Databases/utilities';
+import {
+  getIsLinkInactive,
+  useIsDatabasesEnabled,
+} from 'src/features/Databases/utilities';
 import { isWithinDays, parseAPIDate } from 'src/utilities/date';
 import { formatDate } from 'src/utilities/formatDate';
 
@@ -64,11 +67,6 @@ export const DatabaseRow = ({
   const plan = types?.find((t: DatabaseType) => t.id === type);
   const formattedPlan = plan && formatStorageUnits(plan.label);
   const actualRegion = regions?.find((r) => r.id === region);
-  const isLinkInactive =
-    status === 'suspended' ||
-    status === 'suspending' ||
-    status === 'resuming' ||
-    status === 'migrated';
   const { isDatabasesV2GA } = useIsDatabasesEnabled();
 
   const configuration =
@@ -97,7 +95,7 @@ export const DatabaseRow = ({
           flex: '0 1 20.5%',
         }}
       >
-        {isDatabasesV2GA && isLinkInactive ? (
+        {isDatabasesV2GA && getIsLinkInactive(status) ? (
           label
         ) : (
           <Link to={`/databases/${engine}/${id}`}>{label}</Link>

--- a/packages/manager/src/features/Databases/utilities.ts
+++ b/packages/manager/src/features/Databases/utilities.ts
@@ -9,6 +9,7 @@ import type {
   DatabaseEngine,
   DatabaseFork,
   DatabaseInstance,
+  DatabaseStatus,
   Engine,
   PendingUpdates,
 } from '@linode/api-v4';
@@ -256,3 +257,9 @@ export const convertPrivateToPublicHostname = (host: string) => {
   const baseHostName = host.slice(privateStrIndex + 1);
   return `public-${baseHostName}`;
 };
+
+export const getIsLinkInactive = (status: DatabaseStatus) =>
+  status === 'suspended' ||
+  status === 'suspending' ||
+  status === 'resuming' ||
+  status === 'migrated';

--- a/packages/manager/src/features/Databases/utilities.ts
+++ b/packages/manager/src/features/Databases/utilities.ts
@@ -259,7 +259,4 @@ export const convertPrivateToPublicHostname = (host: string) => {
 };
 
 export const getIsLinkInactive = (status: DatabaseStatus) =>
-  status === 'suspended' ||
-  status === 'suspending' ||
-  status === 'resuming' ||
-  status === 'migrated';
+  ['migrated', 'resuming', 'suspended', 'suspending'].includes(status);

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetAssignLinodesDrawer.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetAssignLinodesDrawer.test.tsx
@@ -52,6 +52,7 @@ const props = {
     label: 'subnet-1',
     linodes: [],
     nodebalancers: [],
+    databases: [],
     created: '',
     updated: '',
   } as Subnet,

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetDatabaseRow.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetDatabaseRow.test.tsx
@@ -29,10 +29,10 @@ describe('SubnetDatabaseRow', () => {
   });
 
   it('should render SubnetDatabaseRow', () => {
-    const dbWithPrimary = {
+    const dbWithPrimary: DatabaseInstance = {
       ...mockDatabase,
       members: { '2.2.2.2': 'primary' },
-    } as DatabaseInstance;
+    };
 
     const { getByText } = renderWithTheme(
       wrapWithTableBody(
@@ -49,14 +49,14 @@ describe('SubnetDatabaseRow', () => {
   });
 
   it('should render SubnetDatabaseRow with multiple failover IPs', () => {
-    const dbWithFailovers = {
+    const dbWithFailovers: DatabaseInstance = {
       ...mockDatabase,
       members: {
         '2.2.2.2': 'primary',
         '2.2.2.3': 'failover',
         '2.2.2.4': 'failover',
       },
-    } as DatabaseInstance;
+    };
 
     const { getByText } = renderWithTheme(
       wrapWithTableBody(
@@ -76,7 +76,7 @@ describe('SubnetDatabaseRow', () => {
     const dbWithNoMembers = {
       ...mockDatabase,
       members: {},
-    } as DatabaseInstance;
+    };
 
     const { getByText } = renderWithTheme(
       wrapWithTableBody(

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetDatabaseRow.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetDatabaseRow.test.tsx
@@ -1,0 +1,132 @@
+import * as React from 'react';
+
+import {
+  databaseInstanceFactory,
+  subnetAssignedDatabaseDataFactory,
+} from 'src/factories';
+import { renderWithTheme, wrapWithTableBody } from 'src/utilities/testHelpers';
+
+import { SubnetDatabaseRow } from './SubnetDatabaseRow';
+
+import type { DatabaseInstance } from '@linode/api-v4';
+
+const mockIpv6Range = '0000:db1::/32';
+const databaseLabel = 'test-database-1';
+const mockDatabase = databaseInstanceFactory.build({
+  id: 1,
+  label: databaseLabel,
+});
+
+const mockAssignedDatabase = subnetAssignedDatabaseDataFactory.build({
+  id: 1,
+  ipv4_range: '1.1.1.1/32',
+  ipv6_ranges: [{ range: mockIpv6Range }],
+});
+
+describe('SubnetDatabaseRow', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should render SubnetDatabaseRow', () => {
+    const dbWithPrimary = {
+      ...mockDatabase,
+      members: { '2.2.2.2': 'primary' },
+    } as DatabaseInstance;
+
+    const { getByText } = renderWithTheme(
+      wrapWithTableBody(
+        <SubnetDatabaseRow
+          assignedDatabase={mockAssignedDatabase}
+          database={dbWithPrimary}
+        />
+      )
+    );
+    getByText(databaseLabel);
+    getByText(mockAssignedDatabase.ipv4_range);
+    getByText(mockIpv6Range);
+    getByText('2.2.2.2');
+  });
+
+  it('should render SubnetDatabaseRow with multiple failover IPs', () => {
+    const dbWithFailovers = {
+      ...mockDatabase,
+      members: {
+        '2.2.2.2': 'primary',
+        '2.2.2.3': 'failover',
+        '2.2.2.4': 'failover',
+      },
+    } as DatabaseInstance;
+
+    const { getByText } = renderWithTheme(
+      wrapWithTableBody(
+        <SubnetDatabaseRow
+          assignedDatabase={mockAssignedDatabase}
+          database={dbWithFailovers}
+        />
+      )
+    );
+    getByText(databaseLabel);
+    getByText(mockAssignedDatabase.ipv4_range);
+    getByText(mockIpv6Range);
+    getByText('2.2.2.2, 2.2.2.3, 2.2.2.4');
+  });
+
+  it('should render SubnetDatabaseRow with no members', () => {
+    const dbWithNoMembers = {
+      ...mockDatabase,
+      members: {},
+    } as DatabaseInstance;
+
+    const { getByText } = renderWithTheme(
+      wrapWithTableBody(
+        <SubnetDatabaseRow
+          assignedDatabase={mockAssignedDatabase}
+          database={dbWithNoMembers}
+        />
+      )
+    );
+    getByText(databaseLabel);
+    getByText(mockAssignedDatabase.ipv4_range);
+    getByText(mockIpv6Range);
+    getByText('—');
+  });
+
+  it('should render SubnetDatabaseRow with no ipv6 ranges', () => {
+    const assignedDatabaseWithNoIpv6 = {
+      ...mockAssignedDatabase,
+      ipv6_ranges: null,
+    };
+
+    const { getByText } = renderWithTheme(
+      wrapWithTableBody(
+        <SubnetDatabaseRow
+          assignedDatabase={assignedDatabaseWithNoIpv6}
+          database={mockDatabase}
+        />
+      )
+    );
+    getByText(databaseLabel);
+    getByText(mockAssignedDatabase.ipv4_range);
+    getByText('—');
+  });
+
+  it('should render SubnetDatabaseRow with HA cluster', () => {
+    const haDatabase = databaseInstanceFactory.build({
+      id: 1,
+      label: databaseLabel,
+      cluster_size: 3,
+    });
+
+    const { getByText } = renderWithTheme(
+      wrapWithTableBody(
+        <SubnetDatabaseRow
+          assignedDatabase={mockAssignedDatabase}
+          database={haDatabase}
+        />
+      )
+    );
+    getByText(databaseLabel);
+    getByText('HA');
+  });
+});

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetDatabaseRow.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetDatabaseRow.tsx
@@ -1,0 +1,99 @@
+import { Box, Chip } from '@linode/ui';
+import * as React from 'react';
+
+import { Link } from 'src/components/Link';
+import { TableCell } from 'src/components/TableCell';
+import { TableRow } from 'src/components/TableRow';
+import { getIsLinkInactive } from 'src/features/Databases/utilities';
+import { determineNoneSingleOrMultipleWithChip } from 'src/utilities/noneSingleOrMultipleWithChip';
+
+import type {
+  DatabaseInstance,
+  SubnetAssignedDatabaseData,
+} from '@linode/api-v4';
+
+interface Props {
+  assignedDatabase: SubnetAssignedDatabaseData;
+  database: DatabaseInstance;
+}
+
+export const SubnetDatabaseRow = ({ assignedDatabase, database }: Props) => {
+  const ipv6Ranges =
+    assignedDatabase?.ipv6_ranges
+      ?.map((rangeObj) => rangeObj.range)
+      .filter((range) => range !== undefined) ?? [];
+
+  const noneSingleOrMultipleWithChipIPV6 =
+    determineNoneSingleOrMultipleWithChip(ipv6Ranges);
+  const ipv6RangeContent = assignedDatabase?.ipv6_ranges
+    ? noneSingleOrMultipleWithChipIPV6
+    : '—';
+
+  // For IPv4 addresses column, we display the primary and failover IPs for the database instance.
+  const getIPv4AddressesContent = () => {
+    const memberKeys = Object.keys(database.members);
+
+    if (memberKeys.length === 0) {
+      return '—';
+    }
+
+    const primaryIPv4 = memberKeys.find(
+      (key) => database.members[key] === 'primary'
+    );
+    // Retrieve failover IPv4 addresses as there can be multiple
+    const failoverIPv4s = memberKeys.filter(
+      (key) => database.members[key] === 'failover'
+    );
+
+    if (failoverIPv4s.length === 0) {
+      return primaryIPv4;
+    }
+
+    return [primaryIPv4, ...failoverIPv4s].join(', ');
+  };
+
+  return (
+    <TableRow>
+      <TableCell>
+        <Box
+          sx={(theme) => ({
+            display: 'flex',
+            alignItems: 'center',
+            gap: theme.spacingFunction(8),
+          })}
+        >
+          {getIsLinkInactive(database.status) ? (
+            database?.label
+          ) : (
+            <Link
+              className="secondaryLink"
+              to={`/databases/${database?.engine}/${database?.id}/summary`}
+            >
+              {database?.label}
+            </Link>
+          )}
+          {database.cluster_size > 1 && (
+            <Chip
+              label="HA"
+              size="small"
+              sx={(theme) => ({ borderColor: theme.color.green, mx: 0, my: 0 })}
+              variant="outlined"
+            />
+          )}
+        </Box>
+      </TableCell>
+      <TableCell>{getIPv4AddressesContent()}</TableCell>
+      <TableCell noWrap>{assignedDatabase?.ipv4_range}</TableCell>
+      <TableCell noWrap>{ipv6RangeContent}</TableCell>
+    </TableRow>
+  );
+};
+
+export const SubnetDatabasesTableRowHead = (
+  <TableRow>
+    <TableCell sx={{ width: '20%' }}>Database Cluster</TableCell>
+    <TableCell>IPv4 Address(s)</TableCell>
+    <TableCell>VPC IPv4 Range</TableCell>
+    <TableCell>VPC IPv6 Range</TableCell>
+  </TableRow>
+);

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetDatabaseRow.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetDatabaseRow.tsx
@@ -90,7 +90,7 @@ export const SubnetDatabaseRow = ({ assignedDatabase, database }: Props) => {
 export const SubnetDatabasesTableRowHead = (
   <TableRow>
     <TableCell sx={{ width: '20%' }}>Database Cluster</TableCell>
-    <TableCell>IPv4 Address(s)</TableCell>
+    <TableCell>IPv4 Address(es)</TableCell>
     <TableCell>VPC IPv4 Range</TableCell>
     <TableCell>VPC IPv6 Range</TableCell>
   </TableRow>

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetDatabaseRow.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetDatabaseRow.tsx
@@ -23,10 +23,8 @@ export const SubnetDatabaseRow = ({ assignedDatabase, database }: Props) => {
       ?.map((rangeObj) => rangeObj.range)
       .filter((range) => range !== undefined) ?? [];
 
-  const noneSingleOrMultipleWithChipIPV6 =
-    determineNoneSingleOrMultipleWithChip(ipv6Ranges);
   const ipv6RangeContent = assignedDatabase?.ipv6_ranges
-    ? noneSingleOrMultipleWithChipIPV6
+    ? determineNoneSingleOrMultipleWithChip(ipv6Ranges)
     : '—';
 
   // For IPv4 addresses column, we display the primary and failover IPs for the database instance.
@@ -36,18 +34,18 @@ export const SubnetDatabaseRow = ({ assignedDatabase, database }: Props) => {
     if (memberKeys.length === 0) {
       return '—';
     }
+    // If there's only one key in members, it only contains the primary IPv4 which should be returned.
+    if (memberKeys.length === 1) {
+      return memberKeys[0];
+    }
 
+    // Retrieve primary and failover IPv4 addresses since there can be up to 2 failover IPv4 addresses for multi-node HA clusters.
     const primaryIPv4 = memberKeys.find(
       (key) => database.members[key] === 'primary'
     );
-    // Retrieve failover IPv4 addresses as there can be multiple
     const failoverIPv4s = memberKeys.filter(
       (key) => database.members[key] === 'failover'
     );
-
-    if (failoverIPv4s.length === 0) {
-      return primaryIPv4;
-    }
 
     return [primaryIPv4, ...failoverIPv4s].join(', ');
   };

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetDatabasesTable.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetDatabasesTable.test.tsx
@@ -15,7 +15,9 @@ const queryMocks = vi.hoisted(() => ({
   }),
 }));
 
-const mockDatabasesData = [subnetAssignedDatabaseDataFactory.build({ id: 1 })];
+const mockSubnetDatabasesData = [
+  subnetAssignedDatabaseDataFactory.build({ id: 1 }),
+];
 
 vi.mock('@linode/queries', async () => {
   const actual = await vi.importActual('@linode/queries');
@@ -39,7 +41,7 @@ describe('SubnetDatabasesTable', () => {
       error: null,
     });
     const { getByText } = renderWithTheme(
-      <SubnetDatabasesTable databasesData={mockDatabasesData} />
+      <SubnetDatabasesTable subnetDatabasesData={mockSubnetDatabasesData} />
     );
     getByText('test-database-1');
     getByText('Database Cluster');
@@ -53,7 +55,7 @@ describe('SubnetDatabasesTable', () => {
     });
 
     const { getByTestId } = renderWithTheme(
-      <SubnetDatabasesTable databasesData={mockDatabasesData} />
+      <SubnetDatabasesTable subnetDatabasesData={mockSubnetDatabasesData} />
     );
     getByTestId('circle-progress');
   });
@@ -66,7 +68,7 @@ describe('SubnetDatabasesTable', () => {
     });
 
     const { getByTestId } = renderWithTheme(
-      <SubnetDatabasesTable databasesData={mockDatabasesData} />
+      <SubnetDatabasesTable subnetDatabasesData={mockSubnetDatabasesData} />
     );
     getByTestId('table-row-empty');
   });
@@ -80,7 +82,7 @@ describe('SubnetDatabasesTable', () => {
     });
 
     const { getByText } = renderWithTheme(
-      <SubnetDatabasesTable databasesData={mockDatabasesData} />
+      <SubnetDatabasesTable subnetDatabasesData={mockSubnetDatabasesData} />
     );
     getByText(expectedErrorMessage);
   });

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetDatabasesTable.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetDatabasesTable.test.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+
+import {
+  databaseInstanceFactory,
+  subnetAssignedDatabaseDataFactory,
+} from 'src/factories';
+import { makeResourcePage } from 'src/mocks/serverHandlers';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { SubnetDatabasesTable } from './SubnetDatabasesTable';
+
+const queryMocks = vi.hoisted(() => ({
+  useDatabasesQuery: vi.fn().mockReturnValue({
+    data: [],
+  }),
+}));
+
+const mockDatabasesData = [subnetAssignedDatabaseDataFactory.build({ id: 1 })];
+
+vi.mock('@linode/queries', async () => {
+  const actual = await vi.importActual('@linode/queries');
+  return {
+    ...actual,
+    useDatabasesQuery: queryMocks.useDatabasesQuery,
+  };
+});
+
+describe('SubnetDatabasesTable', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should render table for SubnetDatabasesTable when there are assigned databases', async () => {
+    queryMocks.useDatabasesQuery.mockReturnValue({
+      data: makeResourcePage([
+        databaseInstanceFactory.build({ id: 1, label: 'test-database-1' }),
+      ]),
+      isLoading: false,
+      error: null,
+    });
+    const { getByText } = renderWithTheme(
+      <SubnetDatabasesTable databasesData={mockDatabasesData} />
+    );
+    getByText('test-database-1');
+    getByText('Database Cluster');
+  });
+
+  it('should render loading state for SubnetDatabasesTable', async () => {
+    queryMocks.useDatabasesQuery.mockReturnValue({
+      data: makeResourcePage([]),
+      isLoading: true,
+      error: null,
+    });
+
+    const { getByTestId } = renderWithTheme(
+      <SubnetDatabasesTable databasesData={mockDatabasesData} />
+    );
+    getByTestId('circle-progress');
+  });
+
+  it('should render empty state for SubnetDatabasesTable when no databases are returned', async () => {
+    queryMocks.useDatabasesQuery.mockReturnValue({
+      data: makeResourcePage([]),
+      isLoading: false,
+      error: null,
+    });
+
+    const { getByTestId } = renderWithTheme(
+      <SubnetDatabasesTable databasesData={mockDatabasesData} />
+    );
+    getByTestId('table-row-empty');
+  });
+
+  it('should render error state for SubnetDatabasesTable', async () => {
+    const expectedErrorMessage = 'Failed to fetch databases';
+    queryMocks.useDatabasesQuery.mockReturnValue({
+      data: makeResourcePage([]),
+      isLoading: false,
+      error: [{ reason: expectedErrorMessage }],
+    });
+
+    const { getByText } = renderWithTheme(
+      <SubnetDatabasesTable databasesData={mockDatabasesData} />
+    );
+    getByText(expectedErrorMessage);
+  });
+});

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetDatabasesTable.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetDatabasesTable.tsx
@@ -67,30 +67,16 @@ export const SubnetDatabasesTable = ({ databasesData }: Props) => {
   }: {
     children: React.ReactNode;
   }) => (
-    <>
-      <Table aria-label="Databases" size="small" striped={false}>
-        <TableHead
-          style={{
-            color: theme.tokens.color.Neutrals.White,
-          }}
-        >
-          {SubnetDatabasesTableRowHead}
-        </TableHead>
-        <TableBody>{children}</TableBody>
-      </Table>
-      <PaginationFooter
-        count={databases?.results ?? 0}
-        handlePageChange={(page: number) => setPage(page)}
-        handleSizeChange={(pageSize: number) => setPageSize(pageSize)}
-        page={page}
-        pageSize={pageSize}
-        sx={{
-          border: 'none',
-          borderBottom: `1px solid ${theme.tokens.component.Table.Row.Border}`,
-          borderTop: `1px solid ${theme.tokens.component.Table.Row.Border}`,
+    <Table aria-label="Databases" size="small" striped={false}>
+      <TableHead
+        style={{
+          color: theme.tokens.color.Neutrals.White,
         }}
-      />
-    </>
+      >
+        {SubnetDatabasesTableRowHead}
+      </TableHead>
+      <TableBody>{children}</TableBody>
+    </Table>
   );
 
   const LoadingState = () => (
@@ -150,5 +136,21 @@ export const SubnetDatabasesTable = ({ databasesData }: Props) => {
       />
     ));
 
-  return <DatabasesTableWrapper>{databaseRows()}</DatabasesTableWrapper>;
+  return (
+    <>
+      <DatabasesTableWrapper>{databaseRows()}</DatabasesTableWrapper>
+      <PaginationFooter
+        count={databases?.results ?? 0}
+        handlePageChange={(page: number) => setPage(page)}
+        handleSizeChange={(pageSize: number) => setPageSize(pageSize)}
+        page={page}
+        pageSize={pageSize}
+        sx={{
+          border: 'none',
+          borderBottom: `1px solid ${theme.tokens.component.Table.Row.Border}`,
+          borderTop: `1px solid ${theme.tokens.component.Table.Row.Border}`,
+        }}
+      />
+    </>
+  );
 };

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetDatabasesTable.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetDatabasesTable.tsx
@@ -29,24 +29,13 @@ export const SubnetDatabasesTable = ({ databasesData }: Props) => {
   const [pageSize, setPageSize] = React.useState(25);
   const [page, setPage] = React.useState(1);
 
-  const assignedDatabasesMap = React.useMemo(() => {
-    const databaseMap: Record<number, SubnetAssignedDatabaseData> = {};
-    databasesData.forEach((assignedDatabase) => {
-      databaseMap[assignedDatabase.id] = assignedDatabase;
-    });
-    return databaseMap;
-  }, [databasesData]);
-
-  // Create filter using unique database IDs from the assigned databases
-  const makeDatabaseIDsFilter = React.useMemo(() => {
-    const uniqueIds = Object.values(assignedDatabasesMap).map((db) => {
-      return { id: db.id };
-    });
-
+  const assignedDatabasesMap: Record<number, SubnetAssignedDatabaseData> = {}; // Store assigned databases in map for easy lookup when rendering subnet database rows
+  const databaseIDsToFilter = databasesData.map((database) => {
+    assignedDatabasesMap[database.id] = database;
     return {
-      '+or': uniqueIds,
+      id: database.id,
     };
-  }, [assignedDatabasesMap]);
+  });
 
   const {
     data: databases,
@@ -57,9 +46,10 @@ export const SubnetDatabasesTable = ({ databasesData }: Props) => {
       page_size: pageSize,
       page,
     },
-    makeDatabaseIDsFilter,
-    true,
-    false
+    {
+      '+or': databaseIDsToFilter,
+    },
+    true
   );
 
   const DatabasesTableWrapper = ({
@@ -79,34 +69,14 @@ export const SubnetDatabasesTable = ({ databasesData }: Props) => {
     </Table>
   );
 
-  const LoadingState = () => (
-    <TableRow>
-      <TableCell colSpan={4} style={{ textAlign: 'center' }}>
-        <CircleProgress size="sm" />
-      </TableCell>
-    </TableRow>
-  );
-
-  const TableErrorState = () => (
-    <TableRowError
-      colSpan={4}
-      message={
-        getAPIErrorOrDefault(
-          databasesError ?? [],
-          'There was a problem retrieving your databases. Refresh the page or try again later.'
-        )[0].reason
-      }
-    />
-  );
-
-  const EmptyState = () => (
-    <TableRowEmpty colSpan={4} message="No Database Clusters" />
-  );
-
   if (isLoading) {
     return (
       <DatabasesTableWrapper>
-        <LoadingState />
+        <TableRow>
+          <TableCell colSpan={4} style={{ textAlign: 'center' }}>
+            <CircleProgress size="sm" />
+          </TableCell>
+        </TableRow>
       </DatabasesTableWrapper>
     );
   }
@@ -114,7 +84,15 @@ export const SubnetDatabasesTable = ({ databasesData }: Props) => {
   if (databasesError) {
     return (
       <DatabasesTableWrapper>
-        <TableErrorState />
+        <TableRowError
+          colSpan={4}
+          message={
+            getAPIErrorOrDefault(
+              databasesError ?? [],
+              'There was a problem retrieving your databases. Refresh the page or try again later.'
+            )[0].reason
+          }
+        />
       </DatabasesTableWrapper>
     );
   }
@@ -122,23 +100,22 @@ export const SubnetDatabasesTable = ({ databasesData }: Props) => {
   if (databases && databases.data.length === 0) {
     return (
       <DatabasesTableWrapper>
-        <EmptyState />
+        <TableRowEmpty colSpan={4} message="No Database Clusters" />
       </DatabasesTableWrapper>
     );
   }
 
-  const databaseRows = () =>
-    databases?.data.map((database) => (
-      <SubnetDatabaseRow
-        assignedDatabase={assignedDatabasesMap[database.id]}
-        database={database}
-        key={database.id}
-      />
-    ));
-
   return (
     <>
-      <DatabasesTableWrapper>{databaseRows()}</DatabasesTableWrapper>
+      <DatabasesTableWrapper>
+        {databases?.data.map((database) => (
+          <SubnetDatabaseRow
+            assignedDatabase={assignedDatabasesMap[database.id]}
+            database={database}
+            key={database.id}
+          />
+        ))}
+      </DatabasesTableWrapper>
       <PaginationFooter
         count={databases?.results ?? 0}
         handlePageChange={(page: number) => setPage(page)}

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetDatabasesTable.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetDatabasesTable.tsx
@@ -20,18 +20,19 @@ import {
 
 import type { SubnetAssignedDatabaseData } from '@linode/api-v4';
 interface Props {
-  databasesData: SubnetAssignedDatabaseData[];
+  subnetDatabasesData: SubnetAssignedDatabaseData[];
 }
 
-export const SubnetDatabasesTable = ({ databasesData }: Props) => {
+export const SubnetDatabasesTable = ({ subnetDatabasesData }: Props) => {
   const theme = useTheme();
 
   const [pageSize, setPageSize] = React.useState(25);
   const [page, setPage] = React.useState(1);
 
-  const assignedDatabasesMap: Record<number, SubnetAssignedDatabaseData> = {}; // Store assigned databases in map for easy lookup when rendering subnet database rows
-  const databaseIDsToFilter = databasesData.map((database) => {
-    assignedDatabasesMap[database.id] = database;
+  const assignedSubnetDatabasesMap: Record<number, SubnetAssignedDatabaseData> =
+    {}; // Store assigned databases in map for easy lookup when rendering subnet database rows
+  const databaseIDsToFilter = subnetDatabasesData.map((database) => {
+    assignedSubnetDatabasesMap[database.id] = database;
     return {
       id: database.id,
     };
@@ -110,7 +111,7 @@ export const SubnetDatabasesTable = ({ databasesData }: Props) => {
       <DatabasesTableWrapper>
         {databases?.data.map((database) => (
           <SubnetDatabaseRow
-            assignedDatabase={assignedDatabasesMap[database.id]}
+            assignedDatabase={assignedSubnetDatabasesMap[database.id]}
             database={database}
             key={database.id}
           />

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetDatabasesTable.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetDatabasesTable.tsx
@@ -29,24 +29,24 @@ export const SubnetDatabasesTable = ({ databasesData }: Props) => {
   const [pageSize, setPageSize] = React.useState(25);
   const [page, setPage] = React.useState(1);
 
-  const assignedDatabasesMap = () => {
+  const assignedDatabasesMap = React.useMemo(() => {
     const databaseMap: Record<number, SubnetAssignedDatabaseData> = {};
     databasesData.forEach((assignedDatabase) => {
       databaseMap[assignedDatabase.id] = assignedDatabase;
     });
     return databaseMap;
-  };
+  }, [databasesData]);
 
   // Create filter using unique database IDs from the assigned databases
-  const makeDatabaseIDsFilter = () => {
-    const uniqueIds = Object.values(assignedDatabasesMap()).map((db) => {
+  const makeDatabaseIDsFilter = React.useMemo(() => {
+    const uniqueIds = Object.values(assignedDatabasesMap).map((db) => {
       return { id: db.id };
     });
 
     return {
       '+or': uniqueIds,
     };
-  };
+  }, [assignedDatabasesMap]);
 
   const {
     data: databases,
@@ -57,12 +57,16 @@ export const SubnetDatabasesTable = ({ databasesData }: Props) => {
       page_size: pageSize,
       page,
     },
-    makeDatabaseIDsFilter(),
+    makeDatabaseIDsFilter,
     true,
     false
   );
 
-  const DatabasesTable = ({ children }: { children: React.ReactNode }) => (
+  const DatabasesTableWrapper = ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) => (
     <>
       <Table aria-label="Databases" size="small" striped={false}>
         <TableHead
@@ -91,7 +95,7 @@ export const SubnetDatabasesTable = ({ databasesData }: Props) => {
 
   const LoadingState = () => (
     <TableRow>
-      <TableCell colSpan={6} style={{ textAlign: 'center' }}>
+      <TableCell colSpan={4} style={{ textAlign: 'center' }}>
         <CircleProgress size="sm" />
       </TableCell>
     </TableRow>
@@ -99,7 +103,7 @@ export const SubnetDatabasesTable = ({ databasesData }: Props) => {
 
   const TableErrorState = () => (
     <TableRowError
-      colSpan={6}
+      colSpan={4}
       message={
         getAPIErrorOrDefault(
           databasesError ?? [],
@@ -110,42 +114,41 @@ export const SubnetDatabasesTable = ({ databasesData }: Props) => {
   );
 
   const EmptyState = () => (
-    <TableRowEmpty colSpan={8} message="No Database Clusters" />
+    <TableRowEmpty colSpan={4} message="No Database Clusters" />
   );
 
   if (isLoading) {
     return (
-      <DatabasesTable>
+      <DatabasesTableWrapper>
         <LoadingState />
-      </DatabasesTable>
+      </DatabasesTableWrapper>
     );
   }
 
   if (databasesError) {
-    // TODO: Fix the error state styling
     return (
-      <DatabasesTable>
+      <DatabasesTableWrapper>
         <TableErrorState />
-      </DatabasesTable>
+      </DatabasesTableWrapper>
     );
   }
 
   if (databases && databases.data.length === 0) {
     return (
-      <DatabasesTable>
+      <DatabasesTableWrapper>
         <EmptyState />
-      </DatabasesTable>
+      </DatabasesTableWrapper>
     );
   }
 
   const databaseRows = () =>
     databases?.data.map((database) => (
       <SubnetDatabaseRow
-        assignedDatabase={assignedDatabasesMap()[database.id]}
+        assignedDatabase={assignedDatabasesMap[database.id]}
         database={database}
         key={database.id}
       />
     ));
 
-  return <DatabasesTable>{databaseRows()}</DatabasesTable>;
+  return <DatabasesTableWrapper>{databaseRows()}</DatabasesTableWrapper>;
 };

--- a/packages/manager/src/features/VPCs/VPCDetail/SubnetDatabasesTable.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/SubnetDatabasesTable.tsx
@@ -1,0 +1,151 @@
+import { useDatabasesQuery } from '@linode/queries';
+import { CircleProgress } from '@linode/ui';
+import { useTheme } from '@mui/material/styles';
+import * as React from 'react';
+
+import { PaginationFooter } from 'src/components/PaginationFooter/PaginationFooter';
+import { Table } from 'src/components/Table';
+import { TableBody } from 'src/components/TableBody';
+import { TableCell } from 'src/components/TableCell';
+import { TableHead } from 'src/components/TableHead';
+import { TableRow } from 'src/components/TableRow';
+import { TableRowEmpty } from 'src/components/TableRowEmpty/TableRowEmpty';
+import { TableRowError } from 'src/components/TableRowError/TableRowError';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+
+import {
+  SubnetDatabaseRow,
+  SubnetDatabasesTableRowHead,
+} from './SubnetDatabaseRow';
+
+import type { SubnetAssignedDatabaseData } from '@linode/api-v4';
+interface Props {
+  databasesData: SubnetAssignedDatabaseData[];
+}
+
+export const SubnetDatabasesTable = ({ databasesData }: Props) => {
+  const theme = useTheme();
+
+  const [pageSize, setPageSize] = React.useState(25);
+  const [page, setPage] = React.useState(1);
+
+  const assignedDatabasesMap = () => {
+    const databaseMap: Record<number, SubnetAssignedDatabaseData> = {};
+    databasesData.forEach((assignedDatabase) => {
+      databaseMap[assignedDatabase.id] = assignedDatabase;
+    });
+    return databaseMap;
+  };
+
+  // Create filter using unique database IDs from the assigned databases
+  const makeDatabaseIDsFilter = () => {
+    const uniqueIds = Object.values(assignedDatabasesMap()).map((db) => {
+      return { id: db.id };
+    });
+
+    return {
+      '+or': uniqueIds,
+    };
+  };
+
+  const {
+    data: databases,
+    error: databasesError,
+    isLoading,
+  } = useDatabasesQuery(
+    {
+      page_size: pageSize,
+      page,
+    },
+    makeDatabaseIDsFilter(),
+    true,
+    false
+  );
+
+  const DatabasesTable = ({ children }: { children: React.ReactNode }) => (
+    <>
+      <Table aria-label="Databases" size="small" striped={false}>
+        <TableHead
+          style={{
+            color: theme.tokens.color.Neutrals.White,
+          }}
+        >
+          {SubnetDatabasesTableRowHead}
+        </TableHead>
+        <TableBody>{children}</TableBody>
+      </Table>
+      <PaginationFooter
+        count={databases?.results ?? 0}
+        handlePageChange={(page: number) => setPage(page)}
+        handleSizeChange={(pageSize: number) => setPageSize(pageSize)}
+        page={page}
+        pageSize={pageSize}
+        sx={{
+          border: 'none',
+          borderBottom: `1px solid ${theme.tokens.component.Table.Row.Border}`,
+          borderTop: `1px solid ${theme.tokens.component.Table.Row.Border}`,
+        }}
+      />
+    </>
+  );
+
+  const LoadingState = () => (
+    <TableRow>
+      <TableCell colSpan={6} style={{ textAlign: 'center' }}>
+        <CircleProgress size="sm" />
+      </TableCell>
+    </TableRow>
+  );
+
+  const TableErrorState = () => (
+    <TableRowError
+      colSpan={6}
+      message={
+        getAPIErrorOrDefault(
+          databasesError ?? [],
+          'There was a problem retrieving your databases. Refresh the page or try again later.'
+        )[0].reason
+      }
+    />
+  );
+
+  const EmptyState = () => (
+    <TableRowEmpty colSpan={8} message="No Database Clusters" />
+  );
+
+  if (isLoading) {
+    return (
+      <DatabasesTable>
+        <LoadingState />
+      </DatabasesTable>
+    );
+  }
+
+  if (databasesError) {
+    // TODO: Fix the error state styling
+    return (
+      <DatabasesTable>
+        <TableErrorState />
+      </DatabasesTable>
+    );
+  }
+
+  if (databases && databases.data.length === 0) {
+    return (
+      <DatabasesTable>
+        <EmptyState />
+      </DatabasesTable>
+    );
+  }
+
+  const databaseRows = () =>
+    databases?.data.map((database) => (
+      <SubnetDatabaseRow
+        assignedDatabase={assignedDatabasesMap()[database.id]}
+        database={database}
+        key={database.id}
+      />
+    ));
+
+  return <DatabasesTable>{databaseRows()}</DatabasesTable>;
+};

--- a/packages/manager/src/features/VPCs/VPCDetail/VPCDetail.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/VPCDetail.test.tsx
@@ -114,14 +114,14 @@ describe('VPC Detail Summary section', () => {
     });
 
     const { getByText } = renderWithTheme(<VPCDetail />, {
-      flags: { nodebalancerVpc: true },
+      flags: { nodebalancerVpc: true, vpcDbaasResources: true },
     });
 
-    // there is 1 subnet with 8 resources (5 Linodes, 3 nbs)
+    // there is 1 subnet with 11 resources (5 Linodes, 3 nbs, 3 dbs)
     expect(getByText('Subnets')).toBeVisible();
     expect(getByText('1')).toBeVisible();
     expect(getByText('Resources')).toBeVisible();
-    expect(getByText('8')).toBeVisible();
+    expect(getByText('11')).toBeVisible();
 
     expect(getByText('Region')).toBeVisible();
     expect(getByText('US, Newark, NJ')).toBeVisible();

--- a/packages/manager/src/features/VPCs/VPCDetail/VPCDetail.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/VPCDetail.tsx
@@ -19,6 +19,7 @@ import { usePermissions } from 'src/features/IAM/hooks/usePermissions';
 import { LKE_ENTERPRISE_AUTOGEN_VPC_WARNING } from 'src/features/Kubernetes/constants';
 import { useIsNodebalancerVPCEnabled } from 'src/features/NodeBalancers/utils';
 import { VPC_DOCS_LINK, VPC_LABEL } from 'src/features/VPCs/constants';
+import { useFlags } from 'src/hooks/useFlags';
 
 import {
   getIsVPCLKEEnterpriseCluster,
@@ -51,7 +52,9 @@ const VPCDetail = () => {
     isLoading,
   } = useVPCQuery(Number(vpcId) || -1, Boolean(vpcId));
 
-  const flags = useIsNodebalancerVPCEnabled();
+  const flags = useFlags();
+
+  const { isNodebalancerVPCEnabled } = useIsNodebalancerVPCEnabled();
 
   const { data: regions } = useRegionsQuery();
 
@@ -104,8 +107,11 @@ const VPCDetail = () => {
   const regionLabel =
     regions?.find((r) => r.id === vpc.region)?.label ?? vpc.region;
 
-  const numResources = flags.isNodebalancerVPCEnabled
-    ? getUniqueResourcesFromSubnets(vpc.subnets)
+  const numResources = isNodebalancerVPCEnabled
+    ? getUniqueResourcesFromSubnets(
+        vpc.subnets,
+        flags.vpcDbaasResources ?? false
+      )
     : getUniqueLinodesFromSubnets(vpc.subnets);
 
   const summaryData = [
@@ -115,7 +121,7 @@ const VPCDetail = () => {
         value: vpc.subnets.length,
       },
       {
-        label: flags.isNodebalancerVPCEnabled ? 'Resources' : 'Linodes',
+        label: isNodebalancerVPCEnabled ? 'Resources' : 'Linodes',
         value: numResources,
       },
     ],

--- a/packages/manager/src/features/VPCs/VPCDetail/VPCDetail.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/VPCDetail.tsx
@@ -110,7 +110,7 @@ const VPCDetail = () => {
   const numResources = isNodebalancerVPCEnabled
     ? getUniqueResourcesFromSubnets(
         vpc.subnets,
-        flags.vpcDbaasResources ?? false
+        Boolean(flags.vpcDbaasResources)
       )
     : getUniqueLinodesFromSubnets(vpc.subnets);
 

--- a/packages/manager/src/features/VPCs/VPCDetail/VPCSubnetsTable.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/VPCSubnetsTable.test.tsx
@@ -122,7 +122,7 @@ describe('VPC Subnets table', () => {
         vpcRegion=""
       />,
       {
-        flags: { nodebalancerVpc: true },
+        flags: { nodebalancerVpc: true, vpcDbaasResources: true },
       }
     );
 
@@ -137,7 +137,11 @@ describe('VPC Subnets table', () => {
 
     expect(getByText('Resources')).toBeVisible();
     expect(
-      getByText(subnet.linodes.length + subnet.nodebalancers.length)
+      getByText(
+        subnet.linodes.length +
+          subnet.nodebalancers.length +
+          subnet.databases.length
+      )
     ).toBeVisible();
 
     const actionMenuButton = getByLabelText(
@@ -291,6 +295,37 @@ describe('VPC Subnets table', () => {
       await findByText('Frontend IPv6');
       await findByText('Backend IPv4 Ranges');
       await findByText('Backend IPv6 Ranges');
+    }
+  );
+
+  it(
+    'should show Databases table head data when table is expanded',
+    { timeout: 15_000 },
+    async () => {
+      const subnet = subnetFactory.build();
+
+      queryMocks.useSubnetsQuery.mockReturnValue({
+        data: {
+          data: [subnet],
+        },
+      });
+
+      const { getByLabelText, findByText } = renderWithTheme(
+        <VPCSubnetsTable
+          isVPCLKEEnterpriseCluster={false}
+          vpcId={3}
+          vpcRegion=""
+        />,
+        { flags: { nodebalancerVpc: true, vpcDbaasResources: true } }
+      );
+
+      const expandTableButton = getByLabelText(`expand ${subnet.label} row`);
+      await userEvent.click(expandTableButton);
+
+      await findByText('Database Cluster');
+      await findByText('IPv4 Address(s)');
+      await findByText('VPC IPv4 Range');
+      await findByText('VPC IPv6 Range');
     }
   );
 

--- a/packages/manager/src/features/VPCs/VPCDetail/VPCSubnetsTable.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/VPCSubnetsTable.test.tsx
@@ -323,7 +323,7 @@ describe('VPC Subnets table', () => {
       await userEvent.click(expandTableButton);
 
       await findByText('Database Cluster');
-      await findByText('IPv4 Address(s)');
+      await findByText('IPv4 Address(es)');
       await findByText('VPC IPv4 Range');
       await findByText('VPC IPv6 Range');
     }

--- a/packages/manager/src/features/VPCs/VPCDetail/VPCSubnetsTable.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/VPCSubnetsTable.tsx
@@ -407,7 +407,7 @@ export const VPCSubnetsTable = (props: Props) => {
             </Table>
           )}
           {flags.vpcDbaasResources && subnet.databases?.length > 0 && (
-            <SubnetDatabasesTable databasesData={subnet.databases} />
+            <SubnetDatabasesTable subnetDatabasesData={subnet.databases} />
           )}
         </>
       );

--- a/packages/manager/src/features/VPCs/VPCDetail/VPCSubnetsTable.tsx
+++ b/packages/manager/src/features/VPCs/VPCDetail/VPCSubnetsTable.tsx
@@ -29,6 +29,7 @@ import { usePermissions } from 'src/features/IAM/hooks/usePermissions';
 import { PowerActionsDialog } from 'src/features/Linodes/PowerActionsDialogOrDrawer';
 import { useIsNodebalancerVPCEnabled } from 'src/features/NodeBalancers/utils';
 import { SubnetActionMenu } from 'src/features/VPCs/VPCDetail/SubnetActionMenu';
+import { useFlags } from 'src/hooks/useFlags';
 import { useOrderV2 } from 'src/hooks/useOrderV2';
 import { usePaginationV2 } from 'src/hooks/usePaginationV2';
 import { useVPCDualStack } from 'src/hooks/useVPCDualStack';
@@ -37,6 +38,7 @@ import { SUBNET_ACTION_PATH } from '../constants';
 import { VPC_DETAILS_ROUTE } from '../constants';
 import { SubnetAssignLinodesDrawer } from './SubnetAssignLinodesDrawer';
 import { SubnetCreateDrawer } from './SubnetCreateDrawer';
+import { SubnetDatabasesTable } from './SubnetDatabasesTable';
 import { SubnetDeleteDialog } from './SubnetDeleteDialog';
 import { SubnetEditDrawer } from './SubnetEditDrawer';
 import { SubnetLinodeRow, SubnetLinodeTableRowHead } from './SubnetLinodeRow';
@@ -90,6 +92,7 @@ export const VPCSubnetsTable = (props: Props) => {
 
   const { isNodebalancerVPCEnabled } = useIsNodebalancerVPCEnabled();
   const { isDualStackEnabled } = useVPCDualStack();
+  const flags = useFlags();
 
   const { data: permissions } = usePermissions(
     'vpc',
@@ -333,7 +336,7 @@ export const VPCSubnetsTable = (props: Props) => {
           )}
           <Hidden smDown>
             <TableCell>
-              {`${isNodebalancerVPCEnabled ? subnet.linodes.length + uniqueNodebalancers.length : subnet.linodes.length}`}
+              {`${isNodebalancerVPCEnabled ? subnet.linodes.length + uniqueNodebalancers.length + (flags.vpcDbaasResources ? subnet.databases.length : 0) : subnet.linodes.length}`}
             </TableCell>
           </Hidden>
           <TableCell actionCell>
@@ -402,6 +405,9 @@ export const VPCSubnetsTable = (props: Props) => {
                 ))}
               </TableBody>
             </Table>
+          )}
+          {flags.vpcDbaasResources && subnet.databases?.length > 0 && (
+            <SubnetDatabasesTable databasesData={subnet.databases} />
           )}
         </>
       );

--- a/packages/manager/src/features/VPCs/VPCLanding/VPCLanding.tsx
+++ b/packages/manager/src/features/VPCs/VPCLanding/VPCLanding.tsx
@@ -178,7 +178,7 @@ const VPCLanding = () => {
         <TableBody>
           {vpcs?.data.map((vpc: VPC) => (
             <VPCRow
-              displayVPCDBaaSResources={flags.vpcDbaasResources ?? false}
+              displayVPCDBaaSResources={Boolean(flags.vpcDbaasResources)}
               handleDeleteVPC={() => handleDeleteVPC(vpc)}
               handleEditVPC={() => handleEditVPC(vpc)}
               isNodebalancerVPCEnabled={isNodebalancerVPCEnabled}

--- a/packages/manager/src/features/VPCs/VPCLanding/VPCLanding.tsx
+++ b/packages/manager/src/features/VPCs/VPCLanding/VPCLanding.tsx
@@ -21,6 +21,7 @@ import {
   VPC_LANDING_TABLE_PREFERENCE_KEY,
 } from 'src/features/VPCs/constants';
 import { VPC_DOCS_LINK, VPC_LABEL } from 'src/features/VPCs/constants';
+import { useFlags } from 'src/hooks/useFlags';
 import { useOrderV2 } from 'src/hooks/useOrderV2';
 import { usePaginationV2 } from 'src/hooks/usePaginationV2';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
@@ -98,7 +99,8 @@ const VPCLanding = () => {
     error: selectedVPCError,
   } = useVPCQuery(params.vpcId ?? -1, !!params.vpcId);
 
-  const flags = useIsNodebalancerVPCEnabled();
+  const flags = useFlags();
+  const { isNodebalancerVPCEnabled } = useIsNodebalancerVPCEnabled();
 
   if (error) {
     return (
@@ -168,7 +170,7 @@ const VPCLanding = () => {
             </Hidden>
             <TableCell>Subnets</TableCell>
             <Hidden mdDown>
-              <TableCell>{`${flags.isNodebalancerVPCEnabled ? 'Resources' : 'Linodes'}`}</TableCell>
+              <TableCell>{`${isNodebalancerVPCEnabled ? 'Resources' : 'Linodes'}`}</TableCell>
             </Hidden>
             <TableCell />
           </TableRow>
@@ -176,9 +178,10 @@ const VPCLanding = () => {
         <TableBody>
           {vpcs?.data.map((vpc: VPC) => (
             <VPCRow
+              displayVPCDBaaSResources={flags.vpcDbaasResources ?? false}
               handleDeleteVPC={() => handleDeleteVPC(vpc)}
               handleEditVPC={() => handleEditVPC(vpc)}
-              isNodebalancerVPCEnabled={flags.isNodebalancerVPCEnabled}
+              isNodebalancerVPCEnabled={isNodebalancerVPCEnabled}
               key={vpc.id}
               vpc={vpc}
             />

--- a/packages/manager/src/features/VPCs/VPCLanding/VPCRow.test.tsx
+++ b/packages/manager/src/features/VPCs/VPCLanding/VPCRow.test.tsx
@@ -32,6 +32,7 @@ describe('VPC Table Row', () => {
     const { getByText, getByLabelText } = renderWithTheme(
       wrapWithTableBody(
         <VPCRow
+          displayVPCDBaaSResources
           handleDeleteVPC={vi.fn()}
           handleEditVPC={vi.fn()}
           isNodebalancerVPCEnabled
@@ -57,6 +58,7 @@ describe('VPC Table Row', () => {
     const { getByTestId, getByLabelText } = renderWithTheme(
       wrapWithTableBody(
         <VPCRow
+          displayVPCDBaaSResources
           handleDeleteVPC={handleDelete}
           handleEditVPC={vi.fn()}
           isNodebalancerVPCEnabled
@@ -78,6 +80,7 @@ describe('VPC Table Row', () => {
     const { getByTestId, getByLabelText } = renderWithTheme(
       wrapWithTableBody(
         <VPCRow
+          displayVPCDBaaSResources
           handleDeleteVPC={vi.fn()}
           handleEditVPC={handleEdit}
           isNodebalancerVPCEnabled
@@ -105,6 +108,7 @@ describe('VPC Table Row', () => {
     const { getByTestId, getByLabelText } = renderWithTheme(
       wrapWithTableBody(
         <VPCRow
+          displayVPCDBaaSResources
           handleDeleteVPC={vi.fn()}
           handleEditVPC={handleEdit}
           isNodebalancerVPCEnabled
@@ -132,6 +136,7 @@ describe('VPC Table Row', () => {
     const { getByTestId, getByLabelText } = renderWithTheme(
       wrapWithTableBody(
         <VPCRow
+          displayVPCDBaaSResources
           handleDeleteVPC={vi.fn()}
           handleEditVPC={handleEdit}
           isNodebalancerVPCEnabled

--- a/packages/manager/src/features/VPCs/VPCLanding/VPCRow.tsx
+++ b/packages/manager/src/features/VPCs/VPCLanding/VPCRow.tsx
@@ -17,6 +17,7 @@ import {
 import type { VPC } from '@linode/api-v4/lib/vpcs/types';
 
 interface Props {
+  displayVPCDBaaSResources: boolean;
   handleDeleteVPC: () => void;
   handleEditVPC: () => void;
   isNodebalancerVPCEnabled: boolean;
@@ -27,6 +28,7 @@ export const VPCRow = ({
   handleDeleteVPC,
   handleEditVPC,
   isNodebalancerVPCEnabled,
+  displayVPCDBaaSResources,
   vpc,
 }: Props) => {
   const { id, label, subnets } = vpc;
@@ -36,7 +38,7 @@ export const VPCRow = ({
 
   const regionLabel = regions?.find((r) => r.id === vpc.region)?.label ?? '';
   const numResources = isNodebalancerVPCEnabled
-    ? getUniqueResourcesFromSubnets(vpc.subnets)
+    ? getUniqueResourcesFromSubnets(vpc.subnets, displayVPCDBaaSResources)
     : getUniqueLinodesFromSubnets(vpc.subnets);
 
   const { data: permissions, isLoading } = usePermissions(

--- a/packages/manager/src/features/VPCs/utils.test.ts
+++ b/packages/manager/src/features/VPCs/utils.test.ts
@@ -6,6 +6,7 @@ import {
 
 import { linodeConfigFactory } from 'src/factories/linodeConfigs';
 import {
+  subnetAssignedDatabaseDataFactory,
   subnetAssignedLinodeDataFactory,
   subnetAssignedNodebalancerDataFactory,
   subnetFactory,
@@ -36,14 +37,23 @@ const subnetNodeBalancerInfoId1 = subnetAssignedNodebalancerDataFactory.build({
 const subnetNodeBalancerInfoId3 = subnetAssignedNodebalancerDataFactory.build({
   id: 3,
 });
+const subnetdatabaseInfoId1 = subnetAssignedDatabaseDataFactory.build({
+  id: 1,
+});
+const subnetdatabaseInfoId2 = subnetAssignedDatabaseDataFactory.build({
+  id: 2,
+});
 
 describe('getUniqueResourcesFromSubnets', () => {
-  it(`returns the number of unique linodes and nodeBalancers within a VPC's subnets`, () => {
-    const subnets0 = [subnetFactory.build({ linodes: [], nodebalancers: [] })];
+  it(`returns the number of unique linodes, nodeBalancers, and databases within a VPC's subnets`, () => {
+    const subnets0 = [
+      subnetFactory.build({ linodes: [], nodebalancers: [], databases: [] }),
+    ];
     const subnets1 = [
       subnetFactory.build({
         linodes: subnetLinodeInfoList1,
         nodebalancers: subnetNodeBalancerInfoList1,
+        databases: [],
       }),
     ];
     const subnets2 = [
@@ -60,17 +70,20 @@ describe('getUniqueResourcesFromSubnets', () => {
           subnetNodeBalancerInfoId3,
           subnetNodeBalancerInfoId3,
         ],
+        databases: [],
       }),
     ];
     const subnets3 = [
       subnetFactory.build({
         linodes: subnetLinodeInfoList1,
         nodebalancers: subnetNodeBalancerInfoList1,
+        databases: [],
       }),
-      subnetFactory.build({ linodes: [], nodebalancers: [] }),
+      subnetFactory.build({ linodes: [], nodebalancers: [], databases: [] }),
       subnetFactory.build({
         linodes: [subnetLinodeInfoId3],
         nodebalancers: [subnetNodeBalancerInfoId3],
+        databases: [],
       }),
       subnetFactory.build({
         linodes: [
@@ -87,6 +100,21 @@ describe('getUniqueResourcesFromSubnets', () => {
           subnetAssignedNodebalancerDataFactory.build({ id: 9 }),
           subnetNodeBalancerInfoId1,
         ],
+        databases: [],
+      }),
+    ];
+
+    const subnets4 = [
+      ...subnets3,
+      subnetFactory.build({
+        databases: [subnetdatabaseInfoId1],
+        linodes: [],
+        nodebalancers: [],
+      }),
+      subnetFactory.build({
+        databases: [subnetdatabaseInfoId2],
+        linodes: [],
+        nodebalancers: [],
       }),
     ];
 
@@ -95,6 +123,8 @@ describe('getUniqueResourcesFromSubnets', () => {
     expect(getUniqueResourcesFromSubnets(subnets2, false)).toBe(4);
     // updated factory for generating linode ids, so unique linodes will be different
     expect(getUniqueResourcesFromSubnets(subnets3, false)).toBe(16);
+    // Test databases count when getUniqueLinodesFromSubnets countDatabases param is true
+    expect(getUniqueResourcesFromSubnets(subnets4, true)).toBe(18);
   });
 });
 

--- a/packages/manager/src/features/VPCs/utils.test.ts
+++ b/packages/manager/src/features/VPCs/utils.test.ts
@@ -90,11 +90,11 @@ describe('getUniqueResourcesFromSubnets', () => {
       }),
     ];
 
-    expect(getUniqueResourcesFromSubnets(subnets0)).toBe(0);
-    expect(getUniqueResourcesFromSubnets(subnets1)).toBe(8);
-    expect(getUniqueResourcesFromSubnets(subnets2)).toBe(4);
+    expect(getUniqueResourcesFromSubnets(subnets0, false)).toBe(0);
+    expect(getUniqueResourcesFromSubnets(subnets1, false)).toBe(8);
+    expect(getUniqueResourcesFromSubnets(subnets2, false)).toBe(4);
     // updated factory for generating linode ids, so unique linodes will be different
-    expect(getUniqueResourcesFromSubnets(subnets3)).toBe(16);
+    expect(getUniqueResourcesFromSubnets(subnets3, false)).toBe(16);
   });
 });
 

--- a/packages/manager/src/features/VPCs/utils.ts
+++ b/packages/manager/src/features/VPCs/utils.ts
@@ -23,9 +23,13 @@ export const getUniqueLinodesFromSubnets = (subnets: Subnet[]) => {
   return linodes.length;
 };
 
-export const getUniqueResourcesFromSubnets = (subnets: Subnet[]) => {
+export const getUniqueResourcesFromSubnets = (
+  subnets: Subnet[],
+  countDatabases: boolean
+) => {
   const linodes: number[] = [];
   const nodeBalancer: number[] = [];
+  const databases: number[] = [];
   for (const subnet of subnets) {
     subnet.linodes.forEach((linodeInfo) => {
       if (!linodes.includes(linodeInfo.id)) {
@@ -37,8 +41,15 @@ export const getUniqueResourcesFromSubnets = (subnets: Subnet[]) => {
         nodeBalancer.push(nodeBalancerInfo.id);
       }
     });
+    if (countDatabases) {
+      subnet.databases.forEach((databaseInfo) => {
+        if (!databases.includes(databaseInfo.id)) {
+          databases.push(databaseInfo.id);
+        }
+      });
+    }
   }
-  return linodes.length + nodeBalancer.length;
+  return linodes.length + nodeBalancer.length + databases.length;
 };
 
 // Linode Interfaces: show unrecommended notice if (active) VPC interface has an IPv4 nat_1_1 address but isn't the default IPv4 route

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -368,33 +368,14 @@ const entityTransfers = [
 
 const databases = [
   http.get('*/databases/instances', () => {
-    const database1 = databaseInstanceFactory.build({
-      cluster_size: 1,
-      id: 1,
-      label: 'database-instance-1',
-    });
-    const database2 = databaseInstanceFactory.build({
-      cluster_size: 2,
-      id: 2,
-      label: 'database-instance-2',
-    });
-    const database3 = databaseInstanceFactory.build({
-      cluster_size: 3,
-      id: 3,
-      label: 'database-instance-3',
-    });
-    const database4 = databaseInstanceFactory.build({
-      cluster_size: 1,
-      id: 4,
-      label: 'database-instance-4',
-    });
-    const database5 = databaseInstanceFactory.build({
-      cluster_size: 1,
-      id: 5,
-      label: 'database-instance-5',
-    });
+    const ids = Array.from({ length: 5 }, (_, i) => i + 1); // Update length to change the number of databases
 
-    const databases = [database1, database2, database3, database4, database5];
+    const databases = ids.map((id) => {
+      return databaseInstanceFactory.build({
+        id,
+        label: `databases-instance-${id}`,
+      });
+    });
     return HttpResponse.json(makeResourcePage(databases));
   }),
 
@@ -613,6 +594,15 @@ const vpc = [
     );
   }),
   http.get('*/v4beta/vpcs/:vpcId/subnets', () => {
+    /* Uncomment to the code below to mock a subnet with assignedDatabases that can be found in the GET database instances call */
+    // const ids = Array.from({ length: 5 }, (_, i) => i + 1); // Update length to change the number of assigned databases
+    // const assignedDatabases = ids.map((id) => {
+    //   return subnetAssignedDatabaseDataFactory.build({
+    //     id,
+    //   });
+    // });
+    // const mockSubnet = subnetFactory.build({ databases: assignedDatabases });
+    // return HttpResponse.json(makeResourcePage([mockSubnet]));
     return HttpResponse.json(makeResourcePage(subnetFactory.buildList(30)));
   }),
   http.delete('*/v4beta/vpcs/:vpcId/subnets/:subnetId', () => {

--- a/packages/queries/src/databases/databases.ts
+++ b/packages/queries/src/databases/databases.ts
@@ -42,14 +42,9 @@ import type {
   UpdateDatabasePayload,
 } from '@linode/api-v4';
 
-export const useDatabaseQuery = (
-  engine: Engine,
-  id: number,
-  isEnabled = true,
-) =>
+export const useDatabaseQuery = (engine: Engine, id: number) =>
   useQuery<Database, APIError[]>({
     ...databaseQueries.database(engine, id),
-    enabled: isEnabled,
     // @TODO Consider removing polling
     // The refetchInterval will poll the API for this Database. We will do this
     // to ensure we have up to date information. We do this polling because the events

--- a/packages/queries/src/databases/databases.ts
+++ b/packages/queries/src/databases/databases.ts
@@ -61,7 +61,7 @@ export const useDatabasesQuery = (
   params: Params,
   filter: Filter,
   isEnabled: boolean | undefined,
-  refetchInterval: false | number,
+  refetchInterval?: number,
 ) =>
   useQuery<ResourcePage<DatabaseInstance>, APIError[]>({
     ...databaseQueries.databases._ctx.paginated(params, filter),

--- a/packages/queries/src/databases/databases.ts
+++ b/packages/queries/src/databases/databases.ts
@@ -42,9 +42,14 @@ import type {
   UpdateDatabasePayload,
 } from '@linode/api-v4';
 
-export const useDatabaseQuery = (engine: Engine, id: number) =>
+export const useDatabaseQuery = (
+  engine: Engine,
+  id: number,
+  isEnabled = true,
+) =>
   useQuery<Database, APIError[]>({
     ...databaseQueries.database(engine, id),
+    enabled: isEnabled,
     // @TODO Consider removing polling
     // The refetchInterval will poll the API for this Database. We will do this
     // to ensure we have up to date information. We do this polling because the events
@@ -56,13 +61,14 @@ export const useDatabasesQuery = (
   params: Params,
   filter: Filter,
   isEnabled: boolean | undefined,
+  refetchInterval: false | number,
 ) =>
   useQuery<ResourcePage<DatabaseInstance>, APIError[]>({
     ...databaseQueries.databases._ctx.paginated(params, filter),
     enabled: isEnabled,
     placeholderData: keepPreviousData,
     // @TODO Consider removing polling
-    refetchInterval: 20000,
+    refetchInterval,
   });
 
 export const useDatabasesInfiniteQuery = (filter: Filter, enabled: boolean) => {


### PR DESCRIPTION
## Description 📝

This pull request updates the VPC UI to display DBaaS resources and update existing resource counts to include databases

This issue consists of the following: 
- The Resource counts shown in the VPC Landing page, VPC Details Summary, and VPC Details Subnets tables aren't including the number of databases in the count
- In the VPC Details Subnets table, the resource tables shown under each expanded Subnet don't include a databases table in addition to the pre-existing Linode and Nodebalancer tables.

## Changes  🔄

List any change(s) relevant to the reviewer.

- Updating any Resource counts shown in the VPC Landing page, table, VPC Details Summary, and Subnets table to include the number of databases in the count.
- In the VPC Details Subnets table, under an expanded Subnet, display a databases table in addition to the pre-existing Linode and Nodebalancer tables.
- Introducing and integrating the new `vpcDbaasResources` feature flag

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [x] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️
4/29/2026

## Preview 📷
Note: The screenshots below are using mock data, so the data shown may not be accurate. The **resource counts** behavior will need to be checked using the verification steps that follow.

**Databases Resource Tables Not displaying under expanded Subnet in VPC Details View**
| Before  | After   |
| ------- | ------- |
| ![subnet-resource-tables-before](https://github.com/user-attachments/assets/ac40bb74-086f-4d12-aa71-4b91b2afc470) | ![subnet-resource-tables-after](https://github.com/user-attachments/assets/07f445ae-ca96-463d-bcf6-885631d1bc83) |

**Resource Count Locations in VPC: UI**
VPC Landing Table
![vpc-landing-resource-count](https://github.com/user-attachments/assets/9f3e71e0-abeb-40ea-946c-88eef7071dd3)

VPC Detail Summary and Subnets Table
*Note: The count in the summary is inaccurate due to mock data. Use the verification steps to test this behavior.
![vpc-details-resource-counts](https://github.com/user-attachments/assets/c52278e2-65b4-404e-9d45-8827f28f164d)

## How to test 🧪

### Prerequisites

(How to setup test environment)

- Have the **vpcDbaasResources** feature flag enabled in your local environment via `VPC DBaaS Resources`
- Have access to the Staging environment and have a VPC and Subnet created.

### Reproduction steps

**Test the VPC workflow**
- [ ] In the `staging` environment, access the VPC tab, select the `Create VPC` and create a new VPC and Subnet in a region. Preferably one that doesn't currently have one. For example, `US, Chicago, IL`. Keep track of the region for this new VPC/Subnet.
- [ ] Once created, it should navigate you back to the VPC landing page and you should see your new VPC in the table.
- [ ] Observe that the resource count for that VPC in the table is currently 0, which is accurate. 
- [ ] Open the Dev tools `Networking` tab and keep it open
- [ ] Click the VPC label in the table to navigate to the VPC details view.
- [ ] In the Dev Tools networking tab, search for the `subnets` call (*/vpcs/{vpcID}/subnets) and inspect the response to see that the `databases` property is currently an empty array
- [ ] Observe that the VPC `Summary` and  Subnets table below show a resource count of 0, which is accurate
- [ ] Expand the Subnets table and see that the `linodes` table is displayed in an empty state.

**Create a new database and assign the VPC/Subnet you created and retest the steps above**
- [ ] Access the databases tab and select `Create Database Cluster`
- [ ] Create a database cluster in the same region, select 3 nodes for the cluster, and make sure to select the VPC and Subnet you just created. This will assign it as the resource for that VPC/Subnet.
- [ ] Access the VPC tab and follow the `Test the VPC workflow` steps above.
- [ ] See that the `subnets` call returns the databases property with a single database in the array, but the resource counts on all pages are still 0.
- [ ] See that, when the subnet you created is expanded, it still only displays an empty linodes table and no `databases` table is shown.

### Verification steps

(How to verify changes)
**Testing the Resource Counts**
- [ ] In your local environment on the branch for this pull request, point it to staging. 
- [ ] Access the VPC tab and see that the resources count for the VPC you created in the verification steps now shows an accurate count (1 for the database that was assigned)
- [ ] Click the VPC label to access the details view and see that the resource counts in the summary and subnets table is also updated to include this count.

**Testing the database resources table under the expanded Subnet using mock data**
 - [ ] Enable mock data in the local environment
 - [ ] In the [ServerHandler.ts file](https://github.com/smans-akamai/manager/blob/367fdec52530d5e0eb1d1d0d8cb67eb5660b851a/packages/manager/src/mocks/serverHandlers.ts#L598), uncomment the newly added mock data under the `*/v4beta/vpcs/:vpcId/subnets` listener.
 - [ ] Access the VPC tab and open the networking tab in Dev tools.
 - [ ] Click on one of the VPC labels to access the VPC details
 - [ ] In the dev tools Networking tab, search for the `subnets` call (`*/vpcs/{vpcID}/subnets`) and inspect the response to see that `databases` property has 5 items listed.
 - [ ] In this view, expand the single Subnet from the mock data and see that the databases table now appears in addition the Linodes and Nodebalancers table and lists these 5 items.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

-->