### PR TITLE
fix: STORIF-329 - Bucket searching function fixed.

### DIFF
--- a/packages/manager/cypress/e2e/core/objectStorage/object-storage-errors.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorage/object-storage-errors.spec.ts
@@ -21,10 +21,10 @@ describe('object storage failure paths', () => {
    */
   it('shows error upon object upload failure', () => {
     const bucketLabel = randomLabel();
-    const bucketCluster = 'us-southeast-1';
+    const bucketRegion = 'us-southeast';
     const bucketMock = objectStorageBucketFactory.build({
-      cluster: bucketCluster,
-      hostname: `${bucketLabel}.${bucketCluster}.linodeobjects.com`,
+      region: bucketRegion,
+      hostname: `${bucketLabel}.${bucketRegion}-1.linodeobjects.com`,
       label: bucketLabel,
       objects: 0,
     });
@@ -39,19 +39,17 @@ describe('object storage failure paths', () => {
 
     // Mock empty object list and failed object-url upload request.
     mockGetBuckets([bucketMock]).as('getBuckets');
-    mockGetBucketObjects(bucketLabel, bucketCluster, []).as('getBucketObjects');
+    mockGetBucketObjects(bucketLabel, bucketRegion, []).as('getBucketObjects');
     mockUploadBucketObject(
       bucketLabel,
-      bucketCluster,
+      bucketRegion,
       bucketFilename,
       makeError(randomString()),
       404
     ).as('uploadBucketObject');
 
     // Visit bucket details page, initiate object upload.
-    cy.visitWithLogin(
-      `/object-storage/buckets/${bucketCluster}/${bucketLabel}`
-    );
+    cy.visitWithLogin(`/object-storage/buckets/${bucketRegion}/${bucketLabel}`);
     cy.wait('@getBucketObjects');
 
     cy.fixture(bucketFile, null).then((bucketFileContents) => {
@@ -82,10 +80,10 @@ describe('object storage failure paths', () => {
    */
   it('shows error upon object list retrieval failure', () => {
     const bucketLabel = randomLabel();
-    const bucketCluster = 'us-southeast-1';
+    const bucketRegion = 'us-southeast';
     const bucketMock = objectStorageBucketFactory.build({
-      cluster: bucketCluster,
-      hostname: `${bucketLabel}.${bucketCluster}.linodeobjects.com`,
+      region: bucketRegion,
+      hostname: `${bucketLabel}.${bucketRegion}-1.linodeobjects.com`,
       label: bucketLabel,
       objects: 0,
     });
@@ -93,14 +91,12 @@ describe('object storage failure paths', () => {
     mockGetBuckets([bucketMock]).as('getBuckets');
     mockGetBucketObjects(
       bucketLabel,
-      bucketCluster,
+      bucketRegion,
       makeError(randomString()),
       404
     ).as('getBucketObjects');
 
-    cy.visitWithLogin(
-      `/object-storage/buckets/${bucketCluster}/${bucketLabel}`
-    );
+    cy.visitWithLogin(`/object-storage/buckets/${bucketRegion}/${bucketLabel}`);
     cy.wait('@getBucketObjects');
     cy.findByText('We were unable to load your Objects.').should('be.visible');
   });

--- a/packages/manager/cypress/e2e/core/objectStorage/object-storage.smoke.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorage/object-storage.smoke.spec.ts
@@ -12,6 +12,7 @@ import {
   mockDeleteBucketObjectS3,
   mockGetBucketObjects,
   mockGetBuckets,
+  mockGetBucketsForRegion,
   mockUploadBucketObject,
   mockUploadBucketObjectS3,
 } from 'support/intercepts/object-storage';
@@ -87,9 +88,10 @@ describe('object storage smoke tests', () => {
    */
   it('can upload, view, and delete bucket objects - smoke', () => {
     const bucketLabel = randomLabel();
-    const bucketCluster = 'us-southeast-1';
+    const bucketRegion = 'us-southeast';
+    const bucketCluster = `${bucketRegion}-1`;
     const bucketMock = objectStorageBucketFactory.build({
-      cluster: bucketCluster,
+      region: bucketRegion,
       hostname: `${bucketLabel}.${bucketCluster}.linodeobjects.com`,
       label: bucketLabel,
       objects: 0,
@@ -102,23 +104,23 @@ describe('object storage smoke tests', () => {
       'object-storage-files/4.zip',
     ];
 
-    mockGetBuckets([bucketMock]).as('getBuckets');
-    mockGetBucketObjects(bucketLabel, bucketCluster, []).as('getBucketObjects');
-
-    cy.visitWithLogin(
-      `/object-storage/buckets/${bucketCluster}/${bucketLabel}`
+    mockGetBucketsForRegion(bucketRegion, [bucketMock]).as(
+      'getBucketsForRegion'
     );
-    cy.wait('@getBuckets');
+    mockGetBucketObjects(bucketLabel, bucketRegion, []).as('getBucketObjects');
+
+    cy.visitWithLogin(`/object-storage/buckets/${bucketRegion}/${bucketLabel}`);
+    cy.wait('@getBucketsForRegion');
     cy.wait('@getBucketObjects');
 
     cy.log('Upload bucket objects');
     bucketContents.forEach((bucketFile) => {
       const filename = bucketFile.split('/')[1];
 
-      mockUploadBucketObject(bucketLabel, bucketCluster, filename).as(
+      mockUploadBucketObject(bucketLabel, bucketRegion, filename).as(
         'uploadBucketObject'
       );
-      mockUploadBucketObjectS3(bucketLabel, bucketCluster, filename).as(
+      mockUploadBucketObjectS3(bucketLabel, bucketRegion, filename).as(
         'uploadBucketObjectS3'
       );
       // @TODO Intercept and mock bucket objects GET request to reflect upload.
@@ -142,10 +144,10 @@ describe('object storage smoke tests', () => {
     bucketContents.forEach((bucketFile) => {
       const filename = bucketFile.split('/')[1];
 
-      mockDeleteBucketObject(bucketLabel, bucketCluster, filename).as(
+      mockDeleteBucketObject(bucketLabel, bucketRegion, filename).as(
         'deleteBucketObject'
       );
-      mockDeleteBucketObjectS3(bucketLabel, bucketCluster, filename).as(
+      mockDeleteBucketObjectS3(bucketLabel, bucketRegion, filename).as(
         'deleteBucketObjectS3'
       );
 

--- a/packages/manager/cypress/e2e/core/objectStorageGen2/bucket-details-gen2.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorageGen2/bucket-details-gen2.spec.ts
@@ -68,9 +68,11 @@ describe('Object Storage Gen 2 bucket details tabs', () => {
       it(`does not hide the CORS toggle and SSL/TLS tab for buckets with an ${endpoint} endpoint`, () => {
         const { mockBucket, mockEndpoint } =
           createMocksBasedOnEndpointType(endpoint);
-        const { cluster, label } = mockBucket;
+        const { label } = mockBucket;
 
-        mockGetBucketAccess(label, cluster, mockAccess).as('getBucketAccess');
+        mockGetBucketAccess(label, mockRegion.id, mockAccess).as(
+          'getBucketAccess'
+        );
         mockGetBucketsForRegion(mockRegion.id, [mockBucket]).as(
           'getBucketsForRegion'
         );
@@ -78,7 +80,9 @@ describe('Object Storage Gen 2 bucket details tabs', () => {
           'getObjectStorageEndpoints'
         );
 
-        cy.visitWithLogin(`/object-storage/buckets/${cluster}/${label}/access`);
+        cy.visitWithLogin(
+          `/object-storage/buckets/${mockRegion.id}/${label}/access`
+        );
         cy.wait([
           '@getFeatureFlags',
           '@getAccount',
@@ -110,9 +114,11 @@ describe('Object Storage Gen 2 bucket details tabs', () => {
       it(`hides the CORS toggle and SSL/TLS tab for for buckets with an ${endpoint} endpoint`, () => {
         const { mockBucket, mockEndpoint } =
           createMocksBasedOnEndpointType(endpoint);
-        const { cluster, label } = mockBucket;
+        const { label } = mockBucket;
 
-        mockGetBucketAccess(label, cluster, mockAccess).as('getBucketAccess');
+        mockGetBucketAccess(label, mockRegion.id, mockAccess).as(
+          'getBucketAccess'
+        );
         mockGetBucketsForRegion(mockRegion.id, [mockBucket]).as(
           'getBucketsForRegion'
         );
@@ -120,7 +126,9 @@ describe('Object Storage Gen 2 bucket details tabs', () => {
           'getObjectStorageEndpoints'
         );
 
-        cy.visitWithLogin(`/object-storage/buckets/${cluster}/${label}/access`);
+        cy.visitWithLogin(
+          `/object-storage/buckets/${mockRegion.id}/${label}/access`
+        );
         cy.wait([
           '@getFeatureFlags',
           '@getAccount',

--- a/packages/manager/cypress/e2e/core/objectStorageMulticluster/object-storage-objects-multicluster.spec.ts
+++ b/packages/manager/cypress/e2e/core/objectStorageMulticluster/object-storage-objects-multicluster.spec.ts
@@ -27,7 +27,7 @@ const emptyFolderMessage = 'This folder is empty.';
  * @returns Non-empty bucket error message.
  */
 const getNonEmptyBucketMessage = (bucketLabel: string) => {
-  return `Bucket ${bucketLabel} is not empty. Please delete all objects and try again.`;
+  return `The specified bucket '${bucketLabel}' is not empty. Please delete all objects before retrying.`;
 };
 
 /**

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectsTab/ObjectDetailsDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectsTab/ObjectDetailsDrawer.tsx
@@ -45,7 +45,7 @@ export const ObjectDetailsDrawer = React.memo(
     const isLoadingEndpoint = isLoadingEndpointData || !bucketsData;
 
     const bucket = bucketsData?.buckets.find(
-      ({ label }) => label === bucketName
+      ({ label, region }) => label === bucketName && region === clusterId
     );
 
     const { endpoint_type: endpointType } = bucket ?? {};

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/index.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/index.tsx
@@ -59,7 +59,9 @@ export const BucketDetailLanding = React.memo(() => {
     isPending,
   } = useObjectStorageBuckets();
 
-  const bucket = bucketsData?.buckets.find(({ label }) => label === bucketName);
+  const bucket = bucketsData?.buckets.find(
+    ({ label, region }) => label === bucketName && region === clusterId
+  );
 
   const {
     data: region,


### PR DESCRIPTION
## Description 📝

Bucket searching function fixed.

## How to test 🧪

- Run `pnpm dev`
- Create 2 buckets in two different regions, 
  one Gen1 and one Gen2, with the same label.
- Navigate to the Bucket Details page for the Gen2 bucket.
- Observe SSL/TLS tab hidden.
- Navigate to the Bucket Details -> Access tab.
- Observe CORS option not available warning.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>