### PR TITLE
fix: [UIE-10597] - Stale state issue in legacy-ACLP alerts save flow

### DIFF
--- a/packages/manager/.changeset/pr-13545-fixed-1774861891760.md
+++ b/packages/manager/.changeset/pr-13545-fixed-1774861891760.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Stale state issue in legacy-ACLP alerts save flow ([#13545](https://github.com/linode/manager/pull/13545))

--- a/packages/manager/src/features/CloudPulse/Alerts/ContextualView/AlertInformationActionTable.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/ContextualView/AlertInformationActionTable.tsx
@@ -63,7 +63,13 @@ export interface AlertInformationActionTableProps {
   /**
    * Called when an alert is toggled on or off.
    * @param payload enabled alerts ids
-   * @param hasUnsavedChanges boolean to check if there are unsaved changes
+   * @param hasUnsavedChanges boolean to check if there are unsaved changes.
+   * - NOTE: Should not be used by service types in SERVICES_WITH_EXTERNAL_SAVE — this value
+   * is derived from the query cache and can be stale in the window between save success and
+   * the invalidated query resolving. Any toggle during that window would produce an incorrect
+   * result. Those service owners should compute this themselves from the incoming payload,
+   * and also invalidate the alerts query after save so toggle rows show the correct state
+   * if the user navigates away and comes back.
    */
   onToggleAlert?: (
     payload: CloudPulseAlertsPayload,
@@ -113,7 +119,13 @@ export interface AlertRowPropsOptions {
   /**
    * Callback function to handle alert toggle
    * @param payload enabled alerts ids
-   * @param hasUnsavedChanges boolean to check if there are unsaved changes
+   * @param hasUnsavedChanges boolean to check if there are unsaved changes.
+   * - NOTE: Should not be used by service types in SERVICES_WITH_EXTERNAL_SAVE — this value
+   * is derived from the query cache and can be stale in the window between save success and
+   * the invalidated query resolving. Any toggle during that window would produce an incorrect
+   * result. Those service owners should compute this themselves from the incoming payload,
+   * and also invalidate the alerts query after save so toggle rows show the correct state
+   * if the user navigates away and comes back.
    */
   onToggleAlert?: (
     payload: CloudPulseAlertsPayload,

--- a/packages/manager/src/features/CloudPulse/Alerts/ContextualView/AlertReusableComponent.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/ContextualView/AlertReusableComponent.tsx
@@ -54,7 +54,7 @@ interface AlertReusableComponentProps {
    * Called when an alert is toggled on or off.
    * @param payload enabled alerts ids
    * @param hasUnsavedChanges boolean to check if there are unsaved changes.
-   * Should not be used by service types in SERVICES_WITH_EXTERNAL_SAVE — this value
+   * - NOTE: Should not be used by service types in SERVICES_WITH_EXTERNAL_SAVE — this value
    * is derived from the query cache and can be stale in the window between save success and
    * the invalidated query resolving. Any toggle during that window would produce an incorrect
    * result. Those service owners should compute this themselves from the incoming payload,

--- a/packages/manager/src/features/CloudPulse/Alerts/ContextualView/AlertReusableComponent.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/ContextualView/AlertReusableComponent.tsx
@@ -53,7 +53,13 @@ interface AlertReusableComponentProps {
   /**
    * Called when an alert is toggled on or off.
    * @param payload enabled alerts ids
-   * @param hasUnsavedChanges boolean to check if there are unsaved changes
+   * @param hasUnsavedChanges boolean to check if there are unsaved changes.
+   * Should not be used by service types in SERVICES_WITH_EXTERNAL_SAVE — this value
+   * is derived from the query cache and can be stale in the window between save success and
+   * the invalidated query resolving. Any toggle during that window would produce an incorrect
+   * result. Those service owners should compute this themselves from the incoming payload,
+   * and also invalidate the alerts query after save so toggle rows show the correct state
+   * if the user navigates away and comes back.
    */
   onToggleAlert?: (
     payload: CloudPulseAlertsPayload,

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeAlerts/LinodeAlerts.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeAlerts/LinodeAlerts.test.tsx
@@ -22,13 +22,18 @@ vi.mock('src/features/IAM/hooks/usePermissions', () => ({
   usePermissions: queryMocks.userPermissions,
 }));
 
-vi.mock('src/features/CloudPulse/Utils/utils', () => ({
-  useIsAclpSupportedRegion: queryMocks.useIsAclpSupportedRegion,
-}));
+vi.mock('src/features/CloudPulse/Utils/utils', async () => {
+  const actual = await vi.importActual('src/features/CloudPulse/Utils/utils');
+  return {
+    ...actual,
+    useIsAclpSupportedRegion: queryMocks.useIsAclpSupportedRegion,
+  };
+});
 
 // Keep AlertReusableComponent lightweight in tests - it has its own test coverage.
 // Renders a button so tests can simulate ACLP alert changes via onToggleAlert.
-// Calls onStatusChange(true) on mount to simulate a successful alerts load.
+// On mount, calls onStatusChange(true) and onToggleAlert({}) to simulate the real
+// component's initialization: reporting ready and sending the initial server state.
 vi.mock(
   'src/features/CloudPulse/Alerts/ContextualView/AlertReusableComponent',
   () => ({
@@ -37,17 +42,18 @@ vi.mock(
       onToggleAlert,
     }: {
       onStatusChange?: (isReady: boolean) => void;
-      onToggleAlert: (payload: unknown, hasUnsavedChanges: boolean) => void;
+      onToggleAlert: (payload: unknown) => void;
     }) => {
       React.useEffect(() => {
         onStatusChange?.(true);
-      }, [onStatusChange]);
+        onToggleAlert({});
+      }, []);
 
       return (
         <div data-testid="aclp-alerts">
           <button
             data-testid="aclp-toggle"
-            onClick={() => onToggleAlert({}, true)}
+            onClick={() => onToggleAlert({ system_alerts: [1] })}
           >
             Toggle ACLP Alert
           </button>
@@ -195,6 +201,7 @@ describe('LinodeAlerts — unified mode (aclpServices.linode.alerts.enabled + re
     const saveBtn = getByTestId('unified-alerts-save');
     expect(saveBtn).toHaveAttribute('aria-disabled', 'true');
 
+    // Simulate the user toggling an alert away from the initial state.
     await userEvent.click(getByTestId('aclp-toggle'));
 
     await waitFor(() => {

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeAlerts/LinodeAlerts.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeAlerts/LinodeAlerts.tsx
@@ -21,7 +21,10 @@ import * as React from 'react';
 import { ConfirmationDialog } from 'src/components/ConfirmationDialog/ConfirmationDialog';
 import { DismissibleBanner } from 'src/components/DismissibleBanner/DismissibleBanner';
 import { AlertReusableComponent } from 'src/features/CloudPulse/Alerts/ContextualView/AlertReusableComponent';
-import { useIsAclpSupportedRegion } from 'src/features/CloudPulse/Utils/utils';
+import {
+  arraysEqual,
+  useIsAclpSupportedRegion,
+} from 'src/features/CloudPulse/Utils/utils';
 import { usePermissions } from 'src/features/IAM/hooks/usePermissions';
 import { useFlags } from 'src/hooks/useFlags';
 import { invalidateAclpAlerts } from 'src/queries/cloudpulse/useAlertsMutation';
@@ -30,6 +33,17 @@ import { AlertsPanel } from './AlertsPanel';
 import { getLinodeAlertsInitialValues } from './utilities';
 
 import type { APIError, CloudPulseAlertsPayload, Linode } from '@linode/api-v4';
+
+/**
+ * Returns true if two ACLP alert payloads contain the same alert IDs,
+ * regardless of array order.
+ */
+const aclpPayloadsEqual = (
+  a: CloudPulseAlertsPayload,
+  b: CloudPulseAlertsPayload
+): boolean =>
+  arraysEqual(a.system_alerts, b.system_alerts) &&
+  arraysEqual(a.user_alerts, b.user_alerts);
 
 const LinodeAlerts = () => {
   const { linodeId } = useParams({ from: '/linodes/$linodeId' });
@@ -74,24 +88,11 @@ const LinodeAlerts = () => {
 
   // Holds what was last saved (or the initial server state on mount).
   // We compare incoming payloads against this to decide if there are unsaved
-  // changes, rather than relying on the child component's hasUnsavedChanges
+  // changes, rather than relying on the ACLP reusable component's hasUnsavedChanges
   // which can briefly be stale right after a save while the cache refetches.
-  const lastSavedAclpPayloadRef = React.useRef<
-    CloudPulseAlertsPayload | undefined
-  >(undefined);
-
-  // Compares two ACLP payloads regardless of array order.
-  const aclpPayloadsEqual = (
-    a: CloudPulseAlertsPayload,
-    b: CloudPulseAlertsPayload
-  ) => {
-    const sort = (arr: number[] | undefined) =>
-      [...(arr ?? [])].sort((x, y) => x - y).join(',');
-    return (
-      sort(a.system_alerts) === sort(b.system_alerts) &&
-      sort(a.user_alerts) === sort(b.user_alerts)
-    );
-  };
+  const savedAclpPayloadRef = React.useRef<CloudPulseAlertsPayload | undefined>(
+    undefined
+  );
 
   // Track whether ACLP alerts have finished loading without error
   const [isAclpAlertsReady, setIsAclpAlertsReady] =
@@ -144,6 +145,25 @@ const LinodeAlerts = () => {
     }
   }, [status, reset]);
 
+  // Handles ACLP alert toggle changes from AlertReusableComponent.
+  // On the first call (mount), captures the initial server state as what was last saved.
+  // On subsequent calls, checks whether the incoming payload differs from what was last saved.
+  const handleAclpAlertsToggle = React.useCallback(
+    (payload: CloudPulseAlertsPayload) => {
+      setAclpAlertsPayload(payload);
+      if (savedAclpPayloadRef.current === undefined) {
+        // First call on mount - treat this as the initial saved state.
+        savedAclpPayloadRef.current = payload;
+        setHasAclpAlertsUnsavedChanges(false);
+      } else {
+        setHasAclpAlertsUnsavedChanges(
+          !aclpPayloadsEqual(payload, savedAclpPayloadRef.current)
+        );
+      }
+    },
+    []
+  );
+
   // Unified save handler for both legacy and ACLP alerts
   const handleUnifiedSave = React.useCallback(
     async (legacyAlertsValues: Linode['alerts']) => {
@@ -159,7 +179,7 @@ const LinodeAlerts = () => {
           setHasLegacyAlertsUnsavedChanges(false);
           setHasAclpAlertsUnsavedChanges(false);
           // Update the reference point so the next toggle compares against what was just saved.
-          lastSavedAclpPayloadRef.current = aclpAlertsPayload;
+          savedAclpPayloadRef.current = aclpAlertsPayload;
           // Invalidate the cache so row checkboxes show the correct state if the user returns to this page.
           invalidateAclpAlerts(
             queryClient,
@@ -235,103 +255,93 @@ const LinodeAlerts = () => {
           )}
         {isAclpAlertingInRegionEnabled ? (
           // Unified mode - both Legacy Alerts and ACLP Alerts are displayed with a shared save button.
-          <Paper ref={unifiedAlertsContainerRef}>
-            {/* Display general mutation error globally for unified save */}
-            {generalOrRootError && (
-              <Notice
-                sx={(theme) => ({ mb: theme.spacingFunction(8) })}
-                variant="error"
-              >
-                {generalOrRootError}
-              </Notice>
-            )}
-            <Formik
-              enableReinitialize
-              initialValues={initialValues}
-              onSubmit={handleUnifiedSave}
-              validateOnChange
-              validationSchema={UpdateLinodeAlertsSchema}
-            >
-              {(formik) => (
-                <Stack divider={<Divider />}>
-                  {/* Legacy Alerts View when ACLP alerting is enabled */}
-                  <Accordion
-                    defaultExpanded
-                    detailProps={{ sx: { p: 0 } }}
-                    heading="Legacy Alerts"
-                    summaryProps={{ sx: { p: 0 } }}
-                  >
-                    <AlertsPanel
-                      error={mutationError}
-                      formik={formik}
-                      isAclpAlertingInRegionEnabled={
-                        isAclpAlertingInRegionEnabled
-                      }
-                      isReadOnly={!permissions.update_linode}
-                      isSaving={isUpdatingLinode}
-                      linodeId={id}
-                      onUnsavedChangesUpdate={setHasLegacyAlertsUnsavedChanges}
-                      paperSx={(theme) => ({
-                        px: 0,
-                        py: theme.spacingFunction(8),
-                      })}
-                    />
-                  </Accordion>
-
-                  {/* ACLP Alerts View when ACLP alerting is enabled */}
-                  <Accordion
-                    defaultExpanded
-                    detailProps={{ sx: { p: 0 } }}
-                    disableGutters // Removes unnecessary default margins when stacking Accordions
-                    heading="Alerts"
-                    headingChip={getFeatureChip(aclpAlerting ?? {})}
-                    summaryProps={{ sx: { p: 0 } }}
-                  >
-                    <AlertReusableComponent
-                      entityId={linodeId.toString()}
-                      entityName={linode?.label ?? ''}
-                      onStatusChange={setIsAclpAlertsReady}
-                      onToggleAlert={(payload) => {
-                        setAclpAlertsPayload(payload);
-                        if (lastSavedAclpPayloadRef.current === undefined) {
-                          // First call on mount — treat this as the initial saved state.
-                          lastSavedAclpPayloadRef.current = payload;
-                          setHasAclpAlertsUnsavedChanges(false);
-                        } else {
-                          setHasAclpAlertsUnsavedChanges(
-                            !aclpPayloadsEqual(
-                              payload,
-                              lastSavedAclpPayloadRef.current
-                            )
-                          );
+          <Formik
+            enableReinitialize
+            initialValues={initialValues}
+            onSubmit={handleUnifiedSave}
+            validateOnChange
+            validationSchema={UpdateLinodeAlertsSchema}
+          >
+            {(formik) => (
+              <>
+                <Paper ref={unifiedAlertsContainerRef}>
+                  {/* Display general mutation error globally for unified save */}
+                  {generalOrRootError && (
+                    <Notice
+                      sx={(theme) => ({ mb: theme.spacingFunction(8) })}
+                      variant="error"
+                    >
+                      {generalOrRootError}
+                    </Notice>
+                  )}
+                  <Stack divider={<Divider />}>
+                    {/* Legacy Alerts View when ACLP alerting is enabled */}
+                    <Accordion
+                      defaultExpanded
+                      detailProps={{ sx: { p: 0 } }}
+                      heading="Legacy Alerts"
+                      summaryProps={{ sx: { p: 0 } }}
+                    >
+                      <AlertsPanel
+                        error={mutationError}
+                        formik={formik}
+                        isAclpAlertingInRegionEnabled={
+                          isAclpAlertingInRegionEnabled
                         }
-                      }}
-                      paperSx={(theme) => ({
-                        px: 0,
-                        py: theme.spacingFunction(16),
-                      })}
-                      serviceType="linode"
-                    />
-                  </Accordion>
+                        isReadOnly={!permissions.update_linode}
+                        isSaving={isUpdatingLinode}
+                        linodeId={id}
+                        onUnsavedChangesUpdate={
+                          setHasLegacyAlertsUnsavedChanges
+                        }
+                        paperSx={(theme) => ({
+                          px: 0,
+                          py: theme.spacingFunction(8),
+                        })}
+                      />
+                    </Accordion>
 
-                  {/* Unified Save Button */}
-                  <ActionsPanel
-                    primaryButtonProps={{
-                      'data-testid': 'unified-alerts-save',
-                      disabled:
-                        (!formik.dirty && !hasAclpAlertsUnsavedChanges) ||
-                        !isAclpAlertsReady ||
-                        isUpdatingLinode,
-                      label: 'Save Alerts',
-                      loading: isUpdatingLinode,
-                      onClick: () => formik.handleSubmit(),
-                    }}
-                    sx={{ justifyContent: 'flex-start' }}
-                  />
-                </Stack>
-              )}
-            </Formik>
-          </Paper>
+                    {/* ACLP Alerts View when ACLP alerting is enabled */}
+                    <Accordion
+                      defaultExpanded
+                      detailProps={{ sx: { p: 0 } }}
+                      disableGutters // Removes unnecessary default margins when stacking Accordions
+                      heading="Alerts"
+                      headingChip={getFeatureChip(aclpAlerting ?? {})}
+                      summaryProps={{ sx: { p: 0 } }}
+                    >
+                      <AlertReusableComponent
+                        entityId={linodeId.toString()}
+                        entityName={linode?.label ?? ''}
+                        onStatusChange={setIsAclpAlertsReady}
+                        onToggleAlert={handleAclpAlertsToggle}
+                        paperSx={(theme) => ({
+                          px: 0,
+                          py: theme.spacingFunction(16),
+                        })}
+                        serviceType="linode"
+                      />
+                    </Accordion>
+                  </Stack>
+                </Paper>
+
+                {/* Unified Save Button */}
+                <ActionsPanel
+                  primaryButtonProps={{
+                    'data-testid': 'unified-alerts-save',
+                    disabled:
+                      (!formik.dirty && !hasAclpAlertsUnsavedChanges) ||
+                      !isAclpAlertsReady ||
+                      isUpdatingLinode,
+                    label: 'Save Alerts',
+                    loading: isUpdatingLinode,
+                    onClick: () => formik.handleSubmit(),
+                  }}
+                  sx={{ justifyContent: 'flex-end' }}
+                />
+              </>
+            )}
+          </Formik>
         ) : (
           // Standalone mode - only Legacy Alerts are displayed and AlertsPanel manages its own save.
           <AlertsPanel

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeAlerts/LinodeAlerts.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeAlerts/LinodeAlerts.tsx
@@ -93,8 +93,8 @@ const LinodeAlerts = () => {
   // synchronously on save so the next toggle reflects the correct Save Alerts button state immediately.
   //
   // Note: invalidateAclpAlerts is also called after every save — it solves a
-  // separate concern: keeping the toggle row checkboxes correct by refreshing
-  // entity_ids in the alerts cache. Without it, the checkboxes would show stale state.
+  // separate concern: keeping the toggle row state correct by refreshing
+  // entity_ids in the alerts cache. Without it, the toggles would show stale state.
   const savedAclpPayloadRef = React.useRef<CloudPulseAlertsPayload | undefined>(
     undefined
   );
@@ -185,7 +185,8 @@ const LinodeAlerts = () => {
           setHasAclpAlertsUnsavedChanges(false);
           // Update the reference point so the next toggle compares against what was just saved.
           savedAclpPayloadRef.current = aclpAlertsPayload;
-          // Invalidate the cache so row checkboxes show the correct state if the user returns to this page.
+          // Invalidate the cache so alert toggles show the correct ON/OFF state
+          // after save and when the user navigates away and comes back.
           invalidateAclpAlerts(
             queryClient,
             'linode',

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeAlerts/LinodeAlerts.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeAlerts/LinodeAlerts.tsx
@@ -86,10 +86,15 @@ const LinodeAlerts = () => {
     CloudPulseAlertsPayload | undefined
   >();
 
-  // Holds what was last saved (or the initial server state on mount).
+  // Tracks what was last saved (or the initial server state on first load).
   // We compare incoming payloads against this to decide if there are unsaved
-  // changes, rather than relying on the ACLP reusable component's hasUnsavedChanges
-  // which can briefly be stale right after a save while the cache refetches.
+  // changes, rather than relying on the AlertReusableComponent's `hasUnsavedChanges`
+  // which can be stale right after a save while the cache refetches. Updated
+  // synchronously on save so the next toggle reflects the correct Save Alerts button state immediately.
+  //
+  // Note: invalidateAclpAlerts is also called after every save — it solves a
+  // separate concern: keeping the toggle row checkboxes correct by refreshing
+  // entity_ids in the alerts cache. Without it, the checkboxes would show stale state.
   const savedAclpPayloadRef = React.useRef<CloudPulseAlertsPayload | undefined>(
     undefined
   );

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeAlerts/LinodeAlerts.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeAlerts/LinodeAlerts.tsx
@@ -270,7 +270,10 @@ const LinodeAlerts = () => {
           >
             {(formik) => (
               <>
-                <Paper ref={unifiedAlertsContainerRef}>
+                <Paper
+                  ref={unifiedAlertsContainerRef}
+                  sx={(theme) => ({ pb: theme.spacingFunction(16) })}
+                >
                   {/* Display general mutation error globally for unified save */}
                   {generalOrRootError && (
                     <Notice

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeAlerts/LinodeAlerts.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeAlerts/LinodeAlerts.tsx
@@ -12,6 +12,7 @@ import {
 } from '@linode/ui';
 import { scrollErrorIntoViewV2 } from '@linode/utilities';
 import { UpdateLinodeAlertsSchema } from '@linode/validation';
+import { useQueryClient } from '@tanstack/react-query';
 import { useBlocker, useParams } from '@tanstack/react-router';
 import { Formik } from 'formik';
 import { useSnackbar } from 'notistack';
@@ -23,6 +24,7 @@ import { AlertReusableComponent } from 'src/features/CloudPulse/Alerts/Contextua
 import { useIsAclpSupportedRegion } from 'src/features/CloudPulse/Utils/utils';
 import { usePermissions } from 'src/features/IAM/hooks/usePermissions';
 import { useFlags } from 'src/hooks/useFlags';
+import { invalidateAclpAlerts } from 'src/queries/cloudpulse/useAlertsMutation';
 
 import { AlertsPanel } from './AlertsPanel';
 import { getLinodeAlertsInitialValues } from './utilities';
@@ -48,6 +50,7 @@ const LinodeAlerts = () => {
     aclpServices?.linode?.alerts?.enabled && isAclpAlertsSupportedRegionLinode;
 
   const { enqueueSnackbar } = useSnackbar();
+  const queryClient = useQueryClient();
 
   const {
     error: mutationError,
@@ -68,6 +71,27 @@ const LinodeAlerts = () => {
   const [aclpAlertsPayload, setAclpAlertsPayload] = React.useState<
     CloudPulseAlertsPayload | undefined
   >();
+
+  // Holds what was last saved (or the initial server state on mount).
+  // We compare incoming payloads against this to decide if there are unsaved
+  // changes, rather than relying on the child component's hasUnsavedChanges
+  // which can briefly be stale right after a save while the cache refetches.
+  const lastSavedAclpPayloadRef = React.useRef<
+    CloudPulseAlertsPayload | undefined
+  >(undefined);
+
+  // Compares two ACLP payloads regardless of array order.
+  const aclpPayloadsEqual = (
+    a: CloudPulseAlertsPayload,
+    b: CloudPulseAlertsPayload
+  ) => {
+    const sort = (arr: number[] | undefined) =>
+      [...(arr ?? [])].sort((x, y) => x - y).join(',');
+    return (
+      sort(a.system_alerts) === sort(b.system_alerts) &&
+      sort(a.user_alerts) === sort(b.user_alerts)
+    );
+  };
 
   // Track whether ACLP alerts have finished loading without error
   const [isAclpAlertsReady, setIsAclpAlertsReady] =
@@ -129,11 +153,20 @@ const LinodeAlerts = () => {
       };
       await updateLinode({ alerts: combinedAlertsPayload })
         .then(() => {
-          enqueueSnackbar('Alert settings have been saved successfully', {
+          enqueueSnackbar('All your settings for Alerts have been saved.', {
             variant: 'success',
           });
           setHasLegacyAlertsUnsavedChanges(false);
           setHasAclpAlertsUnsavedChanges(false);
+          // Update the reference point so the next toggle compares against what was just saved.
+          lastSavedAclpPayloadRef.current = aclpAlertsPayload;
+          // Invalidate the cache so row checkboxes show the correct state if the user returns to this page.
+          invalidateAclpAlerts(
+            queryClient,
+            'linode',
+            linodeId.toString(),
+            aclpAlertsPayload ?? {}
+          );
         })
         .catch((errors) => {
           if (errors && unifiedAlertsContainerRef.current) {
@@ -141,7 +174,7 @@ const LinodeAlerts = () => {
           }
         });
     },
-    [aclpAlertsPayload, updateLinode, enqueueSnackbar]
+    [aclpAlertsPayload, updateLinode, enqueueSnackbar, queryClient, linodeId]
   );
 
   return (
@@ -258,11 +291,20 @@ const LinodeAlerts = () => {
                       entityId={linodeId.toString()}
                       entityName={linode?.label ?? ''}
                       onStatusChange={setIsAclpAlertsReady}
-                      onToggleAlert={(payload, hasUnsavedChanges) => {
+                      onToggleAlert={(payload) => {
                         setAclpAlertsPayload(payload);
-                        setHasAclpAlertsUnsavedChanges(
-                          hasUnsavedChanges ?? false
-                        );
+                        if (lastSavedAclpPayloadRef.current === undefined) {
+                          // First call on mount — treat this as the initial saved state.
+                          lastSavedAclpPayloadRef.current = payload;
+                          setHasAclpAlertsUnsavedChanges(false);
+                        } else {
+                          setHasAclpAlertsUnsavedChanges(
+                            !aclpPayloadsEqual(
+                              payload,
+                              lastSavedAclpPayloadRef.current
+                            )
+                          );
+                        }
                       }}
                       paperSx={(theme) => ({
                         px: 0,


### PR DESCRIPTION
## Description 📝

Fixes a stale state issue in the unified ACLP alerts save flow where `hasUnsavedChanges` computed by the ACLP reusable component becomes unreliable after a parent-consumer level save. 

### Root cause 🐞
  The ACLP reusable component (AlertReusableComponent -> AlertInformationActionTable) derives its initialState from the alerts query cache. However, for certain service types (e.g., Linode), save responsibility was moved to the parent level/service owner (LinodeAlerts), and the query cache is not immediately updated after a save. This occurs because the Linode service consumer uses a different Linode Update API than the alerts definitions query that the Alerts reusable component relies on to derive its `initialState`

  This results in `initialState` becoming stale, causing downstream state comparisons (like `hasUnsavedChanges`) to be computed against outdated data.

## Changes  🔄
- Bug Fix related:
  - Added `savedAclpPayloadRef` in `LinodeAlerts` to track the last saved ACLP payload as the reference point
  - Parent now computes `hasAclpAlertsUnsavedChanges` by comparing incoming payload from AlertReusableComponent's `onToggleAlert` directly against the ref - ignoring this component's `hasUnsavedChanges` prop entirely 
  - Ref is synchronously (in advance) after a successful save, with no dependency on query cache refetch 
  - `invalidateAclpAlerts` is still called after save to keep query cache fresh for correct toggle row state on page revisit
- Minor Styling updates:
  - Moved the `Save Alerts` button outside of the Paper and aligned it to the right as per the latest UX Figma mockups
  - Updated the `Save Alerts` success message from `Alert settings have been saved successfully` -> `All your settings for Alerts have been saved.` 

### Scope 🚢

- [ ] All customers
- [x] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️
April

## Preview 📷

| Before  | After   |
| ------- | ------- |
| Save Alerts button stays disabled after saving and toggling back to pre-save state: <video src="https://github.com/user-attachments/assets/496f6ecf-ab5b-40d0-b676-92b501954dad" /> | Should fix Save Alerts button stale state issue ✅ |
| Unsaved changes modal not appearing due to stale state issue: <video src="https://github.com/user-attachments/assets/6de63cd9-cafd-423b-980a-3bde3bdfaf19" /> | Should fix the Unsaved changes modal issue ✅ |
| ![Screenshot 2026-03-30 at 3 10 01 PM](https://github.com/user-attachments/assets/ce29d8dc-6696-4b78-9d90-6ef7cd188cc6) | `Save Alerts` button is moved outside of the Paper and aligned it to the right ![Screenshot 2026-03-30 at 3 09 15 PM](https://github.com/user-attachments/assets/e88fd8d2-2db5-4bd3-b427-2a241498485d) | 
| ![Screenshot 2026-03-30 at 3 12 53 PM](https://github.com/user-attachments/assets/ad2bd5ac-106c-4288-a35f-2ed016c20877) | `Save Alerts` success message is updated ![Screenshot 2026-03-30 at 3 13 27 PM](https://github.com/user-attachments/assets/85277faf-a8c6-4bb4-9b54-32ed6c661d41) | 

## How to test 🧪

### Prerequisites

- Test on devcloud environment
- Ensure customer tag (mentioned in the epic ticket) is added to you admin devcloud account

### Reproduction steps
1. Open a Linode detail page -> Alerts tab (with ACLP alerting enabled in the region)
2. Toggle any ACLP alert ON (Save button enables)
3. Click Save Alerts (Save button disables - saved successfully)
4. Toggle that same alert back OFF (back to original state)
     - Expected: Save button enables (state differs from saved state)
     - Actual: Save button stays disabled ❌
5. Try navigating away - Unsaved modal also doesn't appear ❌
6. Start again with step 2 & 3 and Navigate to another tab and come back
    - Actual: The updated toggle state is not reflected (shows previous state) ❌
    - A manual refresh is required to see the correct state ❌

### Verification steps
1. Open a Linode detail page and go to the Alerts tab (with ACLP alerting enabled).
2. Toggle any alert -> ensure the Save button is enabled ✅
3. Click Save -> ensure the Save button is disabled ✅
4. Toggle the same alert back -> ensure the Save button is enabled ✅
5. Navigate away -> ensure the Unsaved Changes modal appears ✅
6. Save again, navigate away, then return to the page/tab -> ensure the toggle rows reflect the saved state ✅

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

</details>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules