### PR TITLE
upcoming: [UIE-10430] - Reserved IP: Implement Landing Screen.

### DIFF
--- a/packages/manager/.changeset/pr-13549-upcoming-features-1774976696073.md
+++ b/packages/manager/.changeset/pr-13549-upcoming-features-1774976696073.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Implemented Reserved IPs Landing Page ([#13549](https://github.com/linode/manager/pull/13549))

--- a/packages/manager/src/factories/networking.ts
+++ b/packages/manager/src/factories/networking.ts
@@ -17,3 +17,55 @@ export const ipAddressFactory = Factory.Sync.makeFactory<IPAddress>({
   reserved: false,
   tags: [],
 });
+
+const REGIONS = ['pl-labkrk-2', 'us-labedgeeat-2', 'us-labedgeeat-3'];
+const SAMPLE_TAGS = [
+  ['web', 'production', 'db', 'staging', 'lb', 'api', 'internal'],
+  ['db', 'staging'],
+  ['lb'],
+  ['api', 'internal'],
+  [],
+];
+const SAMPLE_ENTITIES: Array<IPAddress['assigned_entity']> = [
+  {
+    id: 1,
+    label: 'web-server-01',
+    type: 'linode',
+    url: '/v4/linode/instances/1',
+  },
+  {
+    id: 2,
+    label: 'ubuntu-pl-labkrk-2',
+    type: 'linode',
+    url: '/v4/linode/instances/2',
+  },
+  null,
+  {
+    id: 5,
+    label: 'my-nodebalancer',
+    type: 'nodebalancer',
+    url: '/v4/nodebalancers/5',
+  },
+  null,
+];
+
+export const reservedIPsFactory = Factory.Sync.makeFactory<IPAddress>({
+  address: Factory.each((id) => `203.0.113.${id}`),
+  assigned_entity: Factory.each(
+    (id) => SAMPLE_ENTITIES[id % SAMPLE_ENTITIES.length]
+  ),
+  gateway: '203.0.113.1',
+  interface_id: null,
+  linode_id: Factory.each((id) => {
+    const entity = SAMPLE_ENTITIES[id % SAMPLE_ENTITIES.length];
+    return entity?.type === 'linode' ? entity.id : null;
+  }),
+  prefix: 24,
+  public: true,
+  rdns: '172-24-226-80.ip.linodeusercontent.com',
+  region: Factory.each((id) => REGIONS[id % REGIONS.length]),
+  reserved: true,
+  subnet_mask: '255.255.255.0',
+  tags: Factory.each((id) => SAMPLE_TAGS[id % SAMPLE_TAGS.length]),
+  type: 'ipv4',
+});

--- a/packages/manager/src/features/ReservedIps/ReservedIpsLanding/ReservedIpsActionMenu.test.tsx
+++ b/packages/manager/src/features/ReservedIps/ReservedIpsLanding/ReservedIpsActionMenu.test.tsx
@@ -1,0 +1,62 @@
+import { userEvent } from '@testing-library/user-event';
+import * as React from 'react';
+
+import { reservedIPsFactory } from 'src/factories/networking';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { ReservedIpsActionMenu } from './ReservedIpsActionMenu';
+
+import type { ReservedIpsActionHandlers } from './ReservedIpsActionMenu';
+
+describe('ReservedIpsActionMenu', () => {
+  const mockHandlers: ReservedIpsActionHandlers = {
+    onEdit: vi.fn(),
+    onUnreserve: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the action menu with the correct aria-label', () => {
+    const ip = reservedIPsFactory.build({ address: '203.0.113.5' });
+
+    const { getByLabelText } = renderWithTheme(
+      <ReservedIpsActionMenu handlers={mockHandlers} ip={ip} />
+    );
+
+    expect(
+      getByLabelText('Action menu for Reserved IP 203.0.113.5')
+    ).toBeVisible();
+  });
+
+  it('calls onEdit when Edit is clicked', async () => {
+    const ip = reservedIPsFactory.build();
+
+    const { getByLabelText, getByText } = renderWithTheme(
+      <ReservedIpsActionMenu handlers={mockHandlers} ip={ip} />
+    );
+
+    await userEvent.click(
+      getByLabelText(`Action menu for Reserved IP ${ip.address}`)
+    );
+    await userEvent.click(getByText('Edit'));
+
+    expect(mockHandlers.onEdit).toHaveBeenCalledWith(ip);
+  });
+
+  it('calls onUnreserve when Unreserve is clicked', async () => {
+    const ip = reservedIPsFactory.build();
+
+    const { getByLabelText, getByText } = renderWithTheme(
+      <ReservedIpsActionMenu handlers={mockHandlers} ip={ip} />
+    );
+
+    await userEvent.click(
+      getByLabelText(`Action menu for Reserved IP ${ip.address}`)
+    );
+    await userEvent.click(getByText('Unreserve'));
+
+    expect(mockHandlers.onUnreserve).toHaveBeenCalledWith(ip);
+  });
+});

--- a/packages/manager/src/features/ReservedIps/ReservedIpsLanding/ReservedIpsActionMenu.tsx
+++ b/packages/manager/src/features/ReservedIps/ReservedIpsLanding/ReservedIpsActionMenu.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+
+import { ActionMenu } from 'src/components/ActionMenu/ActionMenu';
+
+import type { IPAddress } from '@linode/api-v4';
+import type { Action } from 'src/components/ActionMenu/ActionMenu';
+
+export interface ReservedIpsActionHandlers {
+  onEdit: (ip: IPAddress) => void;
+  onUnreserve: (ip: IPAddress) => void;
+}
+
+interface Props {
+  handlers: ReservedIpsActionHandlers;
+  ip: IPAddress;
+}
+
+export const ReservedIpsActionMenu = ({ handlers, ip }: Props) => {
+  const actions: Action[] = [
+    {
+      onClick: () => handlers.onEdit(ip),
+      title: 'Edit',
+    },
+    {
+      onClick: () => handlers.onUnreserve(ip),
+      title: 'Unreserve',
+    },
+  ];
+
+  return (
+    <ActionMenu
+      actionsList={actions}
+      ariaLabel={`Action menu for Reserved IP ${ip.address}`}
+    />
+  );
+};

--- a/packages/manager/src/features/ReservedIps/ReservedIpsLanding/ReservedIpsLanding.test.tsx
+++ b/packages/manager/src/features/ReservedIps/ReservedIpsLanding/ReservedIpsLanding.test.tsx
@@ -1,98 +1,207 @@
+import { fireEvent, waitForElementToBeRemoved } from '@testing-library/react';
 import * as React from 'react';
 
-import { routeTree } from 'src/routes';
-import { renderWithTheme } from 'src/utilities/testHelpers';
+import { reservedIPsFactory } from 'src/factories/networking';
+import { makeResourcePage } from 'src/mocks/serverHandlers';
+import { http, HttpResponse, server } from 'src/mocks/testServer';
+import { mockMatchMedia, renderWithTheme } from 'src/utilities/testHelpers';
 
 import { ReservedIpsLanding } from './ReservedIpsLanding';
+import { headers } from './ReservedIpsLandingEmptyStateData';
 
-const mockQueryReturn = vi.hoisted(() =>
-  vi.fn().mockReturnValue({
-    data: undefined,
-    error: null,
-    isLoading: true,
-  })
-);
+const queryMocks = vi.hoisted(() => ({
+  useProfile: vi.fn().mockReturnValue({ data: { restricted: false } }),
+}));
 
 vi.mock('@linode/queries', async () => {
   const actual = await vi.importActual('@linode/queries');
   return {
     ...actual,
-    useReservedIPsQuery: mockQueryReturn,
+    useProfile: queryMocks.useProfile,
   };
 });
 
-describe('ReservedIpsLanding', () => {
-  it('renders a loading state while data is fetching', () => {
-    const { getByTestId } = renderWithTheme(<ReservedIpsLanding />, {
-      initialRoute: '/reserved-ips',
-      routeTree,
-    });
+beforeAll(() => mockMatchMedia());
 
-    expect(getByTestId('circle-progress')).toBeInTheDocument();
+const loadingTestId = 'circle-progress';
+const reservedIPsEndpoint = '*/networking/reserved/ips';
+
+describe('Reserved IPs Landing', () => {
+  it('renders loading state initially', async () => {
+    server.use(
+      http.get(reservedIPsEndpoint, () => {
+        return HttpResponse.json(makeResourcePage([]));
+      })
+    );
+
+    const { getByTestId } = renderWithTheme(<ReservedIpsLanding />);
+
+    expect(getByTestId(loadingTestId)).toBeInTheDocument();
+
+    await waitForElementToBeRemoved(getByTestId(loadingTestId), {
+      timeout: 3000,
+    });
   });
 
-  it('renders an error state when the query fails', () => {
-    mockQueryReturn.mockReturnValue({
-      data: undefined,
-      error: [{ reason: 'Something went wrong.' }],
-      isLoading: false,
-    });
+  it('renders the empty state when there are no reserved IPs', async () => {
+    server.use(
+      http.get(reservedIPsEndpoint, () => {
+        return HttpResponse.json(makeResourcePage([]));
+      })
+    );
 
-    const { getByText } = renderWithTheme(<ReservedIpsLanding />, {
-      initialRoute: '/reserved-ips',
-      routeTree,
-    });
+    const { getByTestId, getByText } = renderWithTheme(<ReservedIpsLanding />);
 
-    expect(getByText('Something went wrong.')).toBeVisible();
+    await waitForElementToBeRemoved(getByTestId(loadingTestId));
+
+    expect(getByText(headers.description)).toBeInTheDocument();
   });
 
-  it('renders the empty state when there are no reserved IPs', () => {
-    mockQueryReturn.mockReturnValue({
-      data: { data: [], results: 0 },
-      error: null,
-      isLoading: false,
+  it('renders the table with reserved IPs', async () => {
+    const reservedIPs = reservedIPsFactory.buildList(3, {
+      region: 'us-east',
+      reserved: true,
     });
 
-    const { getByText } = renderWithTheme(<ReservedIpsLanding />, {
-      initialRoute: '/reserved-ips',
-      routeTree,
+    server.use(
+      http.get(reservedIPsEndpoint, () => {
+        return HttpResponse.json(makeResourcePage(reservedIPs));
+      })
+    );
+
+    const { getAllByText, getByTestId, queryAllByText } = renderWithTheme(
+      <ReservedIpsLanding />
+    );
+
+    await waitForElementToBeRemoved(getByTestId(loadingTestId), {
+      timeout: 3000,
     });
 
-    expect(getByText('Reserve an IP Address')).toBeVisible();
+    // Table column headers
+    getAllByText('IP Address');
+    getAllByText('Assigned Resource');
+    getAllByText('Region');
+    getAllByText('Tags');
+
+    // Check mocked IP addresses rendered in the table
+    queryAllByText(reservedIPs[0].address);
   });
 
-  it('renders the table when reserved IPs are returned', () => {
-    mockQueryReturn.mockReturnValue({
-      data: {
-        data: [
-          {
-            address: '203.0.113.1',
-            assigned_entity: null,
-            gateway: '203.0.113.0',
-            interface_id: null,
-            linode_id: null,
-            prefix: 24,
-            public: true,
-            rdns: null,
-            region: 'us-east',
-            reserved: true,
-            subnet_mask: '255.255.255.0',
-            tags: ['web'],
-            type: 'ipv4',
-          },
-        ],
-        results: 1,
-      },
-      error: null,
-      isLoading: false,
+  it('renders the "Reserve an IP Address" button', async () => {
+    server.use(
+      http.get(reservedIPsEndpoint, () => {
+        return HttpResponse.json(makeResourcePage([]));
+      })
+    );
+
+    const { container, getByTestId } = renderWithTheme(<ReservedIpsLanding />);
+
+    await waitForElementToBeRemoved(getByTestId(loadingTestId));
+
+    const reserveIPButton = container.querySelector('button');
+
+    expect(reserveIPButton).toBeInTheDocument();
+    expect(reserveIPButton).toHaveTextContent('Reserve an IP Address');
+  });
+
+  it('renders a row with action menu for each reserved IP', async () => {
+    const reservedIPs = reservedIPsFactory.buildList(3, {
+      assigned_entity: null,
+      reserved: true,
     });
 
-    const { getByText } = renderWithTheme(<ReservedIpsLanding />, {
-      initialRoute: '/reserved-ips',
-      routeTree,
+    server.use(
+      http.get(reservedIPsEndpoint, () => {
+        return HttpResponse.json(makeResourcePage(reservedIPs));
+      })
+    );
+
+    const { getByLabelText, getByTestId } = renderWithTheme(
+      <ReservedIpsLanding />
+    );
+
+    await waitForElementToBeRemoved(getByTestId(loadingTestId), {
+      timeout: 3000,
     });
 
-    expect(getByText('Reserved IP Addresses')).toBeVisible();
-    expect(getByText('203.0.113.1')).toBeVisible();
+    const actionMenu = getByLabelText(
+      `Action menu for Reserved IP ${reservedIPs[0].address}`
+    );
+    expect(actionMenu).toBeInTheDocument();
+  });
+
+  it('opens the action menu with correct options', async () => {
+    const reservedIPs = reservedIPsFactory.buildList(1, {
+      assigned_entity: null,
+      reserved: true,
+    });
+
+    server.use(
+      http.get(reservedIPsEndpoint, () => {
+        return HttpResponse.json(makeResourcePage(reservedIPs));
+      })
+    );
+
+    const { getByLabelText, getByTestId, getByText } = renderWithTheme(
+      <ReservedIpsLanding />
+    );
+
+    await waitForElementToBeRemoved(getByTestId(loadingTestId), {
+      timeout: 3000,
+    });
+
+    const actionMenu = getByLabelText(
+      `Action menu for Reserved IP ${reservedIPs[0].address}`
+    );
+
+    await fireEvent.click(actionMenu);
+
+    getByText('Edit');
+    getByText('Unreserve');
+  });
+
+  describe('Restricted users', () => {
+    it('should have the "Reserve an IP Address" button disabled for restricted users', async () => {
+      queryMocks.useProfile.mockReturnValue({ data: { restricted: true } });
+
+      server.use(
+        http.get(reservedIPsEndpoint, () => {
+          return HttpResponse.json(makeResourcePage([]));
+        })
+      );
+
+      const { container, getByTestId } = renderWithTheme(
+        <ReservedIpsLanding />
+      );
+
+      await waitForElementToBeRemoved(getByTestId(loadingTestId));
+
+      const reserveIPButton = container.querySelector('button');
+
+      expect(reserveIPButton).toBeInTheDocument();
+      expect(reserveIPButton).toHaveTextContent('Reserve an IP Address');
+    });
+
+    it('should have the "Reserve an IP Address" button enabled for users with full access', async () => {
+      queryMocks.useProfile.mockReturnValue({ data: { restricted: false } });
+
+      server.use(
+        http.get(reservedIPsEndpoint, () => {
+          return HttpResponse.json(makeResourcePage([]));
+        })
+      );
+
+      const { container, getByTestId } = renderWithTheme(
+        <ReservedIpsLanding />
+      );
+
+      await waitForElementToBeRemoved(getByTestId(loadingTestId));
+
+      const reserveIPButton = container.querySelector('button');
+
+      expect(reserveIPButton).toBeInTheDocument();
+      expect(reserveIPButton).toHaveTextContent('Reserve an IP Address');
+      expect(reserveIPButton).toBeEnabled();
+    });
   });
 });

--- a/packages/manager/src/features/ReservedIps/ReservedIpsLanding/ReservedIpsLanding.test.tsx
+++ b/packages/manager/src/features/ReservedIps/ReservedIpsLanding/ReservedIpsLanding.test.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+
+import { routeTree } from 'src/routes';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { ReservedIpsLanding } from './ReservedIpsLanding';
+
+const mockQueryReturn = vi.hoisted(() =>
+  vi.fn().mockReturnValue({
+    data: undefined,
+    error: null,
+    isLoading: true,
+  })
+);
+
+vi.mock('@linode/queries', async () => {
+  const actual = await vi.importActual('@linode/queries');
+  return {
+    ...actual,
+    useReservedIPsQuery: mockQueryReturn,
+  };
+});
+
+describe('ReservedIpsLanding', () => {
+  it('renders a loading state while data is fetching', () => {
+    const { getByTestId } = renderWithTheme(<ReservedIpsLanding />, {
+      initialRoute: '/reserved-ips',
+      routeTree,
+    });
+
+    expect(getByTestId('circle-progress')).toBeInTheDocument();
+  });
+
+  it('renders an error state when the query fails', () => {
+    mockQueryReturn.mockReturnValue({
+      data: undefined,
+      error: [{ reason: 'Something went wrong.' }],
+      isLoading: false,
+    });
+
+    const { getByText } = renderWithTheme(<ReservedIpsLanding />, {
+      initialRoute: '/reserved-ips',
+      routeTree,
+    });
+
+    expect(getByText('Something went wrong.')).toBeVisible();
+  });
+
+  it('renders the empty state when there are no reserved IPs', () => {
+    mockQueryReturn.mockReturnValue({
+      data: { data: [], results: 0 },
+      error: null,
+      isLoading: false,
+    });
+
+    const { getByText } = renderWithTheme(<ReservedIpsLanding />, {
+      initialRoute: '/reserved-ips',
+      routeTree,
+    });
+
+    expect(getByText('Reserve an IP Address')).toBeVisible();
+  });
+
+  it('renders the table when reserved IPs are returned', () => {
+    mockQueryReturn.mockReturnValue({
+      data: {
+        data: [
+          {
+            address: '203.0.113.1',
+            assigned_entity: null,
+            gateway: '203.0.113.0',
+            interface_id: null,
+            linode_id: null,
+            prefix: 24,
+            public: true,
+            rdns: null,
+            region: 'us-east',
+            reserved: true,
+            subnet_mask: '255.255.255.0',
+            tags: ['web'],
+            type: 'ipv4',
+          },
+        ],
+        results: 1,
+      },
+      error: null,
+      isLoading: false,
+    });
+
+    const { getByText } = renderWithTheme(<ReservedIpsLanding />, {
+      initialRoute: '/reserved-ips',
+      routeTree,
+    });
+
+    expect(getByText('Reserved IP Addresses')).toBeVisible();
+    expect(getByText('203.0.113.1')).toBeVisible();
+  });
+});

--- a/packages/manager/src/features/ReservedIps/ReservedIpsLanding/ReservedIpsLanding.tsx
+++ b/packages/manager/src/features/ReservedIps/ReservedIpsLanding/ReservedIpsLanding.tsx
@@ -7,32 +7,24 @@ import { useOrderV2 } from 'src/hooks/useOrderV2';
 import { usePaginationV2 } from 'src/hooks/usePaginationV2';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
+import { ReserveIPDrawer } from '../ReserveIPDrawer';
 import { ReservedIpsLandingEmptyState } from './ReservedIpsLandingEmptyState';
 import { ReservedIpsLandingTable } from './ReservedIpsLandingTable';
 
+import type { ReserveIPDrawerMode } from '../ReserveIPDrawer';
 import type { ReservedIpsActionHandlers } from './ReservedIpsActionMenu';
+import type { IPAddress } from '@linode/api-v4';
 
 const preferenceKey = 'reserved-ips';
 
 export const ReservedIpsLanding = () => {
-  // TODO: These will be used by the Edit drawer and Unreserve dialog component
-  // const [_selectedIP, setSelectedIP] = React.useState<IPAddress>();
-  // const [isDrawerOpen, setIsDrawerOpen] = React.useState(false);
+  const [isDrawerOpen, setIsDrawerOpen] = React.useState(false);
+  const [drawerMode, setDrawerMode] =
+    React.useState<ReserveIPDrawerMode>('create');
+  const [selectedIP, setSelectedIP] = React.useState<IPAddress | undefined>();
 
-  // const [_isEditDrawerOpen, setIsEditDrawerOpen] = React.useState(false);
-
-  // const [_isUnreserveDialogOpen, setIsUnreserveDialogOpen] = React.useState(false);
-
-  const handlers: ReservedIpsActionHandlers = {
-    onEdit: (ip) => {
-      // setSelectedIP(ip);
-      // setIsEditDrawerOpen(true);
-    },
-    onUnreserve: (ip) => {
-      // setSelectedIP(ip);
-      // setIsUnreserveDialogOpen(true);
-    },
-  };
+  // TODO: Integrate Unreserve dialog
+  // const [isUnreserveDialogOpen, setIsUnreserveDialogOpen] = React.useState(false);
 
   const pagination = usePaginationV2({
     currentRoute: '/reserved-ips',
@@ -67,6 +59,30 @@ export const ReservedIpsLanding = () => {
     filter
   );
 
+  const openDrawer = (mode: ReserveIPDrawerMode, ip?: IPAddress) => {
+    setSelectedIP(ip);
+    setDrawerMode(mode);
+    setIsDrawerOpen(true);
+  };
+
+  const closeDrawer = () => {
+    setIsDrawerOpen(false);
+    setSelectedIP(undefined);
+  };
+
+  const handlers: ReservedIpsActionHandlers = {
+    onEdit: (ip) => openDrawer('edit', ip),
+    onUnreserve: (_ip) => {
+      // TODO: Integrate Unreserve dialog
+      // setSelectedIP(ip);
+      // setIsUnreserveDialogOpen(true);
+    },
+  };
+
+  if (isLoading) {
+    return <CircleProgress />;
+  }
+
   if (error) {
     return (
       <ErrorState
@@ -80,22 +96,27 @@ export const ReservedIpsLanding = () => {
     );
   }
 
-  if (isLoading) {
-    return <CircleProgress />;
-  }
-
-  if (!reservedIps?.data.length) {
-    return <ReservedIpsLandingEmptyState />;
+  if (reservedIps?.results === 0) {
+    return (
+      <>
+        <ReservedIpsLandingEmptyState
+          openReserveIPDrawer={() => openDrawer('create')}
+        />
+        <ReserveIPDrawer
+          ipAddress={selectedIP}
+          mode={drawerMode}
+          onClose={closeDrawer}
+          open={isDrawerOpen}
+        />
+      </>
+    );
   }
 
   return (
     <>
       <LandingHeader
         createButtonText="Reserve an IP Address"
-        onButtonClick={() => {
-          /*To be updated
-          setIsDrawerOpen(true) */
-        }}
+        onButtonClick={() => openDrawer('create')}
         spacingBottom={16}
         title="Reserved IP Addresses"
       />
@@ -107,6 +128,12 @@ export const ReservedIpsLanding = () => {
         orderBy={orderBy}
         pagination={pagination}
         results={reservedIps?.results}
+      />
+      <ReserveIPDrawer
+        ipAddress={selectedIP}
+        mode={drawerMode}
+        onClose={closeDrawer}
+        open={isDrawerOpen}
       />
     </>
   );

--- a/packages/manager/src/features/ReservedIps/ReservedIpsLanding/ReservedIpsLanding.tsx
+++ b/packages/manager/src/features/ReservedIps/ReservedIpsLanding/ReservedIpsLanding.tsx
@@ -1,28 +1,113 @@
-import { Notice } from '@linode/ui';
+import { useReservedIPsQuery } from '@linode/queries';
+import { CircleProgress, ErrorState } from '@linode/ui';
 import * as React from 'react';
 
 import { LandingHeader } from 'src/components/LandingHeader';
+import { useOrderV2 } from 'src/hooks/useOrderV2';
+import { usePaginationV2 } from 'src/hooks/usePaginationV2';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
 import { ReservedIpsLandingEmptyState } from './ReservedIpsLandingEmptyState';
+import { ReservedIpsLandingTable } from './ReservedIpsLandingTable';
+
+import type { ReservedIpsActionHandlers } from './ReservedIpsActionMenu';
+
+const preferenceKey = 'reserved-ips';
 
 export const ReservedIpsLanding = () => {
-  // TODO: Replace with actual data check once API queries are implemented
-  const showEmptyState = true;
+  // TODO: These will be used by the Edit drawer and Unreserve dialog component
+  // const [_selectedIP, setSelectedIP] = React.useState<IPAddress>();
+  // const [isDrawerOpen, setIsDrawerOpen] = React.useState(false);
 
-  if (showEmptyState) {
+  // const [_isEditDrawerOpen, setIsEditDrawerOpen] = React.useState(false);
+
+  // const [_isUnreserveDialogOpen, setIsUnreserveDialogOpen] = React.useState(false);
+
+  const handlers: ReservedIpsActionHandlers = {
+    onEdit: (ip) => {
+      // setSelectedIP(ip);
+      // setIsEditDrawerOpen(true);
+    },
+    onUnreserve: (ip) => {
+      // setSelectedIP(ip);
+      // setIsUnreserveDialogOpen(true);
+    },
+  };
+
+  const pagination = usePaginationV2({
+    currentRoute: '/reserved-ips',
+    preferenceKey,
+  });
+
+  const { handleOrderChange, order, orderBy } = useOrderV2({
+    initialRoute: {
+      defaultOrder: {
+        order: 'asc',
+        orderBy: 'address',
+      },
+      from: '/reserved-ips',
+    },
+    preferenceKey: `${preferenceKey}-order`,
+  });
+
+  const filter = {
+    ['+order']: order,
+    ['+order_by']: orderBy,
+  };
+
+  const {
+    data: reservedIps,
+    error,
+    isLoading,
+  } = useReservedIPsQuery(
+    {
+      page: pagination.page,
+      page_size: pagination.pageSize,
+    },
+    filter
+  );
+
+  if (error) {
+    return (
+      <ErrorState
+        errorText={
+          getAPIErrorOrDefault(
+            error,
+            'Error loading your Reserved IP addresses.'
+          )[0].reason
+        }
+      />
+    );
+  }
+
+  if (isLoading) {
+    return <CircleProgress />;
+  }
+
+  if (!reservedIps?.data.length) {
     return <ReservedIpsLandingEmptyState />;
   }
+
   return (
     <>
       <LandingHeader
-        breadcrumbProps={{
-          pathname: 'Reserved IPs',
-          removeCrumbX: 1,
+        createButtonText="Reserve an IP Address"
+        onButtonClick={() => {
+          /*To be updated
+          setIsDrawerOpen(true) */
         }}
         spacingBottom={16}
-        title="Reserved IPs"
+        title="Reserved IP Addresses"
       />
-      <Notice variant="info">Reserved IPs is coming soon...</Notice>
+      <ReservedIpsLandingTable
+        data={reservedIps?.data}
+        handleOrderChange={handleOrderChange}
+        handlers={handlers}
+        order={order}
+        orderBy={orderBy}
+        pagination={pagination}
+        results={reservedIps?.results}
+      />
     </>
   );
 };

--- a/packages/manager/src/features/ReservedIps/ReservedIpsLanding/ReservedIpsLanding.tsx
+++ b/packages/manager/src/features/ReservedIps/ReservedIpsLanding/ReservedIpsLanding.tsx
@@ -7,6 +7,7 @@ import { useOrderV2 } from 'src/hooks/useOrderV2';
 import { usePaginationV2 } from 'src/hooks/usePaginationV2';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
+import { RESERVED_IPS_DOCS_LINK } from '../constants';
 import { ReserveIPDrawer } from '../ReserveIPDrawer';
 import { ReservedIpsLandingEmptyState } from './ReservedIpsLandingEmptyState';
 import { ReservedIpsLandingTable } from './ReservedIpsLandingTable';
@@ -116,6 +117,7 @@ export const ReservedIpsLanding = () => {
     <>
       <LandingHeader
         createButtonText="Reserve an IP Address"
+        docsLink={RESERVED_IPS_DOCS_LINK}
         onButtonClick={() => openDrawer('create')}
         spacingBottom={16}
         title="Reserved IP Addresses"

--- a/packages/manager/src/features/ReservedIps/ReservedIpsLanding/ReservedIpsLandingEmptyState.tsx
+++ b/packages/manager/src/features/ReservedIps/ReservedIpsLanding/ReservedIpsLandingEmptyState.tsx
@@ -4,16 +4,19 @@ import NetworkingIcon from 'src/assets/icons/entityIcons/networking.svg';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { ResourcesSection } from 'src/components/EmptyLandingPageResources/ResourcesSection';
 
-import { ReserveIPDrawer } from '../ReserveIPDrawer';
 import {
   gettingStartedGuides,
   headers,
   linkAnalyticsEvent,
 } from './ReservedIpsLandingEmptyStateData';
 
-export const ReservedIpsLandingEmptyState = () => {
-  const [isDrawerOpen, setIsDrawerOpen] = React.useState(false);
+interface Props {
+  openReserveIPDrawer: () => void;
+}
 
+export const ReservedIpsLandingEmptyState = ({
+  openReserveIPDrawer,
+}: Props) => {
   return (
     <React.Fragment>
       <DocumentTitleSegment segment="Reserved IP Addresses" />
@@ -21,7 +24,7 @@ export const ReservedIpsLandingEmptyState = () => {
         buttonProps={[
           {
             children: 'Reserve an IP Address',
-            onClick: () => setIsDrawerOpen(true),
+            onClick: openReserveIPDrawer,
           },
         ]}
         descriptionMaxWidth={500}
@@ -30,11 +33,6 @@ export const ReservedIpsLandingEmptyState = () => {
         icon={NetworkingIcon}
         linkAnalyticsEvent={linkAnalyticsEvent}
         wide={true}
-      />
-      <ReserveIPDrawer
-        mode="create"
-        onClose={() => setIsDrawerOpen(false)}
-        open={isDrawerOpen}
       />
     </React.Fragment>
   );

--- a/packages/manager/src/features/ReservedIps/ReservedIpsLanding/ReservedIpsLandingRow.test.tsx
+++ b/packages/manager/src/features/ReservedIps/ReservedIpsLanding/ReservedIpsLandingRow.test.tsx
@@ -7,6 +7,14 @@ import { ReservedIpsLandingRow } from './ReservedIpsLandingRow';
 
 import type { ReservedIpsActionHandlers } from './ReservedIpsActionMenu';
 
+vi.mock('@mui/material', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@mui/material')>();
+  return {
+    ...actual,
+    useMediaQuery: vi.fn().mockReturnValue(true),
+  };
+});
+
 const mockHandlers: ReservedIpsActionHandlers = {
   onEdit: vi.fn(),
   onUnreserve: vi.fn(),
@@ -20,7 +28,7 @@ describe('ReservedIpsLandingRow', () => {
       <ReservedIpsLandingRow
         handlers={mockHandlers}
         ip={ip}
-        regionLabel="Newark, NJ"
+        regionLabel="PL, Krakow"
       />
     );
 
@@ -41,7 +49,7 @@ describe('ReservedIpsLandingRow', () => {
       <ReservedIpsLandingRow
         handlers={mockHandlers}
         ip={ip}
-        regionLabel="Newark, NJ"
+        regionLabel="PL, Krakow"
       />
     );
 
@@ -64,7 +72,7 @@ describe('ReservedIpsLandingRow', () => {
       <ReservedIpsLandingRow
         handlers={mockHandlers}
         ip={ip}
-        regionLabel="Newark, NJ"
+        regionLabel="PL, Krakow"
       />
     );
 
@@ -80,7 +88,7 @@ describe('ReservedIpsLandingRow', () => {
       <ReservedIpsLandingRow
         handlers={mockHandlers}
         ip={ip}
-        regionLabel="Newark, NJ"
+        regionLabel="PL, Krakow"
       />
     );
 
@@ -94,32 +102,31 @@ describe('ReservedIpsLandingRow', () => {
       <ReservedIpsLandingRow
         handlers={mockHandlers}
         ip={ip}
-        regionLabel="Krakow, PL"
+        regionLabel="PL, Krakow"
       />
     );
 
-    expect(getByText('Krakow, PL')).toBeVisible();
+    expect(getByText('PL, Krakow')).toBeVisible();
   });
 
   it('renders visible tags as chips', () => {
     const ip = reservedIPsFactory.build({
-      tags: ['web', 'production', 'staging'],
+      tags: ['web', 'production'],
     });
 
     const { getByText } = renderWithTheme(
       <ReservedIpsLandingRow
         handlers={mockHandlers}
         ip={ip}
-        regionLabel="Newark, NJ"
+        regionLabel="PL, Krakow"
       />
     );
 
-    expect(getByText('web')).toBeVisible();
-    expect(getByText('production')).toBeVisible();
-    expect(getByText('staging')).toBeVisible();
+    expect(getByText('web')).toBeInTheDocument();
+    expect(getByText('production')).toBeInTheDocument();
   });
 
-  it('renders a ShowMore chip when there are more than 3 tags', () => {
+  it('renders a ShowMore chip when there are more than 2 tags', () => {
     const ip = reservedIPsFactory.build({
       tags: ['web', 'production', 'staging', 'db', 'internal'],
     });
@@ -128,14 +135,13 @@ describe('ReservedIpsLandingRow', () => {
       <ReservedIpsLandingRow
         handlers={mockHandlers}
         ip={ip}
-        regionLabel="Newark, NJ"
+        regionLabel="PL, Krakow"
       />
     );
 
     expect(getByText('web')).toBeVisible();
     expect(getByText('production')).toBeVisible();
-    expect(getByText('staging')).toBeVisible();
-    expect(getByText('+2')).toBeVisible();
+    expect(getByText('+3')).toBeVisible();
   });
 
   it('renders no tags when the tags array is empty', () => {
@@ -145,7 +151,7 @@ describe('ReservedIpsLandingRow', () => {
       <ReservedIpsLandingRow
         handlers={mockHandlers}
         ip={ip}
-        regionLabel="Newark, NJ"
+        regionLabel="PL, Krakow"
       />
     );
 
@@ -159,7 +165,7 @@ describe('ReservedIpsLandingRow', () => {
       <ReservedIpsLandingRow
         handlers={mockHandlers}
         ip={ip}
-        regionLabel="Newark, NJ"
+        regionLabel="PL, Krakow"
       />
     );
 

--- a/packages/manager/src/features/ReservedIps/ReservedIpsLanding/ReservedIpsLandingRow.test.tsx
+++ b/packages/manager/src/features/ReservedIps/ReservedIpsLanding/ReservedIpsLandingRow.test.tsx
@@ -1,0 +1,170 @@
+import * as React from 'react';
+
+import { reservedIPsFactory } from 'src/factories/networking';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import { ReservedIpsLandingRow } from './ReservedIpsLandingRow';
+
+import type { ReservedIpsActionHandlers } from './ReservedIpsActionMenu';
+
+const mockHandlers: ReservedIpsActionHandlers = {
+  onEdit: vi.fn(),
+  onUnreserve: vi.fn(),
+};
+
+describe('ReservedIpsLandingRow', () => {
+  it('renders the IP address', () => {
+    const ip = reservedIPsFactory.build({ address: '203.0.113.10' });
+
+    const { getByText } = renderWithTheme(
+      <ReservedIpsLandingRow
+        handlers={mockHandlers}
+        ip={ip}
+        regionLabel="Newark, NJ"
+      />
+    );
+
+    expect(getByText('203.0.113.10')).toBeVisible();
+  });
+
+  it('renders the assigned entity label as a link for a linode', () => {
+    const ip = reservedIPsFactory.build({
+      assigned_entity: {
+        id: 123,
+        label: 'my-linode',
+        type: 'linode',
+        url: '/v4/linode/instances/123',
+      },
+    });
+
+    const { getByRole } = renderWithTheme(
+      <ReservedIpsLandingRow
+        handlers={mockHandlers}
+        ip={ip}
+        regionLabel="Newark, NJ"
+      />
+    );
+
+    const link = getByRole('link', { name: /my-linode/i });
+    expect(link).toBeVisible();
+    expect(link).toHaveAttribute('href', '/linodes/123');
+  });
+
+  it('renders the assigned entity label as a link for a nodebalancer', () => {
+    const ip = reservedIPsFactory.build({
+      assigned_entity: {
+        id: 456,
+        label: 'my-nodebalancer',
+        type: 'nodebalancer',
+        url: '/v4/nodebalancers/456',
+      },
+    });
+
+    const { getByRole } = renderWithTheme(
+      <ReservedIpsLandingRow
+        handlers={mockHandlers}
+        ip={ip}
+        regionLabel="Newark, NJ"
+      />
+    );
+
+    const link = getByRole('link', { name: /my-nodebalancer/i });
+    expect(link).toBeVisible();
+    expect(link).toHaveAttribute('href', '/nodebalancers/456');
+  });
+
+  it('renders "Unassigned" when there is no assigned entity', () => {
+    const ip = reservedIPsFactory.build({ assigned_entity: null });
+
+    const { getByText } = renderWithTheme(
+      <ReservedIpsLandingRow
+        handlers={mockHandlers}
+        ip={ip}
+        regionLabel="Newark, NJ"
+      />
+    );
+
+    expect(getByText('Unassigned')).toBeVisible();
+  });
+
+  it('renders the region label', () => {
+    const ip = reservedIPsFactory.build();
+
+    const { getByText } = renderWithTheme(
+      <ReservedIpsLandingRow
+        handlers={mockHandlers}
+        ip={ip}
+        regionLabel="Krakow, PL"
+      />
+    );
+
+    expect(getByText('Krakow, PL')).toBeVisible();
+  });
+
+  it('renders visible tags as chips', () => {
+    const ip = reservedIPsFactory.build({
+      tags: ['web', 'production', 'staging'],
+    });
+
+    const { getByText } = renderWithTheme(
+      <ReservedIpsLandingRow
+        handlers={mockHandlers}
+        ip={ip}
+        regionLabel="Newark, NJ"
+      />
+    );
+
+    expect(getByText('web')).toBeVisible();
+    expect(getByText('production')).toBeVisible();
+    expect(getByText('staging')).toBeVisible();
+  });
+
+  it('renders a ShowMore chip when there are more than 3 tags', () => {
+    const ip = reservedIPsFactory.build({
+      tags: ['web', 'production', 'staging', 'db', 'internal'],
+    });
+
+    const { getByText } = renderWithTheme(
+      <ReservedIpsLandingRow
+        handlers={mockHandlers}
+        ip={ip}
+        regionLabel="Newark, NJ"
+      />
+    );
+
+    expect(getByText('web')).toBeVisible();
+    expect(getByText('production')).toBeVisible();
+    expect(getByText('staging')).toBeVisible();
+    expect(getByText('+2')).toBeVisible();
+  });
+
+  it('renders no tags when the tags array is empty', () => {
+    const ip = reservedIPsFactory.build({ tags: [] });
+
+    const { queryByTestId } = renderWithTheme(
+      <ReservedIpsLandingRow
+        handlers={mockHandlers}
+        ip={ip}
+        regionLabel="Newark, NJ"
+      />
+    );
+
+    expect(queryByTestId('show-more')).not.toBeInTheDocument();
+  });
+
+  it('renders the action menu', () => {
+    const ip = reservedIPsFactory.build();
+
+    const { getByLabelText } = renderWithTheme(
+      <ReservedIpsLandingRow
+        handlers={mockHandlers}
+        ip={ip}
+        regionLabel="Newark, NJ"
+      />
+    );
+
+    expect(
+      getByLabelText(`Action menu for Reserved IP ${ip.address}`)
+    ).toBeVisible();
+  });
+});

--- a/packages/manager/src/features/ReservedIps/ReservedIpsLanding/ReservedIpsLandingRow.tsx
+++ b/packages/manager/src/features/ReservedIps/ReservedIpsLanding/ReservedIpsLandingRow.tsx
@@ -1,5 +1,6 @@
-import { Chip, Hidden, Stack, styled } from '@linode/ui';
+import { Hidden, Stack, styled } from '@linode/ui';
 import { splitAt } from '@linode/utilities';
+import { Badge } from 'akamai-cds-react-components/Badge';
 import { TableCell, TableRow } from 'akamai-cds-react-components/Table';
 import * as React from 'react';
 
@@ -84,7 +85,7 @@ const TagsList = ({ tags }: { tags: string[] }) => {
   return (
     <>
       {visible.map((tag) => (
-        <StyledTagChip key={tag} label={tag} />
+        <Badge key={tag}>{tag}</Badge>
       ))}
       {overflow.length > 0 && (
         <ShowMore
@@ -102,16 +103,6 @@ const TagsList = ({ tags }: { tags: string[] }) => {
     </>
   );
 };
-
-const StyledTagChip = styled(Chip, {
-  label: 'StyledTagChip',
-})(({ theme }) => ({
-  '& .MuiChip-label': {
-    color: theme.tokens.component.Badge.Informative.Subtle.Text,
-    font: theme.font.bold,
-    fontSize: theme.tokens.font.FontSize.Xxxs,
-  },
-}));
 
 const StyledActionMenuCell = styled(TableCell, {
   label: 'StyledActionMenuCell',

--- a/packages/manager/src/features/ReservedIps/ReservedIpsLanding/ReservedIpsLandingRow.tsx
+++ b/packages/manager/src/features/ReservedIps/ReservedIpsLanding/ReservedIpsLandingRow.tsx
@@ -1,4 +1,4 @@
-import { Chip, Stack, styled } from '@linode/ui';
+import { Chip, Hidden, Stack, styled } from '@linode/ui';
 import { splitAt } from '@linode/utilities';
 import { TableCell, TableRow } from 'akamai-cds-react-components/Table';
 import * as React from 'react';
@@ -57,8 +57,14 @@ export const ReservedIpsLandingRow = ({ handlers, ip, regionLabel }: Props) => {
           'Unassigned'
         )}
       </TableCell>
-      <TableCell>{regionLabel}</TableCell>
-      <TableCell>{tags?.length > 0 ? <TagsList tags={tags} /> : ''}</TableCell>
+      <Hidden smDown>
+        <TableCell>{regionLabel}</TableCell>
+        <Hidden mdDown>
+          <TableCell>
+            {tags?.length > 0 ? <TagsList tags={tags} /> : ''}
+          </TableCell>
+        </Hidden>
+      </Hidden>
       <StyledActionMenuCell>
         <ReservedIpsActionMenu handlers={handlers} ip={ip} />
       </StyledActionMenuCell>
@@ -70,7 +76,7 @@ export const ReservedIpsLandingRow = ({ handlers, ip, regionLabel }: Props) => {
  * Displays up to 3 non-clickable tag chips, with a "+N" ShowMore popover
  * for any overflow tags.
  */
-const MAX_VISIBLE_TAGS = 3;
+const MAX_VISIBLE_TAGS = 2;
 
 const TagsList = ({ tags }: { tags: string[] }) => {
   const [visible, overflow] = splitAt(MAX_VISIBLE_TAGS, tags);

--- a/packages/manager/src/features/ReservedIps/ReservedIpsLanding/ReservedIpsLandingRow.tsx
+++ b/packages/manager/src/features/ReservedIps/ReservedIpsLanding/ReservedIpsLandingRow.tsx
@@ -1,0 +1,126 @@
+import { Chip, Stack, styled } from '@linode/ui';
+import { splitAt } from '@linode/utilities';
+import { TableCell, TableRow } from 'akamai-cds-react-components/Table';
+import * as React from 'react';
+
+import { Link } from 'src/components/Link';
+import { ShowMore } from 'src/components/ShowMore/ShowMore';
+
+import { ReservedIpsActionMenu } from './ReservedIpsActionMenu';
+
+import type { ReservedIpsActionHandlers } from './ReservedIpsActionMenu';
+import type { IPAddress } from '@linode/api-v4';
+
+interface Props {
+  handlers: ReservedIpsActionHandlers;
+  ip: IPAddress;
+  regionLabel: string;
+}
+
+/**
+ * Derives the Cloud Manager route from the assigned entity.
+ * API URLs (e.g. `/v4/linode/instances/123`) are not valid app routes.
+ */
+const getEntityRoute = (
+  entity: IPAddress['assigned_entity']
+): null | string => {
+  if (!entity) {
+    return null;
+  }
+
+  switch (entity.type) {
+    case 'linode':
+      return `/linodes/${entity.id}`;
+    case 'nodebalancer':
+      return `/nodebalancers/${entity.id}`;
+    default:
+      return null;
+  }
+};
+
+export const ReservedIpsLandingRow = ({ handlers, ip, regionLabel }: Props) => {
+  const { address, assigned_entity, tags } = ip;
+  const entityRoute = getEntityRoute(assigned_entity);
+
+  return (
+    <TableRow hoverable zebra>
+      <TableCell>{address}</TableCell>
+      <TableCell>
+        {assigned_entity && entityRoute ? (
+          <Link
+            accessibleAriaLabel={`Navigate to ${assigned_entity.type} ${assigned_entity.label}`}
+            to={entityRoute}
+          >
+            {assigned_entity.label}
+          </Link>
+        ) : (
+          'Unassigned'
+        )}
+      </TableCell>
+      <TableCell>{regionLabel}</TableCell>
+      <TableCell>{tags?.length > 0 ? <TagsList tags={tags} /> : ''}</TableCell>
+      <StyledActionMenuCell>
+        <ReservedIpsActionMenu handlers={handlers} ip={ip} />
+      </StyledActionMenuCell>
+    </TableRow>
+  );
+};
+
+/**
+ * Displays up to 3 non-clickable tag chips, with a "+N" ShowMore popover
+ * for any overflow tags.
+ */
+const MAX_VISIBLE_TAGS = 3;
+
+const TagsList = ({ tags }: { tags: string[] }) => {
+  const [visible, overflow] = splitAt(MAX_VISIBLE_TAGS, tags);
+
+  return (
+    <>
+      {visible.map((tag) => (
+        <StyledTagChip key={tag} label={tag} />
+      ))}
+      {overflow.length > 0 && (
+        <ShowMore
+          ariaItemType="tags"
+          items={overflow}
+          render={(items) => (
+            <Stack spacing={0.5}>
+              {items.map((tag) => (
+                <span key={tag}>{tag}</span>
+              ))}
+            </Stack>
+          )}
+        />
+      )}
+    </>
+  );
+};
+
+const StyledTagChip = styled(Chip, {
+  label: 'StyledTagChip',
+})(({ theme }) => ({
+  '& .MuiChip-label': {
+    color: theme.tokens.component.Badge.Informative.Subtle.Text,
+    font: theme.font.bold,
+    fontSize: theme.tokens.font.FontSize.Xxxs,
+  },
+}));
+
+const StyledActionMenuCell = styled(TableCell, {
+  label: 'StyledActionMenuCell',
+})(({ theme }) => ({
+  alignItems: 'center',
+  display: 'flex',
+  justifyContent: 'flex-end',
+  maxWidth: 40,
+  '& button': {
+    backgroundColor: 'transparent',
+    color: theme.tokens.alias.Content.Icon.Primary.Default,
+    padding: 0,
+  },
+  '& button:hover': {
+    backgroundColor: 'transparent',
+    color: theme.tokens.alias.Content.Icon.Primary.Hover,
+  },
+}));

--- a/packages/manager/src/features/ReservedIps/ReservedIpsLanding/ReservedIpsLandingTable.tsx
+++ b/packages/manager/src/features/ReservedIps/ReservedIpsLanding/ReservedIpsLandingTable.tsx
@@ -1,0 +1,139 @@
+import { useRegionsQuery } from '@linode/queries';
+import { useTheme } from '@mui/material/styles';
+import { Pagination } from 'akamai-cds-react-components/Pagination';
+import {
+  Table,
+  TableBody,
+  TableHead,
+  TableHeaderCell,
+  TableRow,
+} from 'akamai-cds-react-components/Table';
+import * as React from 'react';
+
+import { MIN_PAGE_SIZE } from 'src/components/PaginationFooter/PaginationFooter.constants';
+import { TableRowEmpty } from 'src/components/TableRowEmpty/TableRowEmpty';
+
+import { ReservedIpsLandingRow } from './ReservedIpsLandingRow';
+
+import type { ReservedIpsActionHandlers } from './ReservedIpsActionMenu';
+import type { IPAddress } from '@linode/api-v4';
+import type { Order } from '@linode/utilities';
+import type { PaginationPropsV2 } from 'src/hooks/usePaginationV2';
+
+const DEFAULT_PAGE_SIZES = [25, 50, 100];
+
+interface Props {
+  data: IPAddress[] | undefined;
+  handleOrderChange: (newOrderBy: string, newOrder: Order) => void;
+  handlers: ReservedIpsActionHandlers;
+  order: 'asc' | 'desc';
+  orderBy: string;
+  pagination: PaginationPropsV2;
+  results: number | undefined;
+}
+
+export const ReservedIpsLandingTable = ({
+  data,
+  handleOrderChange,
+  handlers,
+  order,
+  orderBy,
+  pagination,
+  results,
+}: Props) => {
+  const theme = useTheme();
+
+  const { data: regions } = useRegionsQuery();
+
+  const regionLabelMap = React.useMemo(() => {
+    const map = new Map<string, string>();
+    regions?.forEach((r) => map.set(r.id, r.label));
+    return map;
+  }, [regions]);
+
+  return (
+    <>
+      <div style={{ overflowX: 'auto', width: '100%' }}>
+        <Table
+          aria-label="List of Reserved IP Addresses"
+          style={
+            {
+              border: `1px solid ${theme.tokens.alias.Border.Normal}`,
+              marginTop: '10px',
+              minWidth: '600px',
+              '--token-component-table-header-outlined-border':
+                theme.tokens.component.Table.Row.Border,
+            } as React.CSSProperties
+          }
+        >
+          <TableHead>
+            <TableRow
+              headerbackground={
+                theme.tokens.component.Table.HeaderNested.Background
+              }
+              headerborder
+            >
+              <TableHeaderCell
+                sort={() =>
+                  handleOrderChange('address', order === 'asc' ? 'desc' : 'asc')
+                }
+                sortable
+                sorted={orderBy === 'address' ? order : undefined}
+              >
+                IP Address
+              </TableHeaderCell>
+              <TableHeaderCell>Assigned Resource</TableHeaderCell>
+              <TableHeaderCell
+                sort={() =>
+                  handleOrderChange('region', order === 'asc' ? 'desc' : 'asc')
+                }
+                sortable
+                sorted={orderBy === 'region' ? order : undefined}
+              >
+                Region
+              </TableHeaderCell>
+              <TableHeaderCell>Tags</TableHeaderCell>
+              <TableHeaderCell style={{ maxWidth: 40 }} />
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {data?.length === 0 ? (
+              <TableRowEmpty
+                colSpan={5}
+                message="No Reserved IP addresses found."
+              />
+            ) : (
+              data?.map((ip: IPAddress) => (
+                <ReservedIpsLandingRow
+                  handlers={handlers}
+                  ip={ip}
+                  key={ip.address}
+                  regionLabel={regionLabelMap.get(ip.region) ?? ip.region}
+                />
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+      {(results || 0) > MIN_PAGE_SIZE && (
+        <Pagination
+          count={results || 0}
+          onPageChange={(e: CustomEvent<number>) =>
+            pagination.handlePageChange(Number(e.detail))
+          }
+          onPageSizeChange={(
+            e: CustomEvent<{ page: number; pageSize: number }>
+          ) => pagination.handlePageSizeChange(Number(e.detail.pageSize))}
+          page={pagination.page}
+          pageSize={pagination.pageSize}
+          pageSizes={DEFAULT_PAGE_SIZES}
+          style={{
+            borderLeft: `1px solid ${theme.tokens.alias.Border.Normal}`,
+            borderRight: `1px solid ${theme.tokens.alias.Border.Normal}`,
+            borderTop: 0,
+          }}
+        />
+      )}
+    </>
+  );
+};

--- a/packages/manager/src/features/ReservedIps/ReservedIpsLanding/ReservedIpsLandingTable.tsx
+++ b/packages/manager/src/features/ReservedIps/ReservedIpsLanding/ReservedIpsLandingTable.tsx
@@ -1,4 +1,5 @@
 import { useRegionsQuery } from '@linode/queries';
+import { Hidden } from '@linode/ui';
 import { useTheme } from '@mui/material/styles';
 import { Pagination } from 'akamai-cds-react-components/Pagination';
 import {
@@ -60,7 +61,6 @@ export const ReservedIpsLandingTable = ({
             {
               border: `1px solid ${theme.tokens.alias.Border.Normal}`,
               marginTop: '10px',
-              minWidth: '600px',
               '--token-component-table-header-outlined-border':
                 theme.tokens.component.Table.Row.Border,
             } as React.CSSProperties
@@ -83,16 +83,23 @@ export const ReservedIpsLandingTable = ({
                 IP Address
               </TableHeaderCell>
               <TableHeaderCell>Assigned Resource</TableHeaderCell>
-              <TableHeaderCell
-                sort={() =>
-                  handleOrderChange('region', order === 'asc' ? 'desc' : 'asc')
-                }
-                sortable
-                sorted={orderBy === 'region' ? order : undefined}
-              >
-                Region
-              </TableHeaderCell>
-              <TableHeaderCell>Tags</TableHeaderCell>
+              <Hidden smDown>
+                <TableHeaderCell
+                  sort={() =>
+                    handleOrderChange(
+                      'region',
+                      order === 'asc' ? 'desc' : 'asc'
+                    )
+                  }
+                  sortable
+                  sorted={orderBy === 'region' ? order : undefined}
+                >
+                  Region
+                </TableHeaderCell>
+                <Hidden mdDown>
+                  <TableHeaderCell>Tags</TableHeaderCell>
+                </Hidden>
+              </Hidden>
               <TableHeaderCell style={{ maxWidth: 40 }} />
             </TableRow>
           </TableHead>

--- a/packages/manager/src/mocks/mockState.ts
+++ b/packages/manager/src/mocks/mockState.ts
@@ -55,6 +55,7 @@ export const emptyStore: MockState = {
   placementGroups: [],
   regionAvailability: [],
   regions: [],
+  reservedIPs: [],
   streams: [],
   subnets: [],
   supportReplies: [],

--- a/packages/manager/src/mocks/presets/baseline/crud.ts
+++ b/packages/manager/src/mocks/presets/baseline/crud.ts
@@ -14,7 +14,10 @@ import { firewallCrudPreset } from '../crud/firewalls';
 import { imagesCrudPreset } from '../crud/images';
 import { kubernetesCrudPreset } from '../crud/kubernetes';
 import { locksCrudPreset } from '../crud/locks';
-import { networkingCrudPreset } from '../crud/networking';
+import {
+  networkingCrudPreset,
+  reservedIPsCrudPreset,
+} from '../crud/networking';
 import { nodeBalancerCrudPreset } from '../crud/nodebalancers';
 import { permissionsCrudPreset } from '../crud/permissions';
 import { placementGroupsCrudPreset } from '../crud/placementGroups';
@@ -49,6 +52,8 @@ export const baselineCrudPreset: MockPresetBaseline = {
     ...vpcCrudPreset.handlers,
     ...networkingCrudPreset.handlers,
     ...nodeBalancerCrudPreset.handlers,
+    ...networkingCrudPreset.handlers,
+    ...reservedIPsCrudPreset.handlers,
 
     // Events.
     getEvents,

--- a/packages/manager/src/mocks/presets/crud/handlers/networking.ts
+++ b/packages/manager/src/mocks/presets/crud/handlers/networking.ts
@@ -118,3 +118,23 @@ export const getReservedIPsTypes = () => [
 ];
 
 // @TODO Linode Interfaces - add mocks for sharing/assigning IPs
+
+// Reserved IP handlers
+
+export const getReservedIPs = (mockState: MockState) => [
+  http.get(
+    '*/v4beta/networking/reserved/ips',
+    async ({
+      request,
+    }): Promise<
+      StrictResponse<APIErrorResponse | APIPaginatedResponse<IPAddress>>
+    > => {
+      const reservedIPs = await mswDB.getAll('reservedIPs');
+
+      return makePaginatedResponse({
+        data: reservedIPs || [],
+        request,
+      });
+    }
+  ),
+];

--- a/packages/manager/src/mocks/presets/crud/handlers/networking.ts
+++ b/packages/manager/src/mocks/presets/crud/handlers/networking.ts
@@ -80,6 +80,25 @@ export const allocateIP = (mockState: MockState) => [
   ),
 ];
 
+// Reserved IP handlers
+
+export const getReservedIPs = () => [
+  http.get(
+    '*/v4beta/networking/reserved/ips',
+    async ({
+      request,
+    }): Promise<
+      StrictResponse<APIErrorResponse | APIPaginatedResponse<IPAddress>>
+    > => {
+      const reservedIPs = await mswDB.getAll('reservedIPs');
+      return makePaginatedResponse({
+        data: reservedIPs ?? [],
+        request,
+      });
+    }
+  ),
+];
+
 export const reserveIP = (mockState: MockState) => [
   http.post(
     '*/v4beta/networking/reserved/ips',
@@ -95,7 +114,7 @@ export const reserveIP = (mockState: MockState) => [
         type: 'ipv4',
       });
 
-      await mswDB.add('ipAddresses', ipAddress, mockState);
+      await mswDB.add('reservedIPs', ipAddress, mockState);
 
       return makeResponse(ipAddress);
     }
@@ -118,23 +137,3 @@ export const getReservedIPsTypes = () => [
 ];
 
 // @TODO Linode Interfaces - add mocks for sharing/assigning IPs
-
-// Reserved IP handlers
-
-export const getReservedIPs = (mockState: MockState) => [
-  http.get(
-    '*/v4beta/networking/reserved/ips',
-    async ({
-      request,
-    }): Promise<
-      StrictResponse<APIErrorResponse | APIPaginatedResponse<IPAddress>>
-    > => {
-      const reservedIPs = await mswDB.getAll('reservedIPs');
-
-      return makePaginatedResponse({
-        data: reservedIPs || [],
-        request,
-      });
-    }
-  ),
-];

--- a/packages/manager/src/mocks/presets/crud/networking.ts
+++ b/packages/manager/src/mocks/presets/crud/networking.ts
@@ -1,9 +1,9 @@
 import {
   allocateIP,
   getIPAddresses,
+  getReservedIPs,
   getReservedIPsTypes,
   reserveIP,
-  getReservedIPs,
 } from 'src/mocks/presets/crud/handlers/networking';
 
 import type { MockPresetCrud } from 'src/mocks/types';

--- a/packages/manager/src/mocks/presets/crud/networking.ts
+++ b/packages/manager/src/mocks/presets/crud/networking.ts
@@ -3,13 +3,21 @@ import {
   getIPAddresses,
   getReservedIPsTypes,
   reserveIP,
+  getReservedIPs,
 } from 'src/mocks/presets/crud/handlers/networking';
 
 import type { MockPresetCrud } from 'src/mocks/types';
 
 export const networkingCrudPreset: MockPresetCrud = {
   group: { id: 'IP Addresses' },
-  handlers: [getIPAddresses, allocateIP, getReservedIPsTypes, reserveIP],
+  handlers: [getIPAddresses],
   id: 'ip-addresses:crud',
   label: 'IP Addresses CRUD',
+};
+
+export const reservedIPsCrudPreset: MockPresetCrud = {
+  group: { id: 'Reserved IPs' },
+  handlers: [getReservedIPs, allocateIP, getReservedIPsTypes, reserveIP],
+  id: 'reserved-ips:crud',
+  label: 'Reserved IPs CRUD',
 };

--- a/packages/manager/src/mocks/presets/crud/seeds/index.ts
+++ b/packages/manager/src/mocks/presets/crud/seeds/index.ts
@@ -4,7 +4,7 @@ import { firewallSeeder } from './firewalls';
 import { kubernetesSeeder } from './kubernetes';
 import { linodesSeeder } from './linodes';
 import { locksSeeder } from './locks';
-import { ipAddressSeeder } from './networking';
+import { ipAddressSeeder, reservedIPSeeder } from './networking';
 import { nodeBalancerSeeder } from './nodebalancers';
 import { placementGroupSeeder } from './placementGroups';
 import { supportTicketsSeeder } from './supportTickets';
@@ -22,6 +22,7 @@ export const dbSeeders = [
   locksSeeder,
   nodeBalancerSeeder,
   placementGroupSeeder,
+  reservedIPSeeder,
   supportTicketsSeeder,
   defaultUsersSeeder,
   parentUsersSeeder,

--- a/packages/manager/src/mocks/presets/crud/seeds/networking.ts
+++ b/packages/manager/src/mocks/presets/crud/seeds/networking.ts
@@ -56,6 +56,7 @@ export const reservedIPSeeder: MockSeeder = {
     };
 
     await mswDB.saveStore(updatedMockState, 'seedState');
+
     return updatedMockState;
   },
 };

--- a/packages/manager/src/mocks/presets/crud/seeds/networking.ts
+++ b/packages/manager/src/mocks/presets/crud/seeds/networking.ts
@@ -1,6 +1,6 @@
 import { getSeedsCountMap } from 'src/dev-tools/utils';
-import { ipAddressFactory } from 'src/factories';
-import { mswDB } from 'src/mocks/indexedDB';
+import { ipAddressFactory, reservedIPsFactory } from 'src/factories';
+import { addToEntities, mswDB } from 'src/mocks/indexedDB';
 import { seedWithUniqueIds } from 'src/mocks/presets/crud/seeds/utils';
 
 import type { MockSeeder, MockState } from 'src/mocks/types';
@@ -27,6 +27,35 @@ export const ipAddressSeeder: MockSeeder = {
 
     await mswDB.saveStore(updatedMockState, 'seedState');
 
+    return updatedMockState;
+  },
+};
+
+export const reservedIPSeeder: MockSeeder = {
+  canUpdateCount: true,
+  desc: 'Reserved IP Address Seeds',
+  group: { id: 'Reserved IPs' },
+  id: 'reserved-ips:crud',
+  label: 'Reserved IPs',
+
+  seeder: async (mockState: MockState) => {
+    const seedsCountMap = getSeedsCountMap();
+    const count = seedsCountMap[reservedIPSeeder.id] ?? 0;
+    const reservedIPSeeds = reservedIPsFactory.buildList(count);
+
+    const uniqueReservedIPSeeds = seedWithUniqueIds<'reservedIPs'>({
+      dbEntities: await mswDB.getAll('reservedIPs'),
+      seedEntities: reservedIPSeeds,
+    });
+
+    addToEntities(mockState, 'reservedIPs', uniqueReservedIPSeeds);
+
+    const updatedMockState = {
+      ...mockState,
+      reservedIPs: mockState.reservedIPs.concat(uniqueReservedIPSeeds),
+    };
+
+    await mswDB.saveStore(updatedMockState, 'seedState');
     return updatedMockState;
   },
 };

--- a/packages/manager/src/mocks/presets/crud/seeds/utils.ts
+++ b/packages/manager/src/mocks/presets/crud/seeds/utils.ts
@@ -42,6 +42,9 @@ export const removeSeeds = async (seederId: MockSeeder['id']) => {
     case 'placement-groups:crud':
       await mswDB.deleteAll('placementGroups', mockState, 'seedState');
       break;
+    case 'reserved-ips:crud':
+      await mswDB.deleteAll('reservedIPs', mockState, 'seedState');
+      break;
     case 'support-tickets:crud':
       await mswDB.deleteAll('supportTickets', mockState, 'seedState');
       break;

--- a/packages/manager/src/mocks/types.ts
+++ b/packages/manager/src/mocks/types.ts
@@ -148,6 +148,7 @@ export type MockPresetCrudGroup = {
     | 'Permissions'
     | 'Placement Groups'
     | 'Quotas'
+    | 'Reserved IPs'
     | 'Support Tickets'
     | 'Users'
     | 'Volumes'
@@ -171,6 +172,7 @@ export type MockPresetCrudId =
   | 'permissions:crud'
   | 'placement-groups:crud'
   | 'quotas:crud'
+  | 'reserved-ips:crud'
   | 'support-tickets:crud'
   | 'users(default):crud'
   | 'users(parent):crud'
@@ -241,6 +243,7 @@ export interface MockState {
   placementGroups: PlacementGroup[];
   regionAvailability: RegionAvailability[];
   regions: Region[];
+  reservedIPs: IPAddress[];
   streams: Stream[];
   subnets: [number, Subnet][]; // number is VPC ID
   supportReplies: SupportReply[];


### PR DESCRIPTION
## Description 📝

Implement Reserved IP Landing Table alongwith CRUD MSW mock setup.

## Changes  🔄

- Add ReservedIpsLanding component to render Reserved IPs list with pagination, loading/error/empty states using web components.
- Implement ShowMore to allow overflow of tags based on maxLength
- Implement ReservedIps factory, seeds and handlers

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [x] No customers / Not applicable

## Target release date 🗓️

Please specify a release date (and environment, if applicable) to guarantee timely review of this PR. If exact date is not known, please approximate and update it as needed.

## Preview 📷

![Screenshot 2026-03-31 at 5 30 16 PM](https://github.com/user-attachments/assets/931ffd95-63a2-4cbd-a8ed-5fff7fbac487)

## How to test 🧪

### Prerequisites

- Open DevTools Panel
- Enable the Reserved IP feature flag
- Navigate to "MSW" section, Toggle "Enable MSW" to ON -> Select "CRUD" preset
- navigate to "Seeds" section -> Set seed counts: Reserve IP: 26

### Verification steps

- [ ] Navigate to localhost:3000/reserved-ips/
- [ ] Verify that you are able to see the list

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>