### PR TITLE
change: [DPS-41857] - Logs: Add new statuses - deactivating, failed

### DIFF
--- a/packages/api-v4/src/delivery/types.ts
+++ b/packages/api-v4/src/delivery/types.ts
@@ -1,5 +1,7 @@
 export const streamStatus = {
   Active: 'active',
+  Deactivating: 'deactivating',
+  Failed: 'failed',
   Inactive: 'inactive',
   Provisioning: 'provisioning',
 } as const;

--- a/packages/manager/.changeset/pr-13551-added-1774974854479.md
+++ b/packages/manager/.changeset/pr-13551-added-1774974854479.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Add new stream statuses - deactivating, failed ([#13551](https://github.com/linode/manager/pull/13551))

--- a/packages/manager/.changeset/pr-13551-added-1774974854479.md
+++ b/packages/manager/.changeset/pr-13551-added-1774974854479.md
@@ -2,4 +2,4 @@
 "@linode/manager": Added
 ---
 
-Add new stream statuses - deactivating, failed ([#13551](https://github.com/linode/manager/pull/13551))
+New stream statuses - deactivating, failed ([#13551](https://github.com/linode/manager/pull/13551))

--- a/packages/manager/src/features/Delivery/Shared/types.ts
+++ b/packages/manager/src/features/Delivery/Shared/types.ts
@@ -50,6 +50,16 @@ export const streamStatusOptions: AutocompleteOption[] = [
     pendoId: 'Logs Delivery Streams-Status Active',
   },
   {
+    value: streamStatus.Deactivating,
+    label: 'Deactivating',
+    pendoId: 'Logs Delivery Streams-Status Deactivating',
+  },
+  {
+    value: streamStatus.Failed,
+    label: 'Failed',
+    pendoId: 'Logs Delivery Streams-Status Failed',
+  },
+  {
     value: streamStatus.Inactive,
     label: 'Inactive',
     pendoId: 'Logs Delivery Streams-Status Inactive',

--- a/packages/manager/src/features/Delivery/Streams/StreamActionMenu.tsx
+++ b/packages/manager/src/features/Delivery/Streams/StreamActionMenu.tsx
@@ -17,6 +17,7 @@ interface StreamActionMenuProps extends StreamHandlers {
 
 export const StreamActionMenu = (props: StreamActionMenuProps) => {
   const { stream, onDelete, onDisableOrEnable, onEdit } = props;
+  const { status, label } = stream;
 
   const menuActions: Action[] = [
     {
@@ -25,14 +26,19 @@ export const StreamActionMenu = (props: StreamActionMenuProps) => {
       },
       title: 'Edit',
       pendoId: 'Logs Delivery Streams-Edit',
+      disabled:
+        status === streamStatus.Deactivating || status === streamStatus.Failed,
     },
     {
       onClick: () => {
         onDisableOrEnable(stream);
       },
-      title: stream.status === streamStatus.Active ? 'Deactivate' : 'Activate',
-      pendoId: `Logs Delivery Streams-${stream.status === streamStatus.Active ? 'Deactivate' : 'Activate'}`,
-      disabled: stream.status === streamStatus.Provisioning,
+      title: status === streamStatus.Active ? 'Deactivate' : 'Activate',
+      pendoId: `Logs Delivery Streams-${status === streamStatus.Active ? 'Deactivate' : 'Activate'}`,
+      disabled:
+        status === streamStatus.Deactivating ||
+        status === streamStatus.Failed ||
+        status === streamStatus.Provisioning,
     },
     {
       onClick: () => {
@@ -46,7 +52,7 @@ export const StreamActionMenu = (props: StreamActionMenuProps) => {
   return (
     <ActionMenu
       actionsList={menuActions}
-      ariaLabel={`Action menu for Stream ${stream.label}`}
+      ariaLabel={`Action menu for Stream ${label}`}
       pendoId="Logs Delivery Streams-Action Menu"
     />
   );

--- a/packages/manager/src/features/Delivery/Streams/StreamActionMenu.tsx
+++ b/packages/manager/src/features/Delivery/Streams/StreamActionMenu.tsx
@@ -26,8 +26,6 @@ export const StreamActionMenu = (props: StreamActionMenuProps) => {
       },
       title: 'Edit',
       pendoId: 'Logs Delivery Streams-Edit',
-      disabled:
-        status === streamStatus.Deactivating || status === streamStatus.Failed,
     },
     {
       onClick: () => {

--- a/packages/manager/src/features/Delivery/Streams/StreamForm/StreamEdit.test.tsx
+++ b/packages/manager/src/features/Delivery/Streams/StreamForm/StreamEdit.test.tsx
@@ -1,3 +1,4 @@
+import { streamStatus } from '@linode/api-v4';
 import {
   screen,
   waitFor,
@@ -239,47 +240,63 @@ describe('StreamEdit', () => {
             });
           });
 
-          describe('and stream has status: provisioning', () => {
-            it('should have disabled Edit Stream button and show info tooltip', async () => {
-              server.use(
-                http.get('*/monitor/streams/destinations', () => {
-                  return HttpResponse.json(makeResourcePage(mockDestinations));
-                }),
-                http.get(`*/monitor/streams/${streamId}`, () => {
-                  return HttpResponse.json({
-                    ...mockStream,
-                    status: 'provisioning',
-                  });
-                })
-              );
+          const blockingStatuses = [
+            streamStatus.Deactivating,
+            streamStatus.Failed,
+            streamStatus.Provisioning,
+          ];
 
-              renderWithThemeAndHookFormContext({
-                component: <StreamEdit />,
+          describe.each(blockingStatuses)(
+            'and stream has status: %status',
+            (status) => {
+              it('should have disabled Edit Stream button and show info tooltip', async () => {
+                server.use(
+                  http.get('*/monitor/streams/destinations', () => {
+                    return HttpResponse.json(
+                      makeResourcePage(mockDestinations)
+                    );
+                  }),
+                  http.get(`*/monitor/streams/${streamId}`, () => {
+                    return HttpResponse.json({
+                      ...mockStream,
+                      status,
+                    });
+                  })
+                );
+
+                renderWithThemeAndHookFormContext({
+                  component: <StreamEdit />,
+                });
+                const loadingElement = screen.queryByTestId(loadingTestId);
+                await waitForElementToBeRemoved(loadingElement);
+
+                const editStreamButton = screen.getByRole('button', {
+                  name: saveStreamButtonText,
+                });
+
+                // Edit stream button should be disabled
+                expect(editStreamButton).toBeDisabled();
+
+                // Edit stream
+                await userEvent.hover(editStreamButton);
+                await screen.findByRole('tooltip');
+
+                screen.getByText((content) =>
+                  content.includes(
+                    `You cannot save changes while the stream status is ${status}`
+                  )
+                );
+
+                const disabledButtonTooltip = screen.getByText((content) =>
+                  content.includes(
+                    `You cannot save changes while the stream status is ${status}`
+                  )
+                );
+
+                expect(disabledButtonTooltip).toBeInTheDocument();
               });
-              const loadingElement = screen.queryByTestId(loadingTestId);
-              await waitForElementToBeRemoved(loadingElement);
-
-              const editStreamButton = screen.getByRole('button', {
-                name: saveStreamButtonText,
-              });
-
-              // Edit stream button should be disabled
-              expect(editStreamButton).toBeDisabled();
-
-              // Edit stream
-              await userEvent.hover(editStreamButton);
-
-              await waitFor(() => {
-                expect(screen.getByRole('tooltip')).toBeInTheDocument();
-              });
-
-              const disabledButtonTooltip = screen.getByText(
-                'You cannot save changes while the stream is provisioning.'
-              );
-
-              expect(disabledButtonTooltip).toBeInTheDocument();
-            });
-          });
+            }
+          );
         });
       });
 

--- a/packages/manager/src/features/Delivery/Streams/StreamForm/StreamForm.tsx
+++ b/packages/manager/src/features/Delivery/Streams/StreamForm/StreamForm.tsx
@@ -77,12 +77,23 @@ export const StreamForm = (props: StreamFormProps) => {
     control,
     name: 'stream.status',
   });
+
+  const isStreamStatusBlocking =
+    !!selectedStreamStatus &&
+    (
+      [
+        streamStatus.Provisioning,
+        streamStatus.Deactivating,
+        streamStatus.Failed,
+      ] as StreamStatus[]
+    ).includes(selectedStreamStatus);
+
   const submitButtonTooltip = useMemo(
     () =>
-      selectedStreamStatus === streamStatus.Provisioning
-        ? 'You cannot save changes while the stream is provisioning.'
+      isStreamStatusBlocking
+        ? `You cannot save changes while the stream status is ${selectedStreamStatus}`
         : undefined,
-    [selectedStreamStatus]
+    [isStreamStatusBlocking, selectedStreamStatus]
   );
 
   useEffect(() => {
@@ -211,8 +222,7 @@ export const StreamForm = (props: StreamFormProps) => {
         <Grid size={{ lg: 3, md: 12, sm: 12, xs: 12 }}>
           <FormSubmitBar
             blockSubmit={
-              selectedStreamStatus === streamStatus.Provisioning ||
-              !selectedDestinations?.length
+              isStreamStatusBlocking || !selectedDestinations?.length
             }
             connectionTested={destinationVerified}
             destinationType={destination?.type}

--- a/packages/manager/src/features/Delivery/Streams/StreamTableRow.tsx
+++ b/packages/manager/src/features/Delivery/Streams/StreamTableRow.tsx
@@ -23,9 +23,13 @@ interface StreamTableRowProps extends StreamHandlers {
 export const StreamTableRow = React.memo((props: StreamTableRowProps) => {
   const { stream, onDelete, onDisableOrEnable, onEdit } = props;
   const { id, status } = stream;
-  const iconStatus = (
-    ['active', 'error', 'inactive'].includes(status) ? status : 'other'
-  ) as Status;
+  const iconStatus = ((): Status => {
+    if (status === 'failed') return 'error';
+    if (['active', 'error', 'inactive'].includes(status)) {
+      return status as Status;
+    }
+    return 'other';
+  })();
 
   return (
     <TableRow key={id}>
@@ -72,6 +76,10 @@ const humanizeStreamStatus = (status: StreamStatus) => {
   switch (status) {
     case 'active':
       return 'Active';
+    case 'deactivating':
+      return 'Deactivating';
+    case 'failed':
+      return 'Failed';
     case 'inactive':
       return 'Inactive';
     case 'provisioning':

--- a/packages/validation/src/delivery.schema.ts
+++ b/packages/validation/src/delivery.schema.ts
@@ -351,11 +351,9 @@ const streamSchemaBase = object({
     .min(3, 'Stream name must have at least 3 characters.')
     .max(maxLength, maxLengthMessage)
     .required('Stream name is required.'),
-  status: mixed<'active' | 'inactive' | 'provisioning'>().oneOf([
-    'active',
-    'inactive',
-    'provisioning',
-  ]),
+  status: mixed<
+    'active' | 'deactivating' | 'failed' | 'inactive' | 'provisioning'
+  >().oneOf(['active', 'deactivating', 'failed', 'inactive', 'provisioning']),
   type: string()
     .oneOf(['audit_logs', 'lke_audit_logs'])
     .required('Stream type is required.'),
@@ -372,8 +370,10 @@ export const createStreamSchema = streamSchemaBase;
 export const updateStreamSchema = streamSchemaBase
   .omit(['type'])
   .shape({
-    status: mixed<'active' | 'inactive' | 'provisioning'>()
-      .oneOf(['active', 'inactive', 'provisioning'])
+    status: mixed<
+      'active' | 'deactivating' | 'failed' | 'inactive' | 'provisioning'
+    >()
+      .oneOf(['active', 'deactivating', 'failed', 'inactive', 'provisioning'])
       .required(),
     details: lazy((value) => {
       if (


### PR DESCRIPTION
## Description 📝

Two new statuses (Delivery Logs Streams status) have been added in the UI: Failed and Deactivating.
It also prevents users from performing edit or activate actions when a stream is in either of these statuses.

## Changes  🔄

- Added Failed and Deactivating statuses to the UI.
- Disabled edit and activate actions when the stream status is Failed or Deactivating.
- Updated UI logic to handle these statuses consistently.

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [x] No customers / Not applicable

Some customers (e.g. in Beta or Limited Availability)

## Target release date 🗓️

April 2026

## Preview 📷
<img width="1313" height="416" alt="Screenshot 2026-03-31 at 18 26 15" src="https://github.com/user-attachments/assets/3cf026f3-0da8-43fd-9a5b-07dcc1f5e01d" />
<img width="1291" height="543" alt="Screenshot 2026-03-31 at 18 27 06" src="https://github.com/user-attachments/assets/26088673-eee6-4129-828a-b65229a37f90" />

## How to test 🧪

- Application running locally
- Having a stream that returns Failed or Deactivating status from the API (or mocked in `packages/manager/src/factories/delivery.ts`)

### Verification steps
- Verify **Failed** status is displayed correctly in the UI.
- Verify **Deactivating** status is displayed correctly in the UI.
- Verify Edit action is disabled when status is **Failed**.
- Verify Edit action is disabled when status is **Deactivating**.
- Verify the Activate action is disabled when the status is **Failed** or **Deactivating**.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
🚩 Using a feature flag to protect the release
📱 Providing mobile support

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

-->