### PR TITLE
change: [DPS-42071] - Improve errors handling in stream and destination form

### DIFF
--- a/packages/manager/.changeset/pr-13552-changed-1775047281616.md
+++ b/packages/manager/.changeset/pr-13552-changed-1775047281616.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Use API error message in Stream and Destination Create and Edit forms snack bars ([#13552](https://github.com/linode/manager/pull/13552))

--- a/packages/manager/cypress/e2e/core/delivery/create-destination.spec.ts
+++ b/packages/manager/cypress/e2e/core/delivery/create-destination.spec.ts
@@ -1,4 +1,5 @@
 import {
+  CREATE_DESTINATION_ERROR_MESSAGE,
   mockAkamaiObjectStorageDestination,
   mockAkamaiObjectStorageDestinationPayload,
   mockCustomHttpsDestination,
@@ -78,13 +79,16 @@ describe('Create Destination', () => {
       );
 
       // Submit the destination create form - failure
-      mockCreateDestination({}, 400);
+      mockCreateDestination(
+        { errors: [{ reason: CREATE_DESTINATION_ERROR_MESSAGE }] },
+        500
+      );
       cy.findByRole('button', { name: 'Create Destination' })
         .should('be.enabled')
         .should('have.attr', 'type', 'button')
         .click();
 
-      ui.toast.assertMessage(`There was an issue creating your destination`);
+      ui.toast.assertMessage(CREATE_DESTINATION_ERROR_MESSAGE);
 
       // Submit the destination create form - success
       mockCreateDestination(mockAkamaiObjectStorageDestination);
@@ -223,13 +227,16 @@ describe('Create Destination', () => {
       );
 
       // Submit the destination create form - failure
-      mockCreateDestination({}, 400);
+      mockCreateDestination(
+        { errors: [{ reason: CREATE_DESTINATION_ERROR_MESSAGE }] },
+        500
+      );
       cy.findByRole('button', { name: 'Create Destination' })
         .should('be.enabled')
         .should('have.attr', 'type', 'button')
         .click();
 
-      ui.toast.assertMessage(`There was an issue creating your destination`);
+      ui.toast.assertMessage(CREATE_DESTINATION_ERROR_MESSAGE);
 
       // Submit the destination create form - success
       mockCreateDestination(mockCustomHttpsDestination);

--- a/packages/manager/cypress/e2e/core/delivery/create-stream.spec.ts
+++ b/packages/manager/cypress/e2e/core/delivery/create-stream.spec.ts
@@ -1,6 +1,8 @@
 import { streamType } from '@linode/api-v4';
 import { regionFactory } from '@linode/utilities';
 import {
+  CREATE_DESTINATION_ERROR_MESSAGE,
+  CREATE_STREAM_ERROR_MESSAGE,
   mockAkamaiObjectStorageDestination,
   mockCustomHttpsDestination,
 } from 'support/constants/delivery';
@@ -19,6 +21,7 @@ import { logsDestinationForm } from 'support/ui/pages/logs-destination-form';
 import { logsStreamForm } from 'support/ui/pages/logs-stream-form';
 import { randomLabel } from 'support/util/random';
 
+import { DEFAULT_ERROR_MESSAGE } from 'src/constants';
 import { accountFactory, kubernetesClusterFactory } from 'src/factories';
 
 describe('Create Stream', () => {
@@ -107,7 +110,7 @@ describe('Create Stream', () => {
           .should('have.attr', 'type', 'button')
           .click();
 
-        ui.toast.assertMessage(`There was an issue creating your destination`);
+        ui.toast.assertMessage(DEFAULT_ERROR_MESSAGE);
 
         // Submit the stream create form - success
         mockCreateDestination(mockAkamaiObjectStorageDestination);
@@ -167,7 +170,7 @@ describe('Create Stream', () => {
 
         cy.findByRole('button', { name: 'Create Stream' }).click();
         cy.wait('@createStreamFail');
-        ui.toast.assertMessage('There was an issue creating your stream');
+        ui.toast.assertMessage(DEFAULT_ERROR_MESSAGE);
 
         // Submit the stream create form - success
         mockCreateStream({ label: streamName }).as('createStream');
@@ -248,13 +251,16 @@ describe('Create Stream', () => {
           .should('have.attr', 'type', 'button');
 
         // Submit the stream create form - failure in creating destination
-        mockCreateDestination({}, 400);
+        mockCreateDestination(
+          { errors: [{ reason: CREATE_DESTINATION_ERROR_MESSAGE }] },
+          500
+        );
         cy.findByRole('button', { name: 'Create Stream' })
           .should('be.enabled')
           .should('have.attr', 'type', 'button')
           .click();
 
-        ui.toast.assertMessage(`There was an issue creating your destination`);
+        ui.toast.assertMessage(CREATE_DESTINATION_ERROR_MESSAGE);
 
         // Submit the stream create form - success
         mockCreateDestination(mockCustomHttpsDestination);
@@ -313,11 +319,14 @@ describe('Create Stream', () => {
           .should('have.attr', 'type', 'button');
 
         // Submit the stream create form - failure
-        mockCreateStream({}, 400).as('createStreamFail');
+        mockCreateStream(
+          { errors: [{ reason: CREATE_STREAM_ERROR_MESSAGE }] },
+          400
+        ).as('createStreamFail');
 
         cy.findByRole('button', { name: 'Create Stream' }).click();
         cy.wait('@createStreamFail');
-        ui.toast.assertMessage('There was an issue creating your stream');
+        ui.toast.assertMessage(CREATE_STREAM_ERROR_MESSAGE);
 
         // Submit the stream create form - success
         mockCreateStream({ label: streamName }).as('createStream');

--- a/packages/manager/cypress/e2e/core/delivery/edit-stream.spec.ts
+++ b/packages/manager/cypress/e2e/core/delivery/edit-stream.spec.ts
@@ -21,6 +21,7 @@ import { ui } from 'support/ui';
 import { logsStreamForm } from 'support/ui/pages/logs-stream-form';
 import { randomLabel } from 'support/util/random';
 
+import { DEFAULT_ERROR_MESSAGE } from 'src/constants';
 import { kubernetesClusterFactory } from 'src/factories';
 
 describe('Edit Stream', () => {
@@ -114,7 +115,7 @@ describe('Edit Stream', () => {
       mockCreateDestination({}, 400);
       ui.button.findByTitle(saveChangesButtonText).should('be.enabled').click();
 
-      ui.toast.assertMessage(`There was an issue creating your destination`);
+      ui.toast.assertMessage(DEFAULT_ERROR_MESSAGE);
 
       // Submit the stream edit form - success
       mockCreateDestination(mockAkamaiObjectStorageDestination);
@@ -309,7 +310,7 @@ describe('Edit Stream', () => {
 
       ui.button.findByTitle(saveChangesButtonText).click();
       cy.wait('@updateStreamFail');
-      ui.toast.assertMessage('There was an issue editing your stream');
+      ui.toast.assertMessage(DEFAULT_ERROR_MESSAGE);
 
       // Submit the stream edit form - success
       mockUpdateStream(

--- a/packages/manager/cypress/support/constants/delivery.ts
+++ b/packages/manager/cypress/support/constants/delivery.ts
@@ -114,3 +114,9 @@ export const mockLKEAuditLogsStream: Stream = streamFactory.build({
   destinations: [mockAkamaiObjectStorageDestination],
   version: '1.0',
 });
+
+export const CREATE_DESTINATION_ERROR_MESSAGE =
+  'Cannot create destination at this time.';
+
+export const CREATE_STREAM_ERROR_MESSAGE =
+  'You\u2019ve reached the limit of streams you can create. If you have any questions, please contact support.';

--- a/packages/manager/src/features/Delivery/Destinations/DestinationForm/DestinationCreate.tsx
+++ b/packages/manager/src/features/Delivery/Destinations/DestinationForm/DestinationCreate.tsx
@@ -69,15 +69,17 @@ export const DestinationCreate = () => {
         );
       })
       .catch((errors) => {
+        let errorMessage = `There was an issue creating your destination`;
         for (const error of errors) {
           if (error.field) {
             form.setError(error.field, { message: error.reason });
           } else {
+            errorMessage = error.reason;
             form.setError('root', { message: error.reason });
           }
         }
 
-        return enqueueSnackbar('There was an issue creating your destination', {
+        return enqueueSnackbar(errorMessage, {
           variant: 'error',
         });
       });

--- a/packages/manager/src/features/Delivery/Destinations/DestinationForm/DestinationEdit.tsx
+++ b/packages/manager/src/features/Delivery/Destinations/DestinationForm/DestinationEdit.tsx
@@ -112,30 +112,39 @@ export const DestinationEdit = () => {
       });
   };
 
+  if (isLoading) {
+    return (
+      <Box display="flex" justifyContent="center">
+        <CircleProgress size="md" />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <ErrorState
+        compact
+        errorText={
+          getAPIErrorOrDefault(
+            error,
+            'There was an error retrieving destination. Please reload and try again.'
+          )[0].reason
+        }
+      />
+    );
+  }
+
   return (
     <>
       <DocumentTitleSegment segment="Edit Destination" />
       <LandingHeader {...landingHeaderProps} />
-      {isLoading && (
-        <Box display="flex" justifyContent="center">
-          <CircleProgress size="md" />
-        </Box>
-      )}
-      {error && (
-        <ErrorState
-          compact
-          errorText="There was an error retrieving destination. Please reload and try again."
+      <FormProvider {...form}>
+        <DestinationForm
+          isSubmitting={isUpdatingDestination}
+          mode="edit"
+          onSubmit={onSubmit}
         />
-      )}
-      {!isLoading && !error && (
-        <FormProvider {...form}>
-          <DestinationForm
-            isSubmitting={isUpdatingDestination}
-            mode="edit"
-            onSubmit={onSubmit}
-          />
-        </FormProvider>
-      )}
+      </FormProvider>
     </>
   );
 };

--- a/packages/manager/src/features/Delivery/Streams/StreamForm/StreamForm.tsx
+++ b/packages/manager/src/features/Delivery/Streams/StreamForm/StreamForm.tsx
@@ -119,15 +119,17 @@ export const StreamForm = (props: StreamFormProps) => {
         );
         form.setValue('stream.destinations', [id]);
       } catch (errors) {
+        let errorMessage = `There was an issue creating your destination`;
         for (const error of errors) {
           if (error.field) {
             form.setError(error.field, { message: error.reason });
           } else {
+            errorMessage = error.reason;
             form.setError('root', { message: error.reason });
           }
         }
 
-        enqueueSnackbar('There was an issue creating your destination', {
+        enqueueSnackbar(errorMessage, {
           variant: 'error',
         });
         return;
@@ -166,20 +168,19 @@ export const StreamForm = (props: StreamFormProps) => {
 
       navigate({ to: '/logs/delivery/streams' });
     } catch (errors) {
+      let errorMessage = `There was an issue ${mode === 'create' ? 'creating' : 'editing'} your stream`;
       for (const error of errors) {
         if (error.field) {
           form.setError(error.field, { message: error.reason });
         } else {
+          errorMessage = error.reason;
           form.setError('root', { message: error.reason });
         }
       }
 
-      enqueueSnackbar(
-        `There was an issue ${mode === 'create' ? 'creating' : 'editing'} your stream`,
-        {
-          variant: 'error',
-        }
-      );
+      enqueueSnackbar(errorMessage, {
+        variant: 'error',
+      });
     }
   };
 


### PR DESCRIPTION
## Description 📝

On create/edit stream/destination show error provided in API response. 

## Changes  🔄

- on Create/Edit Stream/Destination action show snackbar with error message from API response if provided.

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [x] Some customers (e.g. in Beta or Limited Availability)

## Target release date 🗓️

April 2026

## Preview 📷

| Before  | After   |
| ------- | ------- |
|![Screenshot 2026-04-01 at 13 52 57](https://github.com/user-attachments/assets/7450ac81-c982-4ba7-8b14-fca8b7b03e34)| ![Screenshot 2026-04-01 at 13 44 13](https://github.com/user-attachments/assets/c002af92-13ce-4ac8-8765-75ba7e814c04)|

## How to test 🧪

### Prerequisites

Launch manager with enabled MSW.
Update mock for createStream in `mocks/presets/crud/handlers/delivery.ts` to return error:
```
export const createStreams = (mockState: MockState) => [
  http.post(
    '*/v4/monitor/streams',
    async ({ request }): Promise<StrictResponse<APIErrorResponse | Stream>> => {
      return makeErrorResponse(
        'You\u2019ve reached the limit of streams you can create. If you have any questions, please contact support.'
      );
    }
  ),
];
```

### Verification steps

- If there is no Destinations created, navigate to logs delivery Destination Create page and create Destination. 
- Navigate to logs delivery Stream Create page and create stream with existing destination. See snackbar error with message provided in mock code above.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

-->