### PR TITLE
fix:[UIE-10720] fixed lke version upgrade logic

### DIFF
--- a/packages/manager/.changeset/pr-13562-fixed-1775692362893.md
+++ b/packages/manager/.changeset/pr-13562-fixed-1775692362893.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+LKE version upgrade logic ([#13562](https://github.com/linode/manager/pull/13562))

--- a/packages/manager/src/features/Kubernetes/kubeUtils.test.ts
+++ b/packages/manager/src/features/Kubernetes/kubeUtils.test.ts
@@ -307,31 +307,102 @@ describe('helper functions', () => {
       const result = getNextVersion(currentVersion, versions);
       expect(result).toEqual('2.00');
     });
-  });
 
-  it('should get the next version when given a current enterprise version', () => {
-    const versions: KubernetesTieredVersion[] = [
-      { id: 'v1.31.1+lke4', tier: 'enterprise' },
-      { id: 'v1.31.6+lke2', tier: 'enterprise' },
-      { id: 'v1.31.6+lke3', tier: 'enterprise' },
-      { id: 'v1.31.8+lke1', tier: 'enterprise' },
-    ];
-    const currentVersion = 'v1.31.6+lke2';
+    it('should get the next version when given a current enterprise version', () => {
+      const versions: KubernetesTieredVersion[] = [
+        { id: 'v1.31.1+lke4', tier: 'enterprise' },
+        { id: 'v1.31.6+lke2', tier: 'enterprise' },
+        { id: 'v1.31.6+lke3', tier: 'enterprise' },
+        { id: 'v1.31.8+lke1', tier: 'enterprise' },
+      ];
+      const currentVersion = 'v1.31.6+lke2';
 
-    const result = getNextVersion(currentVersion, versions);
-    expect(result).toEqual('v1.31.6+lke3');
-  });
+      const result = getNextVersion(currentVersion, versions);
+      expect(result).toEqual('v1.31.6+lke3');
+    });
 
-  it('should get the next version when given an obsolete current version', () => {
-    const versions: KubernetesVersion[] = [
-      { id: '1.16' },
-      { id: '1.17' },
-      { id: '1.18' },
-    ];
-    const currentVersion = '1.15';
+    it('should get the next version when given an obsolete current version', () => {
+      const versions: KubernetesVersion[] = [
+        { id: '1.16' },
+        { id: '1.17' },
+        { id: '1.18' },
+      ];
+      const currentVersion = '1.15';
 
-    const result = getNextVersion(currentVersion, versions);
-    expect(result).toEqual('1.16');
+      const result = getNextVersion(currentVersion, versions);
+      expect(result).toEqual('1.16');
+    });
+
+    it('should correctly sort enterprise versions across different minor versions', () => {
+      const versions: KubernetesTieredVersion[] = [
+        { id: 'v1.31.8+lke5', tier: 'enterprise' },
+        { id: 'v1.32.9+lke1', tier: 'enterprise' },
+      ];
+      const currentVersion = 'v1.31.8+lke5';
+
+      const result = getNextVersion(currentVersion, versions);
+      expect(result).toEqual('v1.32.9+lke1');
+    });
+
+    it('should not suggest a downgrade when cluster version is higher than all available versions', () => {
+      const versions: KubernetesTieredVersion[] = [
+        { id: 'v1.31.8+lke5', tier: 'enterprise' },
+      ];
+      const currentVersion = 'v1.32.9+lke1';
+
+      const result = getNextVersion(currentVersion, versions);
+      expect(result).toBeNull();
+    });
+
+    it('should handle multi-digit lke release numbers correctly', () => {
+      const versions: KubernetesTieredVersion[] = [
+        { id: 'v1.31.8+lke2', tier: 'enterprise' },
+        { id: 'v1.31.8+lke5', tier: 'enterprise' },
+        { id: 'v1.31.8+lke10', tier: 'enterprise' },
+      ];
+      const currentVersion = 'v1.31.8+lke5';
+
+      const result = getNextVersion(currentVersion, versions);
+      expect(result).toEqual('v1.31.8+lke10');
+    });
+
+    it('should handle multi-digit patch versions correctly', () => {
+      const versions: KubernetesTieredVersion[] = [
+        { id: 'v1.32.9+lke1', tier: 'enterprise' },
+        { id: 'v1.32.10+lke1', tier: 'enterprise' },
+      ];
+      const currentVersion = 'v1.32.9+lke1';
+
+      const result = getNextVersion(currentVersion, versions);
+      expect(result).toEqual('v1.32.10+lke1');
+    });
+
+    it('should return null when the cluster is already on the latest version', () => {
+      const versions: KubernetesTieredVersion[] = [
+        { id: 'v1.31.8+lke5', tier: 'enterprise' },
+        { id: 'v1.32.9+lke1', tier: 'enterprise' },
+      ];
+      const currentVersion = 'v1.32.9+lke1';
+
+      const result = getNextVersion(currentVersion, versions);
+      expect(result).toBeNull();
+    });
+
+    it('should return the correct next version for an obsolete enterprise version', () => {
+      const versions: KubernetesTieredVersion[] = [
+        { id: 'v1.31.8+lke5', tier: 'enterprise' },
+        { id: 'v1.32.9+lke1', tier: 'enterprise' },
+      ];
+      const currentVersion = 'v1.30.0+lke1';
+
+      const result = getNextVersion(currentVersion, versions);
+      expect(result).toEqual('v1.31.8+lke5');
+    });
+
+    it('should return null when there are no versions available', () => {
+      const result = getNextVersion('v1.32.9+lke1', []);
+      expect(result).toBeNull();
+    });
   });
 });
 

--- a/packages/manager/src/features/Kubernetes/kubeUtils.ts
+++ b/packages/manager/src/features/Kubernetes/kubeUtils.ts
@@ -137,26 +137,23 @@ export const getNextVersion = (
   if (versions.length === 0) {
     return null;
   }
-  const versionStrings = versions.map((v) => v.id).sort();
+  const versionStrings = versions
+    .map((v) => v.id)
+    .sort((a, b) => compareByKubernetesVersion(a, b, 'asc'));
   const currentIdx = versionStrings.findIndex(
     (thisVersion) => currentVersion === thisVersion
   );
   if (currentIdx < 0) {
-    // For now, assume that if nothing matches the user is on an obsolete version.
-    // According to the LKE team's deprecation policy, there will only ever be
-    // one such obsolete version, so this is safe. However, we'll eventually
-    // have a version.deprecated field to work with, which will be cleaner
-    // and safer.
-    //
-    // Example:
-    // API returns [1.16, 1.17, 1.18].
-    // You haven't upgraded in ages and your cluster is on 1.15.
-    // The next available upgrade would be 1.16, which is the first item in the list.
-    // Return that.
-    //
-    return versionStrings[0];
+    // The current version is not in the available versions list.
+    // This typically means the user is on an obsolete/deprecated version.
+    // Return the first available version that is actually newer than the current version
+    // to avoid suggesting a downgrade.
+    const nextHigherVersion = versionStrings.find(
+      (v) => compareByKubernetesVersion(v, currentVersion, 'asc') > 0
+    );
+    return nextHigherVersion ?? null;
   }
-  if (currentIdx === versions.length - 1) {
+  if (currentIdx === versionStrings.length - 1) {
     return null;
   }
   return versionStrings[currentIdx + 1];


### PR DESCRIPTION
## Description 📝

Fixed lke version upgrade logic

## Changes  🔄

Changed bare .sort() which was just JavaScript's default lexicographic comparison. The correct comparator was already existing started utilizing that compareByKuberenetesVersion

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [x] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️
April End

## Preview 📷
<img width="1710" height="990" alt="Screenshot 2026-04-07 at 12 59 20 PM" src="https://github.com/user-attachments/assets/6870a93b-c19a-4278-a58a-2ac2bd28bc4b" />

### Verification steps
Go to kubernetes, on cluster list find cluster with upgrade chip and check the upgrade banner message. Should show the correct version to upgrade to

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All tests and CI checks are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>