### PR TITLE
upcoming: [UIE-10729] — Parity between image options in Rebuild Linode dialog with privateImageSharing flag on & off

### DIFF
--- a/packages/manager/.changeset/pr-13568-upcoming-features-1775671959206.md
+++ b/packages/manager/.changeset/pr-13568-upcoming-features-1775671959206.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Upcoming Features
+---
+
+Private Image Sharing: include public images in images table in Linode Rebuild dialog ([#13568](https://github.com/linode/manager/pull/13568))

--- a/packages/manager/src/components/ImageSelect/ImageSelectTable.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelectTable.tsx
@@ -129,8 +129,6 @@ export const ImageSelectTable = (props: Props) => {
     {},
     {
       ...combinedFilter,
-      is_public: false,
-      type: 'manual',
     }
   );
 

--- a/packages/manager/src/components/ImageSelect/ImageSelectTable.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelectTable.tsx
@@ -57,6 +57,10 @@ interface Props {
    */
   errorText?: string;
   /**
+   * Determines whether additional filtering of images should be applied, typically if there is a StackScript selected.
+   */
+  filter?: (image: Image) => boolean;
+  /**
    * Callback fired when the user selects an image row.
    */
   onSelect: (image: Image) => void;
@@ -79,6 +83,7 @@ export const ImageSelectTable = (props: Props) => {
   const {
     currentRoute,
     errorText,
+    filter,
     onSelect,
     pendoIDs,
     queryParamsPrefix,
@@ -121,7 +126,7 @@ export const ImageSelectTable = (props: Props) => {
   });
 
   const {
-    data: imagesData,
+    data: _imagesData,
     error: imagesError,
     isFetching,
     isLoading,
@@ -131,6 +136,8 @@ export const ImageSelectTable = (props: Props) => {
       ...combinedFilter,
     }
   );
+
+  const imagesData = filter ? _imagesData?.filter(filter) : _imagesData;
 
   const pagination = usePaginationV2({
     clientSidePaginationData: imagesData,

--- a/packages/manager/src/components/ImageSelect/ImageSelectTableRow.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelectTableRow.tsx
@@ -47,7 +47,7 @@ export const ImageSelectTableRow = (props: Props) => {
     id,
     image_sharing,
     label,
-    regions: imageRegions,
+    regions: _imageRegions,
     size,
     status,
     type,
@@ -76,6 +76,8 @@ export const ImageSelectTableRow = (props: Props) => {
 
     return '—';
   };
+
+  const imageRegions = _imageRegions ?? []; // Failsafe for manual images whose `regions` property is null
 
   const FormattedRegionList = () => (
     <StyledFormattedRegionList>
@@ -121,11 +123,13 @@ export const ImageSelectTableRow = (props: Props) => {
           <PlanTextTooltip
             data-pendo-id={pendoIDs.replicatedRegionPopover}
             displayText={
-              imageRegions.length > 0
+              imageRegions?.length > 0
                 ? pluralize('Region', 'Regions', imageRegions.length)
                 : '—'
             }
-            tooltipText={<FormattedRegionList />}
+            tooltipText={
+              imageRegions?.length > 0 ? <FormattedRegionList /> : 'N/A'
+            }
           />
         </TableCell>
       </Hidden>

--- a/packages/manager/src/components/ImageSelect/ImageSelectTableRow.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelectTableRow.tsx
@@ -123,7 +123,7 @@ export const ImageSelectTableRow = (props: Props) => {
           <PlanTextTooltip
             data-pendo-id={pendoIDs.replicatedRegionPopover}
             displayText={
-              imageRegions?.length > 0
+              imageRegions.length > 0
                 ? pluralize('Region', 'Regions', imageRegions.length)
                 : '—'
             }

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeRebuild/Image.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeRebuild/Image.tsx
@@ -48,6 +48,7 @@ export const Image = (props: Props) => {
                 : '/linodes') as LinkProps['to']
             }
             errorText={fieldState.error?.message}
+            filter={getImageSelectFilter(stackscript)}
             onSelect={(image) => field.onChange(image?.id ?? null)}
             pendoIDs={IMAGE_SELECT_TABLE_LINODE_REBUILD_PENDO_IDS}
             queryParamsPrefix="images"


### PR DESCRIPTION
## Description 📝
Ensure public images are included in the `ImageSelectTable`

## Changes  🔄
Remove the properties in the filter that were causing public images to be excluded.

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [X] No customers / Not applicable

## Target release date 🗓️
TBD

## How to test 🧪
### Prerequisites
Toggle the `Private Image Sharing` flag ON in the CM DevTool.

### Reproduction steps
With the flag OFF, observe that public images such as Arch Linux are options in the `Image` dropdown of the Rebuild Linode dialog.

With the flag ON, observe that the table only has private images as options.

### Verification steps
With the flag ON, there should be parity now with the options available on this branch locally compared to prod or DevCloud.

One way to do this is to check the `images` network request's results count in prod or DevCloud, and confirm the number of items in the `ImageSelectTable` matches that count.

To confirm the StackScript-based filtering is working when you try to rebuild from a StackScript, it would be easiest to choose or create a StackScript that is compatible with only one image. When you choose that StackScript, you should see just the expected image in the table.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

👀 Doing a self review
❔ Our [contribution guidelines](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md)
🤏 Splitting feature into small PRs
➕ Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
🧪 Providing/improving test coverage
 🔐 Removing all sensitive information from the code and PR description
🚩 Using a feature flag to protect the release
👣 Providing comprehensive reproduction steps
📑 Providing or updating our documentation
🕛 Scheduling a pair reviewing session
📱 Providing mobile support
♿  Providing accessibility support

<br/>

- [X] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [X] All tests and CI checks are passing
- [X] TypeScript compilation succeeded without errors
- [X] Code passes all linting rules

</details>